### PR TITLE
redefine paw_checkpoint tool with options -c -r

### DIFF
--- a/src/Tools/Scripts/paw_checkpoint.sh
+++ b/src/Tools/Scripts/paw_checkpoint.sh
@@ -1,66 +1,111 @@
 #!/bin/bash
 #--  help message --------------------------------------------------------------
 export USAGE=""
-USAGE="${USAGE}\n usage: paw_checkpoint [create|recover] name"
+USAGE="${USAGE}\n usage: paw_checkpoint option"
 USAGE="${USAGE}\n"
-USAGE="${USAGE}\n create:\t copy files from current directory to checkpoint"
-USAGE="${USAGE}\n recover:\t delete all files in the current directory and"
-USAGE="${USAGE}\n \t\t copy content from checkpoint into current directory"
-USAGE="${USAGE}\n name\t\t name of the checkpoint directory"
+USAGE="${USAGE}\n\t -c name:\t create snapshop directory name"
+USAGE="${USAGE}\n\t\t\t 1) create a directory name"
+USAGE="${USAGE}\n\t\t\t 2) copy files (no directories) from current "
+USAGE="${USAGE} to snapshot directory"
+USAGE="${USAGE}\n\t -r name:\t recover snapshot name"
+USAGE="${USAGE}\n\t\t\t 1) erase all files (no directories) in current directory"
+USAGE="${USAGE}\n\t\t\t 2) copy files from snapshot into current directory"
+USAGE="${USAGE}\n"
 
 #-------------------------------------------------------------------------------
-#--  check input syntax 
+#--  resolve options
 #-------------------------------------------------------------------------------
-if [ "$#" -ne 2 ]; then
-  echo "error in $0: Illegal number of parameters"
-  echo -e ${USAGE}
-  exit 1
-fi
-
-if [[ $1 != create && $1 != recover ]] ; then
-  echo "error in $0: first argument must be \"create\" or \"recover\""
-  echo "first argument is $1"
-  echo -e ${USAGE}
-  exit 1
-fi
+OP=""
+OPTSTRING=":hvc:r:"
+while getopts "${OPTSTRING}" OPT  ; do
+  case $OPT in
+    c) DIRNAME="$OPTARG" 
+       if [[ -n $OP ]] ; then 
+         echo "error in $0: operation can only be defined once"
+         echo "OPT=$OPT and operation is $OP"
+         exit 1
+       fi
+       OP="create"
+       ;;
+    r) DIRNAME="$OPTARG" 
+       if [[ -n $OP ]] ; then 
+         echo "error in $0: operation can only be defined once"
+         echo "OPT=$OPT and operation is $OP"
+         exit 1
+       fi
+       OP="recover"
+       ;;
+    0)   #nothing:
+       DRYRUN=yes
+#      set -n
+       ;;
+    v)   #verbose
+       VERBOSE=yes
+#      set -v
+#      set -x
+      ;;
+    h)   # help
+      echo -e $USAGE
+      exit 0
+      ;;
+    \?)   # unknown option (placed into OPTARG, if OPTSTRING starts with :)
+      echo "error in $0" >&2
+      echo "invalid option -$OPTARG" >&2
+      echo "retrieve argument list with:" >&2
+      echo "$0 -h" >&2
+      exit 1
+      ;;
+    :)    # no argument passed to option requiring one
+      echo "error in $0" >&2
+      echo "option -$OPTARG requires an additional argument" >&2
+      exit 1
+      ;;  
+  esac
+done
 
 #-------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------
-OP="$1"
-DIRNAME=$2
-
 case "$OP" in
   create)
     #check if directory $DIRNAME already exists
-    if [[ -d $DIRNAME ]] ; then
+    if [[ -d ${DIRNAME} ]] ; then
       echo "WARNING: the directory $DIRNAME already exists, doing NOTHING!" 
-      exit
+      exit 1
     else
       mkdir "$DIRNAME" # create directory
       /bin/cp * "$DIRNAME" #copy all files
     fi
-  ;;
+    ;;
+#
   recover)
     #check if directory $DIRNAME exists
-    if [ -d "$2" ] ;  then
+    if [ -d "${DIRNAME}" ] ;  then
       #ask user if he really wants to
-      echo "Do you really want to delete all files (not directories) in the current directory and copy the files from $DIRNAME into it? (y/n)"
+      TEXT=""
+      TEXT="${TEXT} Do you really want to delete all files (not directories)"
+      TEXT="${TEXT} in the current directory\n"
+      TEXT="${TEXT} and copy the files from $DIRNAME into it? (y/n)"
+      echo -e "$TEXT"
       read answer
       if [ "$answer" = "y" ];  then
         #remove all files in the current directory
         /bin/rm *
         #copy all files from $DIRNAME
         /bin/cp $DIRNAME/* .
-        echo "You now have the all the files from the directory $DIRNAME in the current directory."
+        echo "Now you have the all files from the directory $DIRNAME"\
+             " in the current directory."
       else
         echo "DOING NOTHING."
-        exit
+        exit 1
       fi
     else
       echo "WARNING: directory $DIRNAME does NOT exist, doing NOTHING!" 
       exit
     fi
   ;;
+#
+  *) #do nothing
+    ;; 
 esac
 
 

--- a/src/Tools/Scripts/paw_checkpoint.sh
+++ b/src/Tools/Scripts/paw_checkpoint.sh
@@ -15,8 +15,11 @@ USAGE="${USAGE}\n"
 #-------------------------------------------------------------------------------
 #--  resolve options
 #-------------------------------------------------------------------------------
-OP=""
-OPTSTRING=":hvc:r:"
+export DRYRUN="false"
+export VERBOSE="false"
+export OP=""
+export DIRNAME=""
+OPTSTRING=":hc:r:"
 while getopts "${OPTSTRING}" OPT  ; do
   case $OPT in
     c) DIRNAME="$OPTARG" 
@@ -35,15 +38,15 @@ while getopts "${OPTSTRING}" OPT  ; do
        fi
        OP="recover"
        ;;
-    0)   #nothing:
-       DRYRUN=yes
-#      set -n
-       ;;
-    v)   #verbose
-       VERBOSE=yes
-#      set -v
+#     0)   #nothing:
+#        DRYRUN="true"
+# #      set -n
+#        ;;
+    # v)   #verbose
+    #    VERBOSE="true"
+#       set -v
 #      set -x
-      ;;
+#      ;;
     h)   # help
       echo -e $USAGE
       exit 0
@@ -72,8 +75,10 @@ case "$OP" in
       echo "WARNING: the directory $DIRNAME already exists, doing NOTHING!" 
       exit 1
     else
-      mkdir "$DIRNAME" # create directory
-      /bin/cp * "$DIRNAME" #copy all files
+      if [[ $DRYRUN != true ]] ; then
+        mkdir "$DIRNAME" # create directory
+        /bin/cp * "$DIRNAME" #copy all files
+      fi
     fi
     ;;
 #
@@ -89,11 +94,13 @@ case "$OP" in
       read answer
       if [ "$answer" = "y" ];  then
         #remove all files in the current directory
-        /bin/rm *
-        #copy all files from $DIRNAME
-        /bin/cp $DIRNAME/* .
-        echo "Now you have the all files from the directory $DIRNAME"\
+        if [[ $DRYRUN != true ]]; then
+          /bin/rm *
+          #copy all files from $DIRNAME
+          /bin/cp $DIRNAME/* .
+          echo "Now you have the all files from the directory $DIRNAME"\
              " in the current directory."
+        fi
       else
         echo "DOING NOTHING."
         exit 1


### PR DESCRIPTION
The paw_checkpoint tool uses arguments -c, -r instead of "create" and "recover", which is more consistent with the other paw_tools, which use getups.
