### PR TITLE
Fix: Compiler read write unformatted logical

### DIFF
--- a/src/paw_pdos.f90
+++ b/src/paw_pdos.f90
@@ -732,12 +732,14 @@
       READ(NFIL)LNX(:),LOX(:,:),ISPECIES(:)
       
       IF(FLAG.EQ.'181213')THEN
-!       == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0 ==
-!       == https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/internal-representation-of-logical-variables.html ==
-!       == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT  ==
-!       == https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/logical-data-representations.html ==
-!       == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE               ==
-!       == ENSURES BACKWARDS COMPATIBILITY WITH OLD PDOS FILES          ==
+!         == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0     ==
+!         https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/
+!         internal-representation-of-logical-variables.html
+!         == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT      ==
+!         https://www.intel.com/content/www/us/en/docs/fortran-compiler/
+!         developer-guide-reference/2024-2/logical-data-representations.html
+!         == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE                   ==
+!         == ENSURES BACKWARDS COMPATIBILITY WITH OLD PDOS FILES              ==
         READ(NFIL)NKDIV(:),ISHIFT(:),RNTOT,NEL,ILOGICAL
         TINV=BTEST(ILOGICAL,0)
         READ(NFIL)SPACEGROUP,ILOGICAL

--- a/src/paw_pdos.f90
+++ b/src/paw_pdos.f90
@@ -707,6 +707,7 @@
       CHARACTER(82)          :: IOSTATMSG
       LOGICAL(4)             :: TCHK
       REAL(8)                :: OCCSUM
+      INTEGER(4)             :: ILOGICAL
 !     ******************************************************************
                              CALL TRACE$PUSH('PDOS$READ')
 !
@@ -731,8 +732,16 @@
       READ(NFIL)LNX(:),LOX(:,:),ISPECIES(:)
       
       IF(FLAG.EQ.'181213')THEN
-        READ(NFIL)NKDIV(:),ISHIFT(:),RNTOT,NEL,TINV
-        READ(NFIL)SPACEGROUP,TSHIFT
+!       == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0 ==
+!       == https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/internal-representation-of-logical-variables.html ==
+!       == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT  ==
+!       == https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/logical-data-representations.html ==
+!       == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE               ==
+!       == ENSURES BACKWARDS COMPATIBILITY WITH OLD PDOS FILES          ==
+        READ(NFIL)NKDIV(:),ISHIFT(:),RNTOT,NEL,ILOGICAL
+        TINV=BTEST(ILOGICAL,0)
+        READ(NFIL)SPACEGROUP,ILOGICAL
+        TSHIFT=BTEST(ILOGICAL,0)
       ENDIF
 !
 !     ==================================================================
@@ -821,6 +830,7 @@ PRINT*,"OCCSUM",OCCSUM
       CHARACTER(6),INTENT(IN)      :: FLAG_
       INTEGER(4)                   :: ISP,IKPT
       INTEGER(4)                   :: LNX1
+      INTEGER(4)                   :: ILOGICAL
 !     ******************************************************************
                              CALL TRACE$PUSH('PDOS$WRITE')
       FLAG=FLAG_
@@ -832,8 +842,13 @@ PRINT*,"OCCSUM",OCCSUM
       WRITE(NFIL)LNX(:),LOX(:,:),ISPECIES(:)
 
       IF(FLAG_.EQ.'181213')THEN
-        WRITE(NFIL)NKDIV(:),ISHIFT(:),RNTOT,NEL,TINV
-        WRITE(NFIL)SPACEGROUP,TSHIFT
+!       == PDOS FILE WITH GNU STANDARD OF LOGICAL BIT REPRESENTATION ==
+        ILOGICAL=1
+        IF(.NOT.TINV)ILOGICAL=0
+        WRITE(NFIL)NKDIV(:),ISHIFT(:),RNTOT,NEL,ILOGICAL
+        ILOGICAL=1
+        IF(.NOT.TSHIFT)ILOGICAL=0
+        WRITE(NFIL)SPACEGROUP,ILOGICAL
       ENDIF
 !
 !     ==================================================================

--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -3466,12 +3466,14 @@ CALL FILEHANDLER$UNIT('PROT',NFILO)
 !       ==  READ COORDINATES OF THE WAVE FUNCTIONS                    ==
 !       ================================================================
         IF(THISTASK.EQ.1) THEN
-!         == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0 ==
-!         == https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/internal-representation-of-logical-variables.html ==
-!         == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT  ==
-!         == https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/logical-data-representations.html ==
-!         == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE               ==
-!         == ENSURES BACKWARDS COMPATIBILITY WITH OLD PDOS FILES          ==
+!         == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0     ==
+!         https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/
+!         internal-representation-of-logical-variables.html
+!         == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT      ==
+!         https://www.intel.com/content/www/us/en/docs/fortran-compiler/
+!         developer-guide-reference/2024-2/logical-data-representations.html
+!         == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE                   ==
+!         == ENSURES BACKWARDS COMPATIBILITY WITH OLD RESTART FILES           ==
           READ(NFIL)KEY,NGG_,NDIM_,NB_,ILOGICAL   !<<<<<<<<<<<<<<<<<<<<<<
           TSUPER_=BTEST(ILOGICAL,0)
           IF(KEY.NE.'PSI') THEN
@@ -5249,12 +5251,14 @@ END MODULE TOTALSPIN_MODULE
 !       ==  READ COORDINATES OF THE WAVE FUNCTIONS                    ==
 !       ================================================================
         IF(THISTASK.EQ.1) THEN
-!         == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0 ==
-!         == https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/internal-representation-of-logical-variables.html ==
-!         == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT  ==
-!         == https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/logical-data-representations.html ==
-!         == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE               ==
-!         == ENSURES BACKWARDS COMPATIBILITY WITH OLD PDOS FILES          ==
+!         == GFORTRAN LOGICAL REPRESENTATION DEFINED WITH TRUE=1, FALSE=0     ==
+!         https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/
+!         internal-representation-of-logical-variables.html
+!         == IFORT LOGICAL REPRESENTATION DEFINED WITH VALUE OF LAST BIT      ==
+!         https://www.intel.com/content/www/us/en/docs/fortran-compiler/
+!         developer-guide-reference/2024-2/logical-data-representations.html
+!         == BOTH SHARE MEANING OF LAST BIT 1=TRUE, 0=FALSE                   ==
+!         == ENSURES BACKWARDS COMPATIBILITY WITH OLD RESTART FILES           ==
           READ(NFIL)KEY,NGG_,NDIM_,NB_,ILOGICAL   !<<<<<<<<<<<<<<<<<<<<<<
           TSUPER=BTEST(ILOGICAL,0)
           IF(KEY.NE.'PSI') THEN


### PR DESCRIPTION
Compilers have different bit representation for logicals e.g. [ifort](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/logical-data-representations.html) or [gfortran](https://gcc.gnu.org/onlinedocs/gfortran/compiler-characteristics/internal-representation-of-logical-variables.html).

Unformatted files written by code compiled by one compiler can cause undefined behavior in code compiled by a different compiler. 

### Example
 ifort writes TRUE as 11...11 (or -1 as integer). Reading this with gfortran is undefined behavior as only integers 0 or 1 are valid. The code might still give TRUE, however the negation also gives TRUE as the bits are then 11...10.

### Effected files
.pdos (TINV,TSHIFT) and .rstrt (TSUPER) files

The latter had some form of protection through the following code, this however relies on undefined behavior.
```
IF(TSUPER_) THEN
   TSUPER_=.TRUE.
ELSE
   TSUPER_=.FALSE.
END IF
```

### Proposed solution
- writing to file follows the GNU Standard and writes bits of integers 0 or 1
- reading as integer and checking least significant bit 1=TRUE, 0=FALSE
- ensures backwards compatibility for files from different compilers
- valid for all compilers where least significant bit decides directly or indirectly between true or false

### Further compilers

- [Flang](https://flang.llvm.org/docs/IntrinsicTypes.html) implementation matches gfortran
- [IBM Open XL Fortran](https://www.ibm.com/docs/en/openxl-fortran-aix/17.1.2?topic=types-logical) like gfortran
- [nvfortran](https://docs.nvidia.com/hpc-sdk//compilers/hpc-compilers-ref-guide/index.html): "The logical constants .TRUE. and .FALSE. are all ones and all zeroes, respectively. Internally, the value of a logical variable is true if the least significant bit is one and false otherwise." (like ifort)