### PR TITLE
ORBPOT support for superposition orbital

### DIFF
--- a/src/Docs/manual.tex
+++ b/src/Docs/manual.tex
@@ -3025,6 +3025,13 @@ because it incorporates (almost) all options at the same time.
       !LINE ATOM='H_2' VEC= 0.5 0.0 0.0 !END 
     !END 
   !END
+  !ORBPOT
+    !POT ATOM='H_1' TYPE='S' VALUE=-0.1 !END
+    !POT ATOM='C_1' TYPE='SPECIAL' VALUE=-0.1 
+      !ORB TYPE='PX' FAC=0.707 !END
+      !ORB TYPE='PZ' FAC=0.707 !END
+    !END
+  !END
 !END 
 !EOB
 \end{verbatim}
@@ -4788,6 +4795,23 @@ on p.~\pageref{sec:extendedatomnotation})}
   (\texttt{VALUE=0.1 RC=3. S=1}) changes the spin splitting of
   3d-electrons by about 5~eV.
 
+  A more general approach to apply external potentials is to use the
+  real spherical harmics and coefficients to construct superpositions of
+  orbitals. We can define the potential as
+  \begin{eqnarray}\nonumber
+    \tilde{U}(|\vec{r}|)&=&
+      U\mathrm{e}^{-\left(\frac{|\vec{r}-\vec{R}|}{r_c}\right)^q},\quad
+      \langle \vec{r}|\phi_\alpha\rangle=R_\alpha(|\vec{r}|)
+      Y_{\ell_\alpha,m_\alpha}(\vec{r})\\ \nonumber
+    V(\vec{r},\vec{r}')&=&\sum_{\ell,m,\ell',m'}Y_{\ell,m}(\vec{r})c_{\ell,m}
+      c_{\ell',m'}^*Y_{\ell',m'}(\vec{r}')\tilde{U}(|\vec{r}|)
+      \frac{\delta(|\vec{r}|-|\vec{r}'|)}{|\vec{r}|\cdot|\vec{r}'|}\\ \nonumber
+    \Delta\hat{H}&=&\sum_{\alpha,\beta}|\tilde{p}_\alpha\rangle
+      c_{\ell_\alpha,m_\alpha}\int dr\;r^2 \phi_\alpha^*(r)\tilde{U}(r)
+      \phi_\beta(r)c_{\ell_\beta,m_\beta}^*\langle\tilde{p}_\beta|
+  \end{eqnarray}
+  where $c_{\ell,m}$ are the coefficients of the superposition of the 
+  orbitals.
 %% The relation $|\Psi\rangle\approx
 %%   \sum_i|\phi_i\rangle\langle\tilde{p}_i|\tilde\Psi\rangle$ between
 %%   the true wave function and its one-center expansion is used to
@@ -4821,14 +4845,16 @@ on p.~\pageref{sec:extendedatomnotation})}
 \vdefault{none}}
 %
 \mbax{\key{TYPE} 
-\vdescr{orbital type, can be 'S', 'P', 'D', 'ALL' or the ID of any
+\vdescr{orbital type, can be 'S', 'P', 'D', 'ALL', 'SPECIAL' or the ID of any
   real spherical harmonics with $\ell\le3$. The allowed values for
   real spherical harmonics are provided in
   table~\ref{tab:realsphericalharmonics}
   on p.~\pageref{tab:realsphericalharmonics}.
 .  Some of them are
   'S','PX', 'PY', 'PZ', 'DX2-Y2', 'DXZ', 'D3Z2-R2' or 'DZ2', 'DYZ',
-  'DXY'.}  
+  'DXY'. 'SPECIAL' is used to specify a new orbital from a superposition of real
+  spherical harmonics in one angular
+  momentum shell. Requires at least one !ORBPOT!POT!ORB block.}  
 \vformat{character} 
 \vrules{mandatory} 
 \vdefault{none}}
@@ -4867,6 +4893,34 @@ in \eq{eq:orbpot}.}
   \vrules{optional}
   \vdefault{0}
 }
+%
+%----------------------------------------------------------------------
+\block{!STRUCTURE!ORBPOT!POT!ORB}
+%----------------------------------------------------------------------
+\brules{mandatory if !ORBPOT!POT:TYPE='SPECIAL', multiple}
+\bdescr{describes superposition of orbitals to create new orbital}
+%
+\mbax{\key{TYPE} 
+\vdescr{orbital type, can be ID of any
+  real spherical harmonics with $\ell\le3$. The allowed values for
+  real spherical harmonics are provided in
+  table~\ref{tab:realsphericalharmonics}
+  on p.~\pageref{tab:realsphericalharmonics}.
+.  Some of them are
+  'S','PX', 'PY', 'PZ', 'DX2-Y2', 'DXZ', 'D3Z2-R2' or 'DZ2', 'DYZ',
+  'DXY'. Currently only !ORB:TYPE with the same angular momentum are allowed
+  within one !ORBPOT!POT block. The same orbital can not be selected in two
+  different !ORB blocks within one !ORBPOT!POT block.}  
+\vformat{character} 
+\vrules{mandatory} 
+\vdefault{none}}
+%
+\mbax{\key{FAC}
+\vdescr{factor of the orbital in the superposition. Internally all factors
+within one !ORBPOT!POT block are normalized $\sum_i|c_i|^2=1$.}
+\vformat{real}
+\vrules{mandatory}
+\vdefault{none}}
 %
 } % end of ifthenelse
 

--- a/src/paw_augmentation.f90
+++ b/src/paw_augmentation.f90
@@ -2357,8 +2357,11 @@ TYPE EXTPOT
   CHARACTER(LEN=32):: ATOM
   REAL(8)          :: RC  
   REAL(8)          :: PWR
-  CHARACTER(LEN=32):: TYPE   ! CAN BE 'S','P','D','F','ALL'
+  CHARACTER(LEN=32):: TYPE   ! CAN BE 'S','P','D','F','ALL','SPECIAL'
   INTEGER(4)       :: IDIMD  ! IDIMD=0 REFERES TO ALL SPIN DIRECTIONS
+  INTEGER(4)       :: NSPECIAL  ! NUMBER OF ORBITALS FOR SPECIAL ORBITAL
+  CHARACTER(LEN=32), ALLOCATABLE :: STYPE(:) ! CAN BE 'S','PX','PY','PZ', ...
+  REAL(8), ALLOCATABLE :: FAC(:) ! FACTORS FOR SPECIAL ORBITAL
 END TYPE EXTPOT
 INTEGER(4)             :: NPOT=0
 INTEGER(4)             :: NPOTX=0
@@ -2387,7 +2390,7 @@ CONTAINS
 END MODULE EXPERTNAL1CPOT_MODULE
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
-      SUBROUTINE EXTERNAL1CPOT$SETPOT(ATOM,TYPE,IDIMD,VALUE,RC,PWR)
+      SUBROUTINE EXTERNAL1CPOT$SETPOT(ATOM,TYPE,IDIMD,VALUE,RC,PWR,NSPECIAL,STYPE,FAC)
       USE EXPERTNAL1CPOT_MODULE
       IMPLICIT NONE
       REAL(8)          ,INTENT(IN) :: VALUE
@@ -2396,6 +2399,10 @@ END MODULE EXPERTNAL1CPOT_MODULE
       INTEGER(4)       ,INTENT(IN) :: IDIMD !SPIN DIRECTION OR 0
       REAL(8)          ,INTENT(IN) :: RC
       REAL(8)          ,INTENT(IN) :: PWR
+      INTEGER(4)       ,INTENT(IN) :: NSPECIAL
+      CHARACTER(LEN=32),INTENT(IN) :: STYPE(NSPECIAL)
+      REAL(8)          ,INTENT(IN) :: FAC(NSPECIAL)
+      REAL(8)                      :: SVAR
 !     **************************************************************************
       CALL CREATE
       NPOT=NPOT+1
@@ -2405,6 +2412,19 @@ END MODULE EXPERTNAL1CPOT_MODULE
       POT(NPOT)%PWR=PWR
       POT(NPOT)%IDIMD=IDIMD+1
       POT(NPOT)%TYPE =TYPE
+      POT(NPOT)%NSPECIAL=NSPECIAL
+      IF(NSPECIAL.GT.0) THEN
+        ALLOCATE(POT(NPOT)%STYPE(NSPECIAL))
+        ALLOCATE(POT(NPOT)%FAC(NSPECIAL))
+        POT(NPOT)%STYPE=STYPE
+!       NORMALIZE THE FACTORS
+!       SUM_I |FAC(I)|^2 = 1
+        SVAR=SQRT(ABS(DOT_PRODUCT(FAC,FAC)))
+        POT(NPOT)%FAC=FAC/SVAR
+      ELSE
+        ALLOCATE(POT(NPOT)%FAC(1))
+        POT(NPOT)%FAC(1)=1.D0
+      END IF
       RETURN
       END
 !
@@ -2414,6 +2434,7 @@ END MODULE EXPERTNAL1CPOT_MODULE
       IMPLICIT NONE
       INTEGER(4),INTENT(IN) :: NFIL
       INTEGER(4)            :: IPOT
+      INTEGER(4)            :: I
 !     **************************************************************************
       IF(NPOT.EQ.0) RETURN
 !     CALL REPORT$TITLE(NFIL,"EXTERNAL POTENTIALS ON ORBITALS")
@@ -2433,6 +2454,13 @@ END MODULE EXPERTNAL1CPOT_MODULE
         CALL WRITER8(NFIL,'RC',POT(IPOT)%RC,'ABOHR')
         CALL WRITEI4(NFIL,'IDIMD ([0=NT],[0=NT,1=NS],[0=NT,1=NX,2=NY,3=NZ])' &
      &                   ,POT(IPOT)%IDIMD-1,' ')
+        IF(POT(IPOT)%NSPECIAL.GT.0) THEN
+          WRITE(NFIL,FMT='("SPECIAL ORBITALS")')
+          DO I=1,POT(IPOT)%NSPECIAL
+            CALL WRITECH(NFIL,'STYPE',POT(IPOT)%STYPE(I))
+            CALL WRITER8(NFIL,'FAC',POT(IPOT)%FAC(I),' ')
+          ENDDO
+        END IF
       ENDDO
       RETURN
       CONTAINS
@@ -2484,8 +2512,9 @@ END MODULE EXPERTNAL1CPOT_MODULE
       REAL(8)     ,INTENT(OUT)  :: DATH(LMNX,LMNX,NDIMD)
       REAL(8)     ,INTENT(OUT)  :: ETOT
       TYPE(EXTPOT)              :: POT1
-      INTEGER(4)                :: LANG
-      INTEGER(4)                :: MANG
+      INTEGER(4)                :: NORB
+      INTEGER(4), ALLOCATABLE   :: LANG(:)
+      INTEGER(4), ALLOCATABLE   :: MANG(:)
       INTEGER(4)                :: IAT    ! ATOM INDEX
       INTEGER(4)                :: ISP    ! ATOM TYPE INDEX
       INTEGER(4)                :: NR     ! #(GRID RADIAL POINTS)
@@ -2493,15 +2522,17 @@ END MODULE EXPERTNAL1CPOT_MODULE
       INTEGER(4)   ,ALLOCATABLE :: LOX(:) !(LNX) #(GRID RADIAL POINTS)
       REAL(8)      ,ALLOCATABLE :: AEPHI(:,:) !(NR,LNX) AE PARTIAL WAVES
       REAL(8)      ,ALLOCATABLE :: UONE(:,:)  !(LNX,LNX)
+      REAL(8)                   :: SVAR
       REAL(8)      ,ALLOCATABLE :: RDEP(:)    !(NR)
       REAL(8)      ,ALLOCATABLE :: AUX(:)    !(NR)
       CHARACTER(32)             :: SPECIES
       LOGICAL(4)                :: TCHK
-      INTEGER(4)                :: LN1,LN2,LMN1,LMN2,IPOT,IDIMD,L1,L2,I,LM
+      INTEGER(4)                :: LN1,LN2,LMN1,LMN2,IPOT,IDIMD,L1,L2,I,LM,M1,M2
       INTEGER(4)                :: GID     ! GRID ID
       REAL(8)      ,ALLOCATABLE :: R(:)    ! RADIAL GRID
       LOGICAL(4)                :: TACTIVE
       INTEGER(4)                :: NFILTRACE
+      INTEGER(4)                :: IORB,IORB2
 !     **************************************************************************
       DATH(:,:,:)=0.D0
       ETOT=0.D0
@@ -2527,28 +2558,55 @@ END MODULE EXPERTNAL1CPOT_MODULE
 !       == MANG="MAGNETIC" QUANTUM NUMBER  MANG=-1 ALL "MAGNETIC" QUANTUM NUMBRS
 !       == CAUTION: MANG REFERS TO REAL SPHERICAL HARMONICS
 !
+        IF(POT1%NSPECIAL.EQ.0) NORB=1
+        IF(POT1%NSPECIAL.GT.0) NORB=POT1%NSPECIAL
+        ALLOCATE(LANG(NORB))
+        ALLOCATE(MANG(NORB))
         IF(TRIM(POT1%TYPE).EQ.'ALL') THEN
-          LANG=-1
+          LANG(1)=-1
 !
 !       == SELECT COMPLETE ANGULAR MOMENTUM SHELLS =============================
         ELSE IF(TRIM(POT1%TYPE).EQ.'S') THEN
-          LANG=0
-          MANG=-1
+          LANG(1)=0
+          MANG(1)=-1
         ELSE IF(TRIM(POT1%TYPE).EQ.'P') THEN
-          LANG=1
-          MANG=-1
+          LANG(1)=1
+          MANG(1)=-1
         ELSE IF(TRIM(POT1%TYPE).EQ.'D') THEN
-          LANG=2
-          MANG=-1
+          LANG(1)=2
+          MANG(1)=-1
         ELSE IF(TRIM(POT1%TYPE).EQ.'F') THEN
-          LANG=3
-          MANG=-1
+          LANG(1)=3
+          MANG(1)=-1
+        ELSE IF(TRIM(POT1%TYPE).EQ.'SPECIAL') THEN
+          DO IORB=1,NORB
+            CALL SPHERICAL$LMBYNAME(TRIM(POT1%STYPE(IORB)),LM)
+            LANG(IORB)=INT(SQRT(REAL(LM-1,KIND=8))+1.D-5)
+            MANG(IORB)=LM-LANG(IORB)**2
+          ENDDO
+!         REQUIRE ALL SPECIAL ORBITALS TO HAVE THE SAME L
+!         REQUIRE ALL SPECIAL ORBITALS TO HAVE DIFFERENT M
+!         (IN PRINCIPLE THIS IS NOT NECESSARY)
+          L1=LANG(1)
+          DO IORB=1,NORB
+            IF(LANG(IORB).NE.L1) THEN
+              CALL ERROR$MSG('ALL SPECIAL ORBITALS MUST HAVE THE SAME L')
+              CALL ERROR$STOP('EXTERNAL1CPOT$APPLY')
+            END IF
+            M1=MANG(IORB)
+            DO I=IORB+1,NORB
+              IF(MANG(I).EQ.M1) THEN
+                CALL ERROR$MSG('ALL SPECIAL ORBITALS MUST HAVE DIFFERENT M')
+                CALL ERROR$STOP('EXTERNAL1CPOT$APPLY')
+              END IF
+            ENDDO
+          ENDDO
         ELSE   
 !         == SELECT INDIVIDUAL REAL SPHERICAL HARMONICS ========================
 !         == SPHERICAL$LMBYNAME THROWS AN ERROR IF TYPE IS NOT RECOGNIZED ======
           CALL SPHERICAL$LMBYNAME(TRIM(POT1%TYPE),LM)
-          LANG=INT(SQRT(REAL(LM-1,KIND=8))+1.D-5)
-          MANG=LM-LANG**2        
+          LANG(1)=INT(SQRT(REAL(LM-1,KIND=8))+1.D-5)
+          MANG(1)=LM-LANG(1)**2        
         END IF
 !
 !       ========================================================================
@@ -2583,17 +2641,22 @@ END MODULE EXPERTNAL1CPOT_MODULE
         ALLOCATE(UONE(LNX,LNX))
         UONE(:,:)=0.D0
         LMN1=0
-        DO LN1=1,LNX
-          IF(.NOT.(LANG.EQ.LOX(LN1).OR.LANG.EQ.-1)) CYCLE
-          DO LN2=1,LNX
-            IF(.NOT.(LANG.EQ.LOX(LN2).OR.LANG.EQ.-1)) CYCLE
-            IF(LOX(LN2).NE.LOX(LN1)) CYCLE
-            IF(LN2.LT.LN1) THEN
-              UONE(LN1,LN2)=UONE(LN2,LN1)
-              CYCLE
-            END IF
-            AUX(:)=RDEP(:)*AEPHI(:,LN1)*AEPHI(:,LN2)*R(:)**2
-            CALL RADIAL$INTEGRAL(GID,NR,AUX,UONE(LN1,LN2))
+!       LOOP THROUGH ALL ORBITALS SO EVERY NECESSARY UONE IS CALCULATED
+!       MIGHT CALCULATE SOME UONE TWICE 
+!       (AS ALL L ARE THE SAME, ONLY M DIFFERS, KEPT FOR POTENTIAL FUTURE USE)
+        DO IORB=1,NORB
+          DO LN1=1,LNX
+            IF(.NOT.(LANG(IORB).EQ.LOX(LN1).OR.LANG(IORB).EQ.-1)) CYCLE
+            DO LN2=1,LNX
+              IF(.NOT.(LANG(IORB).EQ.LOX(LN2).OR.LANG(IORB).EQ.-1)) CYCLE
+              IF(LOX(LN2).NE.LOX(LN1)) CYCLE
+              IF(LN2.LT.LN1) THEN
+                UONE(LN1,LN2)=UONE(LN2,LN1)
+                CYCLE
+              END IF
+              AUX(:)=RDEP(:)*AEPHI(:,LN1)*AEPHI(:,LN2)*R(:)**2
+              CALL RADIAL$INTEGRAL(GID,NR,AUX,UONE(LN1,LN2))
+            ENDDO
           ENDDO
         ENDDO
         DEALLOCATE(R)
@@ -2619,10 +2682,15 @@ END MODULE EXPERTNAL1CPOT_MODULE
               DO LN2=1,LNX
                 L2=LOX(LN2)
                 IF(L1.EQ.L2) THEN
-                  DO I=1,2*L1+1
-                    IF(.NOT.(MANG.EQ.I.OR.MANG.EQ.-1)) CYCLE
-                    DATH(LMN1+I,LMN2+I,IDIMD)=DATH(LMN1+I,LMN2+I,IDIMD) &
-       &                                     +UONE(LN1,LN2)
+                  DO IORB=1,NORB
+                    M1=MANG(IORB)
+                    DO IORB2=1,NORB
+                      M2=MANG(IORB2)
+!                     IF SWITCH TO COMPLEX COEFFICIENTS ONE NEEDS CONJUGATE
+                      SVAR=POT1%FAC(IORB)*POT1%FAC(IORB2)*UONE(LN1,LN2)
+                      DATH(LMN1+M1,LMN2+M2,IDIMD)=DATH(LMN1+M1,LMN2+M2,IDIMD) &
+      &                                       +SVAR
+                    ENDDO
                   ENDDO
                 END IF
                 LMN2=LMN2+2*L2+1

--- a/src/paw_ioroutines.f90
+++ b/src/paw_ioroutines.f90
@@ -4911,23 +4911,26 @@ CALL ERROR$STOP('READIN_ANALYSE_OPTIC')
       USE LINKEDLIST_MODULE
       USE PERIODICTABLE_MODULE
       IMPLICIT NONE
-      TYPE(LL_TYPE),INTENT(IN) :: LL_STRC_
-      TYPE(LL_TYPE)            :: LL_STRC
-      LOGICAL(4)               :: TCHK
-      LOGICAL(4)               :: TON
-      CHARACTER(32)            :: ATOM,NAME
-      INTEGER(4)               :: NTH,ITH
-      CHARACTER(32)            :: TYPE
-      INTEGER(4)               :: ISPIN
-      INTEGER(4)               :: NAT
-      INTEGER(4)               :: I
-      INTEGER(4)               :: IAT
-      REAL(8)                  :: VALUE
-      REAL(8)                  :: RC
-      REAL(8)                  :: PWR
-      REAL(8)                  :: AEZ
-      REAL(8)                  :: RCOV
-      INTEGER(4)               :: LM
+      TYPE(LL_TYPE),INTENT(IN)   :: LL_STRC_
+      TYPE(LL_TYPE)              :: LL_STRC
+      LOGICAL(4)                 :: TCHK
+      LOGICAL(4)                 :: TON
+      CHARACTER(32)              :: ATOM,NAME
+      INTEGER(4)                 :: NTH,ITH
+      CHARACTER(32)              :: TYPE
+      INTEGER(4)                 :: ISPIN
+      INTEGER(4)                 :: NAT
+      INTEGER(4)                 :: I
+      INTEGER(4)                 :: IAT
+      REAL(8)                    :: VALUE
+      REAL(8)                    :: RC
+      REAL(8)                    :: PWR
+      INTEGER(4)                 :: NSPECIAL
+      REAL(8), ALLOCATABLE    :: FAC(:)
+      CHARACTER(32), ALLOCATABLE :: STYPE(:)
+      REAL(8)                    :: AEZ
+      REAL(8)                    :: RCOV
+      INTEGER(4)                 :: LM
 !     **************************************************************************
                            CALL TRACE$PUSH('STRCIN_ORBPOT')
       LL_STRC=LL_STRC_
@@ -4983,10 +4986,11 @@ CALL ERROR$STOP('READIN_ANALYSE_OPTIC')
           TYPE=+TYPE   ! MAKE INPUT CASE INSENSITIVE BY UPPERCASING TYPE
         END IF
         TCHK=.FALSE.
-        IF(TYPE.EQ.'P')   TCHK=.TRUE.
-        IF(TYPE.EQ.'D')   TCHK=.TRUE.
-        IF(TYPE.EQ.'F')   TCHK=.TRUE.
-        IF(TYPE.EQ.'ALL') TCHK=.TRUE.
+        IF(TYPE.EQ.'P')       TCHK=.TRUE.
+        IF(TYPE.EQ.'D')       TCHK=.TRUE.
+        IF(TYPE.EQ.'F')       TCHK=.TRUE.
+        IF(TYPE.EQ.'ALL')     TCHK=.TRUE.
+        IF(TYPE.EQ.'SPECIAL') TCHK=.TRUE.
 !       == PURE ANGULAR MOMENTA ================================================
 !       == SEE SPHERICAL$LMBYNAME ==============================================
         IF(.NOT.TCHK) THEN
@@ -5028,13 +5032,47 @@ CALL ERROR$STOP('READIN_ANALYSE_OPTIC')
           CALL ERROR$STOP('STRCIN_ORBPOT')
         END IF
         CALL LINKEDLIST$GET(LL_STRC,'VALUE',1,VALUE)
+!       == DEAL WITH SPECIAL ORBITAL ===========================================
+        IF(TYPE.EQ.'SPECIAL') THEN
+          CALL LINKEDLIST$NLISTS(LL_STRC,'ORB',NSPECIAL)
+          IF(NSPECIAL.EQ.0) THEN
+            CALL ERROR$MSG('!STRUCTURE!ORBPOT!POT:TYPE=SPECIAL BUT NO !ORB')
+            CALL ERROR$STOP('STRCIN_ORBPOT')
+          END IF
+          ALLOCATE(FAC(NSPECIAL))
+          ALLOCATE(STYPE(NSPECIAL))
+          DO I=1,NSPECIAL
+            CALL LINKEDLIST$SELECT(LL_STRC,'ORB',I)
+            CALL LINKEDLIST$EXISTD(LL_STRC,'TYPE',1,TCHK)
+            IF(.NOT.TCHK) THEN
+              CALL ERROR$MSG('!STRUCTURE!ORBPOT!POT!ORB:TYPE NOT SPECIFIED')
+              CALL ERROR$I4VAL('ORB',I)
+              CALL ERROR$STOP('STRCIN_ORBPOT')
+            END IF
+            CALL LINKEDLIST$GET(LL_STRC,'TYPE',1,STYPE(I))
+            CALL LINKEDLIST$EXISTD(LL_STRC,'FAC',1,TCHK)
+            IF(.NOT.TCHK) THEN
+              CALL ERROR$MSG('!STRUCTURE!ORBPOT!POT!ORB:FAC NOT SPECIFIED')
+              CALL ERROR$I4VAL('ORB',I)
+              CALL ERROR$STOP('STRCIN_ORBPOT')
+            END IF
+            CALL LINKEDLIST$GET(LL_STRC,'FAC',1,FAC(I))
+            CALL LINKEDLIST$SELECT(LL_STRC,'..')
+          ENDDO
+        ELSE
+!         ALLOCATE EMPTY ARRAYS AS DUMMY ARGUMENTS
+          NSPECIAL=0
+          ALLOCATE(FAC(NSPECIAL))
+          ALLOCATE(STYPE(NSPECIAL))
+        END IF
 !       ========================================================================
-        CALL EXTERNAL1CPOT$SETPOT(ATOM,TYPE,ISPIN,VALUE,RC,PWR)
+        CALL EXTERNAL1CPOT$SETPOT(ATOM,TYPE,ISPIN,VALUE,RC,PWR, &
+     &                            NSPECIAL,STYPE,FAC)
         CALL LINKEDLIST$SELECT(LL_STRC,'..')
       ENDDO
                            CALL TRACE$POP
       RETURN
-    END SUBROUTINE STRCIN_ORBPOT
+      END SUBROUTINE STRCIN_ORBPOT
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE STRCIN_GROUP(LL_STRC_)


### PR DESCRIPTION
ORBPOT applies an external potential to a selected atom-centred orbital. 
This commit adds support for creating an orbital by superposition of multiple orbitals with the same angular momentum and applying the potential to that.

One example would be a p-orbital pointing in the (1,1,0) direction. This can be achieved by 

```
!ORBPOT
  !POT ATOM='AT1' TYPE='SPECIAL' VAL=-0.1
    !ORB TYPE='PX' FAC=1.0 !END
    !ORB TYPE='PY' FAC=1.0 !END
  !END
!END
```
where the factors are changed internally to ensure normalization.