### PR TITLE
Update Si2 reference for corrected PBE

### DIFF
--- a/tests/fulltests/si2/analyse.sh
+++ b/tests/fulltests/si2/analyse.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 echo "comparing total energy."
-TOTAL_ENERGY_REF=-7.4076060
-# tested with gfortran 11.3.0, FFTW 3.3.10, Apple Accelerate Framework
-# commit d140b678a03822efe485a1e39e0af47370bbce53
+TOTAL_ENERGY_REF=-7.3657485
+# PBE TYPE=10 after the Dec. 10, 2023 PBE TFAC fix. The legacy TYPE=-10 path
+# reproduces the previous reference, -7.4076060.
 
 TOLERANCE=0.0001
 
 TOTAL_ENERGY=`grep "TOTAL ENERGY" si2.prot | tail -n 1 | awk 'BEGIN { FS = " " } ; { print $4 }'`
-CRIT=`echo "define abs(x) {if (x<0) {return -x}; return x;}scale=20;abs(($TOTAL_ENERGY_REF)-($TOTAL_ENERGY))<$TOLERANCE" | bc -l`
+CRIT=`awk -v ref="$TOTAL_ENERGY_REF" -v val="$TOTAL_ENERGY" -v tol="$TOLERANCE" \
+  'BEGIN { diff=ref-val; if (diff < 0) diff=-diff; print (diff < tol) ? 1 : 0 }'`
 #echo $CRIT
 if [ "$CRIT" = "1"  ];
 then


### PR DESCRIPTION
## Summary

This updates the Si2 full-test reference energy to the current corrected intrinsic PBE implementation (`DFT TYPE=10`).

The previous reference, `-7.4076060`, is still reproduced exactly by the legacy PBE path (`DFT TYPE=-10`), which disables the Dec. 10, 2023 TFAC correction. The corrected `TYPE=10` path gives `-7.3657485`, so the test reference was tied to the historical/legacy PBE behavior rather than the corrected default.

The analysis script also switches the tolerance check from a non-portable `bc` function definition to `awk`, which avoids parse failures with the system `bc`.

## Checks

- `DFT TYPE=10`: `TOTAL ENERGY = -7.3657485`
- `DFT TYPE=-10`: `TOTAL ENERGY = -7.4076060` (old reference)
- `TEST=si2 PAWX=/Users/tkuehne/dropbox/CP-PAW@CASUS/bin/fast/paw_fast.x make all` -> `TEST PASSED`
