### PR TITLE
Fix character length in paw_dos.f90

### DIFF
--- a/src/Docs/manual.tex
+++ b/src/Docs/manual.tex
@@ -6685,7 +6685,7 @@ LM & $\ell$ & $m$ & IDs & expression \\
    & $Y_{f_{xz2}}=\sqrt{\frac{21}{32\pi}} \frac{x(5z^2-r^2)}{|r|^3}$\\
 13 & 3 & 4 & fZ3, FZ(5Z2-3R2), F4
    & $Y_{f_{z3}}=\sqrt{\frac{14}{32\pi}} \frac{z(5z^2-3r^2)}{|r|^3}$\\
-14 & 3 & 5 & FYZ2, FY(5Z2-R2), F4
+14 & 3 & 5 & FYZ2, FY(5Z2-R2), F5
    & $Y_{f_{yz2}}=\sqrt{\frac{21}{32\pi}} \frac{y(5z^2-r^2)}{|r|^3}$\\
 15 & 3 & 6 & FXYZ, F6
    & $Y_{f_{xyz}}=\sqrt{\frac{840}{32\pi}} \frac{xyz}{|r|^3}$\\

--- a/src/Tools/PDoS/paw_dos.f90
+++ b/src/Tools/PDoS/paw_dos.f90
@@ -2448,7 +2448,7 @@ END MODULE NEWSET_MODULE
       INTEGER(4)   ,INTENT(OUT):: IT(3)       ! UNIT-CELL INDEX
       INTEGER(4)   ,INTENT(IN) :: LMXX        ! MAX LENGTH OF ORBITAL ARRAY
       COMPLEX(8)   ,INTENT(OUT):: ORB(LMXX)   ! ORBITAL COEFFICIENT VECTOR
-      CHARACTER(8)             :: TYPE  ! ORBITAL TYPE IN LOCAL COORDINATES
+      CHARACTER(32)            :: TYPE  ! ORBITAL TYPE IN LOCAL COORDINATES
       INTEGER(4)               :: IAT2
       CHARACTER(32)            :: ATOMEX      ! ATOM NAME IN EXTENDED NOTATION
       CHARACTER(32)            :: ATOM
@@ -2649,7 +2649,7 @@ CALL LINKEDLIST$REPORT(LL_CNTL,6)
 !
       ELSE
 !       == RESOLVE PURE REAL SPHERICAL HARMONICS ===============================
-        CALL SPHERICAL$LMBYNAME(TYPE,LM)
+        CALL SPHERICAL$LMBYNAME(TRIM(TYPE),LM)
         ORB(LM)=1.D0
       END IF
 !
@@ -3445,7 +3445,7 @@ CALL LINKEDLIST$REPORT(LL_CNTL,6)
       INTEGER(4)                :: ISET   ! SET COUNTER
       INTEGER(4)                :: IAT
       INTEGER(4)                :: IAT0
-      CHARACTER(8)              :: TYPE
+      CHARACTER(32)             :: TYPE
       CHARACTER(32)             :: NAME,SPIN
       LOGICAL(4)                :: TCHK,TCHK1
       INTEGER(4)                :: ITH, NUM


### PR DESCRIPTION
- increase char length to accomodate f-orbitals
- fix typo in manual

Fixes #50 