### PR TITLE
Extend NVHPC generalized solver diagnostics

### DIFF
--- a/src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
+++ b/src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RANKS=${RANKS:-2}
+N=${N:-1024}
+WORKDIR=${WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cppaw-cuda-aware-mpi.XXXXXX")}
+KEEP_WORKDIR=${KEEP_WORKDIR:-no}
+MPIFORT=${MPIFORT:-$(command -v mpifort 2>/dev/null || true)}
+MPIRUN=${MPIRUN:-$(command -v mpirun 2>/dev/null || true)}
+FCFLAGS=${FCFLAGS:-"-acc"}
+MPI_ARGS=${MPI_ARGS:-}
+
+cleanup() {
+  case "${KEEP_WORKDIR}" in
+    yes|true|1) ;;
+    *) rm -rf "${WORKDIR}" ;;
+  esac
+}
+trap cleanup EXIT
+
+if [[ -z "${MPIFORT}" ]]; then
+  echo "cuda_aware_mpi_probe=skip reason=no_mpifort"
+  exit 0
+fi
+if [[ -z "${MPIRUN}" ]]; then
+  echo "cuda_aware_mpi_probe=skip reason=no_mpirun"
+  exit 0
+fi
+
+mkdir -p "${WORKDIR}"
+src="${WORKDIR}/cuda_aware_mpi_probe.f90"
+exe="${WORKDIR}/cuda_aware_mpi_probe.x"
+
+cat > "${src}" <<'EOF'
+program cuda_aware_mpi_probe
+  use mpi
+  implicit none
+  integer :: ierr, rank, nranks, n, i
+  real(8), allocatable :: send(:), recv(:)
+  real(8) :: expected, local_err, global_err
+  character(len=32) :: arg
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, nranks, ierr)
+
+  n = 1024
+  call get_command_argument(1, arg)
+  if (len_trim(arg) > 0) read(arg, *) n
+  allocate(send(n), recv(n))
+
+  do i = 1, n
+    send(i) = real(rank + 1, kind=8)
+    recv(i) = -1.0d0
+  end do
+
+!$acc data copyin(send(1:n)) copyout(recv(1:n))
+!$acc host_data use_device(send, recv)
+  call MPI_Allreduce(send, recv, n, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+!$acc end host_data
+!$acc end data
+
+  expected = 0.5d0 * real(nranks * (nranks + 1), kind=8)
+  local_err = maxval(abs(recv - expected))
+  call MPI_Allreduce(local_err, global_err, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
+  if (rank == 0) then
+    if (global_err <= 1.0d-12) then
+      write(*,'(a,i0,a,i0,a,es12.4)') &
+        'cuda_aware_mpi_probe=pass ranks=', nranks, ' n=', n, ' err=', global_err
+    else
+      write(*,'(a,i0,a,i0,a,es12.4)') &
+        'cuda_aware_mpi_probe=fail ranks=', nranks, ' n=', n, ' err=', global_err
+    end if
+  end if
+
+  deallocate(recv, send)
+  call MPI_Finalize(ierr)
+  if (global_err > 1.0d-12) stop 2
+end program cuda_aware_mpi_probe
+EOF
+
+"${MPIFORT}" ${FCFLAGS} -o "${exe}" "${src}"
+# shellcheck disable=SC2086
+"${MPIRUN}" ${MPI_ARGS} -np "${RANKS}" "${exe}" "${N}"

--- a/src/Tools/Scripts/paw_gpu_capabilities.sh
+++ b/src/Tools/Scripts/paw_gpu_capabilities.sh
@@ -79,6 +79,9 @@ cuda_aware_mpi() {
   else
     echo "cuda_aware_mpi=unknown mpirun=${mpirun}"
   fi
+  "${ompi_info}" --parsable --all 2>/dev/null \
+      | grep -Ei 'cuda|gpu|ucx|hcoll' \
+      | sed -n '1,40s/^/mpi_capability=/' || true
 }
 
 root=$(find_nvhpc_root || true)
@@ -113,6 +116,7 @@ yesno_path "cudss" "$(find_lib libcudss.so "${root}" || true)"
 yesno_path "nccl" "$(find_lib libnccl.so "${root}" || true)"
 yesno_path "nvshmem" "$(find_lib libnvshmem_host.so "${root}" || true)"
 cuda_aware_mpi
+echo "cuda_aware_mpi_probe=run src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh"
 
 echo "recommended_gpu_cases=gpu gpu_force_all gpu_3dfft gpu_off"
 echo "recommended_resource_cases=cpu nvpl gpu gpu_off"

--- a/src/paw_accel_cusolver.f90
+++ b/src/paw_accel_cusolver.f90
@@ -27,6 +27,12 @@
       LOGICAL(4)             :: ENABLED=.TRUE.
       LOGICAL(4)             :: CHECK_ENABLED=.FALSE.
       INTEGER(4)             :: MIN_N=256
+      INTEGER(4)             :: MIN_N_STANDARD=256
+      INTEGER(4)             :: MIN_N_GENERALIZED=256
+      INTEGER(4)             :: MIN_N_DSYEVD=256
+      INTEGER(4)             :: MIN_N_ZHEEVD=256
+      INTEGER(4)             :: MIN_N_DSYGVD=256
+      INTEGER(4)             :: MIN_N_ZHEGVD=256
       REAL(8)                :: CHECK_TOL=1.D-7
       CONTAINS
 !
@@ -66,6 +72,24 @@
       RETURN
       END SUBROUTINE CPPAW_CUSOLVER_ACC_PROFILE_TIME
 #ENDIF
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUSOLVER_ACC_READ_INT_ENV(NAME,VALUE)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN)    :: NAME
+      INTEGER(4) ,INTENT(INOUT) :: VALUE
+      CHARACTER(128)            :: TEXT
+      INTEGER(4)                :: STATUS
+      INTEGER(4)                :: IOS
+      INTEGER(4)                :: TMP
+!     **************************************************************************
+      CALL GET_ENVIRONMENT_VARIABLE(NAME,TEXT,STATUS=STATUS)
+      IF(STATUS.EQ.0) THEN
+        READ(TEXT,*,IOSTAT=IOS) TMP
+        IF(IOS.EQ.0) VALUE=MAX(1,TMP)
+      END IF
+      RETURN
+      END SUBROUTINE CPPAW_CUSOLVER_ACC_READ_INT_ENV
 !
 !     ..........................................................................
       SUBROUTINE CPPAW_CUSOLVER_ACC_INITCONFIG
@@ -123,6 +147,36 @@
         IF(IOS.NE.0) MIN_N=256
         MIN_N=MAX(1,MIN_N)
       END IF
+      MIN_N_STANDARD=MIN_N
+      MIN_N_GENERALIZED=MIN_N
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_STANDARD_MIN_N',MIN_N_STANDARD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_STANDARD_MIN_N',MIN_N_STANDARD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N',MIN_N_GENERALIZED)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_GENERALIZED_MIN_N',MIN_N_GENERALIZED)
+      MIN_N_DSYEVD=MIN_N_STANDARD
+      MIN_N_ZHEEVD=MIN_N_STANDARD
+      MIN_N_DSYGVD=MIN_N_GENERALIZED
+      MIN_N_ZHEGVD=MIN_N_GENERALIZED
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_DSYEVD_MIN_N',MIN_N_DSYEVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_DSYEVD_MIN_N',MIN_N_DSYEVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_ZHEEVD_MIN_N',MIN_N_ZHEEVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ZHEEVD_MIN_N',MIN_N_ZHEEVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_DSYGVD_MIN_N',MIN_N_DSYGVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_DSYGVD_MIN_N',MIN_N_DSYGVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ACC_ZHEGVD_MIN_N',MIN_N_ZHEGVD)
+      CALL CPPAW_CUSOLVER_ACC_READ_INT_ENV &
+     &     ('CPPAW_CUSOLVER_ZHEGVD_MIN_N',MIN_N_ZHEGVD)
       RETURN
       END SUBROUTINE CPPAW_CUSOLVER_ACC_INITCONFIG
 !
@@ -135,6 +189,50 @@
       CPPAW_CUSOLVER_ACC_SHOULD_USE=ENABLED.AND.(N.GE.MIN_N)
       RETURN
       END FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYEVD(N)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN) :: N
+!     **************************************************************************
+      CALL CPPAW_CUSOLVER_ACC_INITCONFIG
+      CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYEVD=ENABLED &
+     &                                    .AND.(N.GE.MIN_N_DSYEVD)
+      RETURN
+      END FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYEVD
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEEVD(N)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN) :: N
+!     **************************************************************************
+      CALL CPPAW_CUSOLVER_ACC_INITCONFIG
+      CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEEVD=ENABLED &
+     &                                    .AND.(N.GE.MIN_N_ZHEEVD)
+      RETURN
+      END FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEEVD
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYGVD(N)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN) :: N
+!     **************************************************************************
+      CALL CPPAW_CUSOLVER_ACC_INITCONFIG
+      CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYGVD=ENABLED &
+     &                                    .AND.(N.GE.MIN_N_DSYGVD)
+      RETURN
+      END FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYGVD
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEGVD(N)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN) :: N
+!     **************************************************************************
+      CALL CPPAW_CUSOLVER_ACC_INITCONFIG
+      CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEGVD=ENABLED &
+     &                                    .AND.(N.GE.MIN_N_ZHEGVD)
+      RETURN
+      END FUNCTION CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEGVD
 !
 !     ..........................................................................
       SUBROUTINE CPPAW_CUSOLVER_ACC_ENSURE
@@ -352,7 +450,7 @@
       USED=.FALSE.
       INFO=0
       IF(N.LE.0) RETURN
-      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE(N)) RETURN
+      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYEVD(N)) RETURN
       U=0.5D0*(H+TRANSPOSE(H))
       CALL CPPAW_CUSOLVER_ACC_ENSURE
       LWORK=0
@@ -422,7 +520,7 @@
       USED=.FALSE.
       INFO=0
       IF(N.LE.0) RETURN
-      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE(N)) RETURN
+      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEEVD(N)) RETURN
       U=0.5D0*(H+TRANSPOSE(CONJG(H)))
       CALL CPPAW_CUSOLVER_ACC_ENSURE
       LWORK=0
@@ -494,7 +592,7 @@
       USED=.FALSE.
       INFO=0
       IF(N.LE.0) RETURN
-      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE(N)) RETURN
+      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE_DSYGVD(N)) RETURN
       U=H
       B=S
       CALL CPPAW_CUSOLVER_ACC_ENSURE
@@ -570,7 +668,7 @@
       USED=.FALSE.
       INFO=0
       IF(N.LE.0) RETURN
-      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE(N)) RETURN
+      IF(.NOT.CPPAW_CUSOLVER_ACC_SHOULD_USE_ZHEGVD(N)) RETURN
       IF(SYM) THEN
         VEC=0.5D0*(H+TRANSPOSE(CONJG(H)))
       ELSE

--- a/src/paw_fft.f90
+++ b/src/paw_fft.f90
@@ -2402,10 +2402,11 @@ END MODULE PLANEWAVE_MODULE
       COMPLEX(8)  ,INTENT(IN)   :: F2(NGL,NDIM,N2)
       COMPLEX(8)  ,INTENT(OUT)  :: MAT(N1,N2)
       INTEGER(4)                :: NGAMMA
-      INTEGER(4)                :: I1,I2,IDIM
+      INTEGER(4)                :: I1,I2,IDIM,IG
       COMPLEX(8)  ,ALLOCATABLE  :: F2M(:,:)
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       COMPLEX(8)  ,ALLOCATABLE  :: F2MB(:,:,:)
+      INTEGER(4)  ,POINTER      :: MINUSGACC(:)
       LOGICAL(4)                :: TUSEINVBATCH
       REAL(8)                   :: INVBATCHFLOPS
 #ENDIF
@@ -2427,14 +2428,23 @@ END MODULE PLANEWAVE_MODULE
      &     .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_OVERLAP(INVBATCHFLOPS)
         IF(TUSEINVBATCH) THEN
           ALLOCATE(F2MB(NGL,NDIM,N2))
+          MINUSGACC=>THIS%MINUSG
 !         == SUM_G F1(-G) F2(G) =CONJG(SUM_G F1(G)^* F2(-G)^*) ==========
+!$ACC DATA PRESENT_OR_COPYIN(F2(1:NGL,1:NDIM,1:N2) &
+!$ACC&                       ,MINUSGACC(1:NGL)) &
+!$ACC& CREATE(F2MB(1:NGL,1:NDIM,1:N2))
+!$ACC PARALLEL LOOP COLLAPSE(3) PRESENT(F2,F2MB,MINUSGACC)
           DO I2=1,N2
             DO IDIM=1,NDIM
 !             __F2MB(G)=F2(-G)^*_________________________________________
-              CALL PLANEWAVE$INVERTG(NGL,F2(1,IDIM,I2),F2MB(1,IDIM,I2))
+              DO IG=1,NGL
+                F2MB(IG,IDIM,I2)=CONJG(F2(MINUSGACC(IG),IDIM,I2))
+              ENDDO
             ENDDO
           ENDDO
+!$ACC END PARALLEL LOOP
           CALL LIB$SCALARPRODUCTC8(.FALSE.,NGL*NDIM,N1,F1,N2,F2MB,MAT)
+!$ACC END DATA
           DO I1=1,N1
             DO I2=1,N2
               MAT(I1,I2)=CONJG(MAT(I1,I2))
@@ -2501,6 +2511,11 @@ END MODULE PLANEWAVE_MODULE
 !     **                                                              **
 !     ******************************************************************
       USE PLANEWAVE_MODULE
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &     CPPAW_CUBLAS_ACC_INVERSION_BATCH_ENABLED &
+     &    ,CPPAW_CUBLAS_ACC_SHOULD_USE_ADDPRODUCT
+#ENDIF
       IMPLICIT NONE 
       CHARACTER(*),INTENT(IN)   :: ID    ! ' ','=','-'
       INTEGER(4)  ,INTENT(IN)   :: NDIM
@@ -2510,8 +2525,13 @@ END MODULE PLANEWAVE_MODULE
       COMPLEX(8)  ,INTENT(INOUT):: F1(NGL,NDIM,N1)
       COMPLEX(8)  ,INTENT(IN)   :: F2(NGL,NDIM,N2)
       COMPLEX(8)  ,INTENT(IN)   :: MAT(N2,N1)
-      INTEGER(4)                :: I2,IDIM
+      INTEGER(4)                :: I2,IDIM,IG
       COMPLEX(8)  ,ALLOCATABLE  :: F2M(:,:,:)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      INTEGER(4)  ,POINTER      :: MINUSGACC(:)
+      LOGICAL(4)                :: TUSEACCINVERT
+      REAL(8)                   :: INVBATCHFLOPS
+#ENDIF
       LOGICAL(4)  ,PARAMETER    :: TESSL=.TRUE.
 !     ******************************************************************
                              CALL TIMING$CLOCKON('PLANEWAVE$ADDPRODUCT')
@@ -2537,12 +2557,38 @@ END MODULE PLANEWAVE_MODULE
           CALL ERROR$MSG('AND NOT FOR SUPER WAVE FUNCTIONS')
         END IF
         ALLOCATE(F2M(NGL,NDIM,N2))
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+        INVBATCHFLOPS=8.D0*REAL(NGL*NDIM,KIND=8) &
+     &                     *REAL(N1,KIND=8)*REAL(N2,KIND=8)
+        TUSEACCINVERT=CPPAW_CUBLAS_ACC_INVERSION_BATCH_ENABLED() &
+     &      .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_ADDPRODUCT(INVBATCHFLOPS)
+        IF(TUSEACCINVERT) THEN
+          MINUSGACC=>THIS%MINUSG
+!$ACC DATA PRESENT_OR_COPYIN(F2(1:NGL,1:NDIM,1:N2) &
+!$ACC&                       ,MINUSGACC(1:NGL)) &
+!$ACC& CREATE(F2M(1:NGL,1:NDIM,1:N2))
+!$ACC PARALLEL LOOP COLLAPSE(3) PRESENT(F2,F2M,MINUSGACC)
+          DO I2=1,N2
+            DO IDIM=1,NDIM
+              DO IG=1,NGL
+                F2M(IG,IDIM,I2)=CONJG(F2(MINUSGACC(IG),IDIM,I2))
+              ENDDO
+            ENDDO
+          ENDDO
+!$ACC END PARALLEL LOOP
+          CALL LIB$ADDPRODUCTC8(.FALSE.,NGL*NDIM,N2,N1,F2M,MAT,F1)
+!$ACC END DATA
+        ELSE
+#ENDIF
         DO I2=1,N2
           DO IDIM=1,NDIM
             CALL PLANEWAVE$INVERTG(NGL,F2(1,IDIM,I2),F2M(1,IDIM,I2))
           ENDDO
         ENDDO
         CALL LIB$ADDPRODUCTC8(.FALSE.,NGL*NDIM,N2,N1,F2M,MAT,F1)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+        END IF
+#ENDIF
         DEALLOCATE(F2M)
       END IF
                             CALL TIMING$CLOCKOFF('PLANEWAVE$ADDPRODUCT')

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -132,7 +132,11 @@ overhead in this configuration.
 
 The `cpu` case uses the plain GNU/OpenBLAS/FFTW build (`profile` or
 `profile_parallel`) as a pre-HPC-SDK reference. For MPI runs it defaults to the
-system or `cppaw-gccmpi` `mpirun`; set `CPU_MPIRUN=...` to override it. Benchmark runs pin common
+system or `cppaw-gccmpi` `mpirun`; for parallel CPU runs, the harness first
+tries to derive the matching MPI launcher and `LD_LIBRARY_PATH` entry from the
+selected executable's resolved `libmpi`. Set `CPU_MPIRUN=...` or
+`CPU_MPI_LIBDIR=...` to override either value on unusual installations.
+Benchmark runs pin common
 CPU threading variables to one thread by default (`OMP_NUM_THREADS`,
 `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `BLIS_NUM_THREADS`,
 `VECLIB_MAXIMUM_THREADS`, `NVPL_NUM_THREADS`) and record those settings plus

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -152,11 +152,13 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `cublas` / `cublas_nosync` / `cublas_invbatch_off` / `cublas_off` | Explicit cuBLAS/OpenACC path with the default threshold, with the post-call device synchronization disabled, with inversion scalarproduct batching disabled, or disabled. |
 | `cublas_conservative` | Explicit cuBLAS/OpenACC with a higher diagnostic threshold. |
 | `cublas_projection_conservative` / `cublas_overlap_conservative` / `cublas_addproduct_conservative` / `cublas_matmul_conservative` | Explicit cuBLAS/OpenACC with only one kernel category raised to the conservative threshold. |
-| `cusolver` / `cusolver_off` | Explicit cuSOLVER/OpenACC forced for small eigensolvers, or disabled. |
+| `cusolver` / `cusolver_standard` / `cusolver_generalized` / `cusolver_off` | Explicit cuSOLVER/OpenACC forced for all eigensolvers, only standard eigensolvers, only generalized eigensolvers, or disabled. |
 | `cusolver_conservative` | cuSOLVER/OpenACC with the production default size threshold. |
+| `cusolver_generalized_conservative` | cuSOLVER/OpenACC with only generalized eigensolvers enabled at the production threshold. |
 | `gpu` / `gpu_nosync` / `gpu_invbatch_off` | Combined GPU profile, with optional diagnostics that disable the cuBLAS post-call synchronization or inversion scalarproduct batching. |
 | `gpu_projection_conservative` / `gpu_overlap_conservative` / `gpu_addproduct_conservative` / `gpu_matmul_conservative` | Combined GPU diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident` / `gpu_resident_nosync` / `gpu_resident_invbatch_off` | Recommended combined GPU profile with `CPPAW_GPU_RESIDENCY=1`; currently keeps selected wavefunction loops in OpenACC data regions for cuBLAS scalarproduct/projection/addproduct reuse, with diagnostics for synchronization and inversion batching. |
+| `gpu_resident_no_cusolver` | Residency diagnostic with cuSOLVER disabled in the same residency binary. |
 | `gpu_resident_projection_conservative` / `gpu_resident_overlap_conservative` / `gpu_resident_addproduct_conservative` / `gpu_resident_matmul_conservative` | Residency diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident_force_all` | Residency diagnostic that also forces cuFFT and small cuSOLVER offload. |
 | `gpu_resident_off` | Residency binary with native cuFFT/cuBLAS/cuSOLVER disabled for same-executable fallback comparison. |
@@ -193,6 +195,19 @@ one-rank CPU references, and eight-rank CPU/NVHPC references. It defaults to
 cd tests/profile/si64
 ./run_followup.sh
 ```
+
+For the current standard NVHPC comparison used before opening follow-up PRs,
+run:
+
+```
+cd tests/profile/si64
+./run_nvhpc_standard.sh
+```
+
+It defaults to `TEST=si64_bands`, `EMPTY_BANDS=1024`, `NSTEPS=3` and compares
+one-rank GPU residency, one-rank CPU references and eight-rank CPU/NVHPC
+references. Override `GPU_CASES`, `CPU_CASES`, `EMPTY_BANDS`, `NSTEPS`,
+`GPU_RANKS` or `CPU_RANKS` for a targeted sweep.
 
 For the larger orthogonalization preset used in the residency follow-up, run:
 
@@ -278,12 +293,18 @@ To test the explicit cuSOLVER/OpenACC dense eigensolver path, build an
 `nvhpc_cusolver_acc_*` target. The default offload threshold is
 `CPPAW_CUSOLVER_ACC_MIN_N=256`; set it to `1` for the small Si64 profiling
 case, or set `CPPAW_CUSOLVER_ACC=0` to run the same binary with the CPU/NVHPC
-fallback:
+fallback. The global threshold can be split into
+`CPPAW_CUSOLVER_ACC_STANDARD_MIN_N` for `DSYEVD/ZHEEVD` and
+`CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N` for `DSYGVD/ZHEGVD`; exact overrides
+`CPPAW_CUSOLVER_ACC_DSYEVD_MIN_N`, `CPPAW_CUSOLVER_ACC_ZHEEVD_MIN_N`,
+`CPPAW_CUSOLVER_ACC_DSYGVD_MIN_N` and `CPPAW_CUSOLVER_ACC_ZHEGVD_MIN_N` are
+also accepted. Use `cusolver_generalized` to force only the generalized path
+and `cusolver_generalized_conservative` for the threshold-gated variant:
 
 ```
 CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -c nvhpc_cusolver_acc_profile
 cd tests/profile/si64
-NSTEPS=1 RANKS=1 CASES="nvhpc_cpu cusolver cusolver_off" ./run_benchmark.sh
+NSTEPS=1 RANKS=1 CASES="nvhpc_cpu cusolver cusolver_generalized cusolver_off" ./run_benchmark.sh
 ```
 
 For a more targeted cuSOLVER/LAPACK follow-up on larger band matrices:
@@ -294,8 +315,8 @@ cd tests/profile/si64
 ```
 
 It defaults to `EMPTY_BANDS_LIST="128 256 512"` and compares
-`cusolver`, `cusolver_conservative`, `cusolver_off`, one-rank CPU/NVHPC and
-eight-rank CPU/NVHPC references.
+`cusolver`, `cusolver_generalized`, `cusolver_generalized_conservative`,
+`cusolver_off`, one-rank CPU/NVHPC and eight-rank CPU/NVHPC references.
 
 For reproducible comparisons, use the benchmark harness:
 
@@ -361,3 +382,13 @@ It reports CUDA devices, NVIDIA HPC SDK library presence for cuBLASLt,
 cuSPARSE, cuTENSOR, cuDSS, NCCL and NVSHMEM, and a best-effort CUDA-aware MPI
 hint. Those libraries are profiled as future candidates; they are not linked
 into CP-PAW unless a concrete code path uses them.
+
+For an active CUDA-aware MPI smoke test, use:
+
+```
+src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
+```
+
+It compiles a tiny MPI/OpenACC allreduce probe and passes device pointers to
+MPI. A failure here means GPU-resident MPI communication should stay disabled
+for production runs until the MPI stack is configured appropriately.

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -17,8 +17,10 @@ bash -n tests/profile/si64/run_followup.sh
 bash -n tests/profile/si64/run_large_bands.sh
 bash -n tests/profile/si64/run_large_bands_long.sh
 bash -n tests/profile/si64/run_gpu_exploration.sh
+bash -n tests/profile/si64/run_nvhpc_standard.sh
 bash -n tests/profile/si64/run_nsys.sh
 bash -n tests/profile/si64/run_overnight.sh
+bash -n src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
 bash -n src/Tools/Scripts/paw_gpu_capabilities.sh
 
 python3 -m py_compile \

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -160,6 +160,12 @@ case_note() {
     *_matmul_conservative)
       echo "cuBLAS diagnostic: raises only the generic MATMUL offload threshold."
       ;;
+    cusolver_standard)
+      echo "cuSOLVER diagnostic: enables only standard DSYEVD/ZHEEVD offload."
+      ;;
+    cusolver_generalized*)
+      echo "cuSOLVER diagnostic: enables only generalized DSYGVD/ZHEGVD offload."
+      ;;
     gpu_all*)
       echo "All-library diagnostic build; includes cuFFTW/NVLAMATH and is not the recommended default."
       ;;
@@ -190,12 +196,42 @@ run_command() {
 cusolver_env() {
   local min_n=$1
   local env_line="CPPAW_CUSOLVER_ACC_MIN_N=${min_n}"
+  if [[ -n "${CPPAW_CUSOLVER_ACC_STANDARD_MIN_N:-}" ]]; then
+    env_line="${env_line} CPPAW_CUSOLVER_ACC_STANDARD_MIN_N=${CPPAW_CUSOLVER_ACC_STANDARD_MIN_N}"
+  fi
+  if [[ -n "${CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N:-}" ]]; then
+    env_line="${env_line} CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N=${CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N}"
+  fi
   if [[ -n "${CPPAW_CUSOLVER_ACC_CHECK:-}" ]]; then
     env_line="${env_line} CPPAW_CUSOLVER_ACC_CHECK=${CPPAW_CUSOLVER_ACC_CHECK}"
   fi
   if [[ -n "${CPPAW_CUSOLVER_ACC_CHECK_TOL:-}" ]]; then
     env_line="${env_line} CPPAW_CUSOLVER_ACC_CHECK_TOL=${CPPAW_CUSOLVER_ACC_CHECK_TOL}"
   fi
+  echo "${env_line}"
+}
+
+cusolver_standard_env() {
+  local env_line
+  env_line=$(cusolver_env "${CPPAW_CUSOLVER_ACC_MIN_N:-1}")
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_STANDARD_MIN_N=${CPPAW_CUSOLVER_STANDARD_FORCE_MIN_N:-1}"
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N=${CPPAW_CUSOLVER_GENERALIZED_OFF_MIN_N:-1000000000}"
+  echo "${env_line}"
+}
+
+cusolver_generalized_env() {
+  local env_line
+  env_line=$(cusolver_env "${CPPAW_CUSOLVER_ACC_MIN_N:-1}")
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_STANDARD_MIN_N=${CPPAW_CUSOLVER_STANDARD_OFF_MIN_N:-1000000000}"
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N=${CPPAW_CUSOLVER_GENERALIZED_FORCE_MIN_N:-1}"
+  echo "${env_line}"
+}
+
+cusolver_generalized_conservative_env() {
+  local env_line
+  env_line=$(cusolver_env "${CPPAW_CUSOLVER_CONSERVATIVE_MIN_N:-256}")
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_STANDARD_MIN_N=${CPPAW_CUSOLVER_STANDARD_OFF_MIN_N:-1000000000}"
+  env_line="${env_line} CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N=${CPPAW_CUSOLVER_GENERALIZED_CONSERVATIVE_MIN_N:-256}"
   echo "${env_line}"
 }
 
@@ -256,6 +292,9 @@ case_env() {
     cublas_matmul_conservative) cublas_matmul_conservative_env ;;
     cublas_off) echo "CPPAW_CUBLAS_ACC=0" ;;
     cusolver) cusolver_env "${CPPAW_CUSOLVER_ACC_MIN_N:-1}" ;;
+    cusolver_standard) cusolver_standard_env ;;
+    cusolver_generalized) cusolver_generalized_env ;;
+    cusolver_generalized_conservative) cusolver_generalized_conservative_env ;;
     cusolver_conservative) cusolver_env "${CPPAW_CUSOLVER_CONSERVATIVE_MIN_N:-256}" ;;
     cusolver_off) echo "CPPAW_CUSOLVER_ACC=0" ;;
     cufft) cufft_env ;;
@@ -279,6 +318,7 @@ case_env() {
     gpu_resident) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_nosync) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_SYNC=0" ;;
     gpu_resident_invbatch_off) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_INVERSION_BATCH=0" ;;
+    gpu_resident_no_cusolver) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env) CPPAW_CUSOLVER_ACC=0" ;;
     gpu_resident_projection_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_projection_conservative_env)" ;;
     gpu_resident_overlap_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_overlap_conservative_env)" ;;
     gpu_resident_addproduct_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_addproduct_conservative_env)" ;;

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -83,12 +83,75 @@ system_mpirun() {
   command -v mpirun 2>/dev/null || echo mpirun
 }
 
+CPU_MPIRUN_USER_SET=${CPU_MPIRUN+x}
+CPU_MPI_LIBDIR_USER_SET=${CPU_MPI_LIBDIR+x}
 CPU_MPIRUN=${CPU_MPIRUN:-$(system_mpirun)}
 MPIRUN=${MPIRUN:-$(default_mpirun)}
 
+mpirun_libdir() {
+  local mpirun=$1
+  local libdir
+  if [[ "${mpirun}" = */bin/mpirun ]]; then
+    libdir=$(cd "$(dirname "${mpirun}")/../lib" 2>/dev/null && pwd || true)
+    if [[ -n "${libdir}" && -d "${libdir}" ]]; then
+      echo "${libdir}"
+    fi
+  fi
+}
+
+CPU_MPI_LIBDIR=${CPU_MPI_LIBDIR:-$(mpirun_libdir "${CPU_MPIRUN}")}
+
+exe_mpi_libdir() {
+  local exe=$1
+  local mpi_lib
+  [[ -x "${exe}" ]] || return 0
+  mpi_lib=$(ldd "${exe}" 2>/dev/null | awk '/libmpi[.]so/ { print $3; exit }')
+  if [[ -n "${mpi_lib}" && -f "${mpi_lib}" ]]; then
+    dirname "${mpi_lib}"
+  fi
+}
+
+mpirun_from_libdir() {
+  local libdir=$1
+  local fallback=$2
+  local prefix candidate
+  if [[ -n "${libdir}" ]]; then
+    prefix=${libdir%/lib}
+    for candidate in \
+        "${prefix}/bin/mpirun" \
+        "${prefix}/ompi/bin/mpirun"; do
+      if [[ -x "${candidate}" ]]; then
+        echo "${candidate}"
+        return 0
+      fi
+    done
+  fi
+  echo "${fallback}"
+}
+
+cpu_mpi_libdir_for_exe() {
+  local exe=$1
+  if [[ -n "${CPU_MPI_LIBDIR_USER_SET}" || -n "${CPU_MPIRUN_USER_SET}" ]]; then
+    echo "${CPU_MPI_LIBDIR}"
+    return 0
+  fi
+  exe_mpi_libdir "${exe}"
+}
+
+cpu_mpirun_for_exe() {
+  local exe=$1
+  local libdir
+  if [[ -n "${CPU_MPIRUN_USER_SET}" ]]; then
+    echo "${CPU_MPIRUN}"
+    return 0
+  fi
+  libdir=$(cpu_mpi_libdir_for_exe "${exe}")
+  mpirun_from_libdir "${libdir}" "${CPU_MPIRUN}"
+}
+
 case_mpirun() {
   case "$1" in
-    cpu) echo "${CPU_MPIRUN}" ;;
+    cpu) cpu_mpirun_for_exe "${2:-}" ;;
     *) echo "${MPIRUN}" ;;
   esac
 }
@@ -180,7 +243,7 @@ run_command() {
   local exe=$2
   local cmd mpi_run
   if [[ "${RANKS}" -gt 1 ]]; then
-    mpi_run=$(case_mpirun "${case_name}")
+    mpi_run=$(case_mpirun "${case_name}" "${exe}")
     # shellcheck disable=SC2086
     cmd="${mpi_run} ${MPI_ARGS} -np ${RANKS} ${exe} ${TEST}.cntl"
   else
@@ -334,6 +397,31 @@ case_env() {
   esac
 }
 
+case_runtime_env() {
+  local case_name=$1
+  local exe=${2:-}
+  local libdir
+  case "${case_name}" in
+    cpu)
+      libdir=$(cpu_mpi_libdir_for_exe "${exe}")
+      if [[ "${RANKS}" -gt 1 && -n "${libdir}" ]]; then
+        echo "LD_LIBRARY_PATH=${libdir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      fi
+      ;;
+    *) echo "" ;;
+  esac
+}
+
+combined_env() {
+  local env_line=""
+  local part
+  for part in "$@"; do
+    [[ -n "${part}" ]] || continue
+    env_line="${env_line:+${env_line} }${part}"
+  done
+  echo "${env_line}"
+}
+
 iso_now() {
   date -u +%Y-%m-%dT%H:%M:%SZ
 }
@@ -375,10 +463,19 @@ capture_metadata() {
       exe=$(if [[ "${RANKS}" -gt 1 ]]; then parallel_exe "${case_name}"; else serial_exe "${case_name}"; fi)
       echo "case=${case_name}"
       echo "exe=${exe}"
+      if [[ "${RANKS}" -gt 1 ]]; then
+        echo "mpirun=$(case_mpirun "${case_name}" "${exe}")"
+      fi
       note=$(case_note "${case_name}")
       [[ -n "${note}" ]] && echo "note=${note}"
       if [[ -x "${exe}" ]]; then
-        ldd "${exe}" 2>/dev/null | grep -E "blas|lapack|fftw|cufft|cusolver|cublas|nvpl|openblas" || true
+        runtime_env=$(case_runtime_env "${case_name}" "${exe}")
+        if [[ -n "${runtime_env}" ]]; then
+          # shellcheck disable=SC2086
+          env ${runtime_env} ldd "${exe}" 2>/dev/null | grep -E "blas|lapack|fftw|cufft|cusolver|cublas|nvpl|openblas|libmpi" || true
+        else
+          ldd "${exe}" 2>/dev/null | grep -E "blas|lapack|fftw|cufft|cusolver|cublas|nvpl|openblas|libmpi" || true
+        fi
       else
         echo "missing"
       fi
@@ -402,7 +499,7 @@ for case_name in ${CASES}; do
     prepare_case "${run_dir}"
     (
       cd "${run_dir}"
-      env_line=$(case_env "${case_name}")
+      env_line=$(combined_env "$(case_runtime_env "${case_name}" "${exe}")" "$(case_env "${case_name}")")
       {
         echo "case=${case_name}"
         echo "repeat=${repeat}"

--- a/tests/profile/si64/run_cusolver_focus.sh
+++ b/tests/profile/si64/run_cusolver_focus.sh
@@ -10,7 +10,7 @@ TIMEOUT=${TIMEOUT:-7200}
 EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-"128 256 512"}
 GPU_RANKS=${GPU_RANKS:-1}
 CPU_RANKS=${CPU_RANKS:-8}
-CUSOLVER_CASES=${CUSOLVER_CASES:-"cusolver cusolver_conservative cusolver_off"}
+CUSOLVER_CASES=${CUSOLVER_CASES:-"cusolver cusolver_generalized cusolver_generalized_conservative cusolver_off"}
 CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
 
 mkdir -p "${CUSOLVER_FOCUS_ROOT}"

--- a/tests/profile/si64/run_nvhpc_standard.sh
+++ b/tests/profile/si64/run_nvhpc_standard.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+TEST=${TEST:-si64_bands}
+NVHPC_STANDARD_ROOT=${NVHPC_STANDARD_ROOT:-"${HERE}/runs/${TEST}-nvhpc-standard-$(date +%Y%m%d-%H%M%S)"}
+NSTEPS=${NSTEPS:-3}
+EMPTY_BANDS=${EMPTY_BANDS:-1024}
+REPEATS=${REPEATS:-1}
+TIMEOUT=${TIMEOUT:-7200}
+GPU_RANKS=${GPU_RANKS:-1}
+CPU_RANKS=${CPU_RANKS:-8}
+GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_invbatch_off gpu_resident_no_cusolver gpu_off"}
+CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+
+mkdir -p "${NVHPC_STANDARD_ROOT}"
+echo "${NVHPC_STANDARD_ROOT}" > "${HERE}/runs/latest_nvhpc_standard"
+
+COMBINED="${NVHPC_STANDARD_ROOT}/combined_benchmark.tsv"
+LOG="${NVHPC_STANDARD_ROOT}/nvhpc_standard.log"
+: > "${LOG}"
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOG}"
+}
+
+append_suite() {
+  local suite=$1
+  local tsv=$2
+  [[ -f "${tsv}" ]] || return 0
+  if [[ ! -s "${COMBINED}" ]]; then
+    awk 'NR == 1 { print "suite\t" $0; next } { print suite "\t" $0 }' \
+      suite="${suite}" "${tsv}" > "${COMBINED}"
+  else
+    awk 'NR > 1 { print suite "\t" $0 }' suite="${suite}" "${tsv}" >> "${COMBINED}"
+  fi
+}
+
+run_suite() {
+  local suite=$1
+  local ranks=$2
+  local cases=$3
+  local root="${NVHPC_STANDARD_ROOT}/${suite}"
+  local suite_log="${NVHPC_STANDARD_ROOT}/${suite}.log"
+
+  log "START suite=${suite} empty_bands=${EMPTY_BANDS} nsteps=${NSTEPS} ranks=${ranks} cases=${cases}"
+  if env TEST="${TEST}" EMPTY_BANDS="${EMPTY_BANDS}" NSTEPS="${NSTEPS}" \
+      RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${cases}" TIMEOUT="${TIMEOUT}" \
+      RUN_ROOT="${root}" "${HERE}/run_benchmark.sh" > "${suite_log}" 2>&1; then
+    log "DONE  suite=${suite}"
+    echo 0 > "${root}.status"
+  else
+    local status=$?
+    log "FAIL  suite=${suite} status=${status}"
+    echo "${status}" > "${root}.status"
+  fi
+  append_suite "${suite}" "${root}/benchmark.tsv"
+}
+
+run_suite "gpu_${GPU_RANKS}rank" "${GPU_RANKS}" "${GPU_CASES}"
+run_suite "cpu_1rank" 1 "${CPU_CASES}"
+run_suite "cpu_${CPU_RANKS}rank_ref" "${CPU_RANKS}" "${CPU_CASES}"
+
+log "ALL DONE root=${NVHPC_STANDARD_ROOT}"
+if [[ -f "${COMBINED}" ]]; then
+  python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
+    > "${NVHPC_STANDARD_ROOT}/combined_benchmark.md" || true
+  log "combined=${COMBINED}"
+fi


### PR DESCRIPTION
## Summary

- add per-kernel cuSOLVER thresholds for standard (`DSYEVD/ZHEEVD`) and generalized (`DSYGVD/ZHEGVD`) eigensolver paths
- add benchmark cases for generalized-only cuSOLVER diagnostics and update the cuSOLVER focus suite
- move the inversion-batch fill for scalarproduct/addproduct into OpenACC data regions so temporary inverted wavefunction batches can stay device-side before cuBLAS calls
- add a standard NVHPC benchmark wrapper for `Si64 EMPTY_BANDS=1024 NSTEPS=3`
- add an active CUDA-aware MPI probe script and extend the GPU capability report
- make the benchmark harness match the CPU parallel reference to the MPI runtime resolved by the selected executable, avoiding mixed `mpirun`/`libmpi` environments under NVHPC/HPCX shells

## Validation

Local:

- `bash tests/profile/si64/check_harness.sh`
- `src/Buildtools/paw_build.sh -z -j 8 -c profile`
- `cd tests/profile/si64 && NSTEPS=1 CASES=cpu TIMEOUT=600 ./run_benchmark.sh`

Remote on `kuehne88@terok.casus.science` with NVHPC 24.5 and NVIDIA A40:

- fresh clone of `codex/cusolver-generalized-followup`, commit `e5738e4`
- `bash tests/profile/si64/check_harness.sh`
- serial builds with `-j16`: `profile`, `nvhpc_profile`, `nvhpc_gpu_acc_residency_profile`, `nvhpc_gpu_acc_profile`, `nvhpc_cusolver_acc_profile`
- parallel builds with `-j16`: `profile_parallel`, `nvhpc_profile_parallel`, `nvhpc_gpu_acc_residency_profile_parallel`, `nvhpc_gpu_acc_profile_parallel`, `nvhpc_cusolver_acc_profile_parallel`
- CUDA-aware MPI probe: `RANKS=2 N=4096 MPI_ARGS="--mca coll ^hcoll" src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh` passed with zero error
- 4-rank GPU smoke: `si64_bands EMPTY_BANDS=128 NSTEPS=1`, cases `gpu_resident gpu_resident_no_cusolver gpu_resident_invbatch_off`, all passed with energy `302.280853`
- cuSOLVER focus: `si64_bands EMPTY_BANDS=512 NSTEPS=1`, cases `cusolver cusolver_standard cusolver_generalized cusolver_generalized_conservative cusolver_off`, all passed with energy `302.280853`

## Benchmark Snapshot

Standard NVHPC comparison on Terok, `si64_bands EMPTY_BANDS=1024 NSTEPS=3`:

| suite | case | ranks | wall_s | energy |
| --- | --- | ---: | ---: | ---: |
| gpu_1rank | `gpu_resident` | 1 | 170.82 | 208.886424 |
| gpu_1rank | `gpu_resident_invbatch_off` | 1 | 197.76 | 208.886424 |
| gpu_1rank | `gpu_resident_no_cusolver` | 1 | 183.58 | 208.886424 |
| gpu_1rank | `gpu_off` | 1 | 312.89 | 208.886424 |
| cpu_1rank | `cpu` | 1 | 313.20 | 208.886424 |
| cpu_1rank | `nvhpc_cpu` | 1 | 314.56 | 208.886424 |
| cpu_8rank_ref | `cpu` | 8 | 182.19 | 208.886424 |
| cpu_8rank_ref | `nvhpc_cpu` | 8 | 182.24 | 208.886424 |

Notes:

- `gpu_resident` is the fastest path in this standard case: about 1.83x faster than 1-rank CPU and slightly faster than the 8-rank CPU reference.
- The OpenACC inversion-batch fill helps here: `gpu_resident` is about 14% faster than `gpu_resident_invbatch_off`.
- cuSOLVER reduces the profiled LAPACK time in this larger-band standard case (`0.52 s` vs `12.68 s` for `gpu_resident_no_cusolver`) and improves wall time by about 7%.
- The initial 8-rank CPU standard block exposed a benchmark-harness MPI mismatch (`profile_parallel` linked against HPCX but launched with `cppaw-gccmpi`); commit `e5738e4` fixes this by deriving the matching launcher/runtime from the executable's resolved `libmpi`.
