### PR TITLE
Expand NVHPC profiling coverage

### DIFF
--- a/src/paw_fft.f90
+++ b/src/paw_fft.f90
@@ -2008,6 +2008,23 @@ END MODULE PLANEWAVE_MODULE
       RETURN
       END      
 !
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+!     ..................................................................
+      SUBROUTINE PLANEWAVE_PROFILE_PHASE(NAME,N1,N2,N3,N4,BYTES,T0)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN) :: NAME
+      INTEGER(4)  ,INTENT(IN) :: N1,N2,N3,N4
+      REAL(8)     ,INTENT(IN) :: BYTES
+      REAL(8)     ,INTENT(IN) :: T0
+      REAL(8)                 :: T1
+!     ******************************************************************
+      CALL ACCELPROFILE$NOW(T1)
+      CALL ACCELPROFILE$ADD(NAME,INT(N1,KIND=8),INT(N2,KIND=8) &
+     & ,INT(N3,KIND=8),INT(N4,KIND=8),0.D0,BYTES,T1-T0)
+      RETURN
+      END
+#ENDIF
+!
 !     ..................................................................
       SUBROUTINE PLANEWAVE_FFTGTOR(CID,NTASKS_,NGL,NRL,NR1,NR2,NR3 &
      &           ,NSTRIPELX,NSTRIPELARR,NR1LARR,IGTOSTRIPE,ISTRIPETOYZ &
@@ -2048,7 +2065,9 @@ END MODULE PLANEWAVE_MODULE
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                   :: ACCEL_T0
       REAL(8)                   :: ACCEL_T1
+      REAL(8)                   :: ACCEL_PHASE0
       REAL(8)                   :: ACCEL_GRID
+      REAL(8)                   :: ACCEL_BYTES
 #ENDIF
 !     ******************************************************************
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
@@ -2070,11 +2089,20 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == MAP TO STRIPES                                               ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(FOFG1(NR1*NSTRIPEL))
       FOFG1(:)=(0.D0,0.D0)
       DO IG=1,NGL
         FOFG1(IGTOSTRIPE(IG))=FOFG(IG)
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NR1,KIND=8)*REAL(NSTRIPEL,KIND=8) &
+     &           +32.D0*REAL(NGL,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_MAP_G',NR1,NSTRIPEL,NGL &
+     & ,NTASKS,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == TRANSFORM 1 ST DIMENSION (NR1)    FOFG(NR1,NSTRIPE)          ==
@@ -2084,6 +2112,9 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == COMMUNICATE AMONG TASKS                                      ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(UIU(NR1LX,NSTRIPELX,NTASKS))
       UIU(:,:,:)=CMPLX(0.D0,0.D0,8)
 !
@@ -2097,9 +2128,28 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(FOFG1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NR1LX,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8) &
+     &           +32.D0*REAL(NR1,KIND=8)*REAL(NSTRIPEL,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_PACK_MPI',NR1LX,NSTRIPELX &
+     & ,NTASKS,NSTRIPEL,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       CALL MPE$TRANSPOSE(CID,UIU)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NR1LX,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_MPE_TRANSPOSE',NR1LX &
+     & ,NSTRIPELX,NTASKS,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       FOFR(:)=CMPLX(0.D0,0.D0,8)
       IMID=NR3/2
       NR3END1=1
@@ -2124,6 +2174,13 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(UIU)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NRL,KIND=8) &
+     &           +32.D0*REAL(NR1L,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_UNPACK_R',NR1L,NSTRIPELX &
+     & ,NTASKS,NRL,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == FFT 2ND DIMENSION (NR2):      FOFR(NR2,NR3,NR1L)             ==
@@ -2142,6 +2199,9 @@ END MODULE PLANEWAVE_MODULE
 !     == TRANSPOSE TO OPTIMIZE STRIDE                                 ==
 !     == FOFR1(IR3,IR2,IR1L)=FOFR(IR2,IR3,IR1L)                       ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(FOFR1(NR3*NR2*NR1L))
       DO IR1L=1,NR1L
         DO IR2=1,NR2
@@ -2156,6 +2216,12 @@ END MODULE PLANEWAVE_MODULE
           ENDDO
         ENDDO
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NR3,KIND=8)*REAL(NR2,KIND=8) &
+     &           *REAL(NR1L,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_TRANSPOSE_23',NR3,NR2 &
+     & ,NR1L,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == FFT 3RD DIMENSION (NR3)                                      ==
@@ -2166,6 +2232,9 @@ END MODULE PLANEWAVE_MODULE
 !     == TRANSPOSE TO OPTIMIZE STRIDE                                 ==
 !     == FOFR(IR1,IR2,IR3)=FOFR(IR2,IR3,IR1)                         ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       STRIDE2=NR1L*NR2
       DO IR1L=1,NR1L
         DO IR2=1,NR2
@@ -2181,6 +2250,12 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(FOFR1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NR3,KIND=8)*REAL(NR2,KIND=8) &
+     &           *REAL(NR1L,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_GTOR_TRANSPOSE_OUT',NR3,NR2 &
+     & ,NR1L,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_T1)
       ACCEL_GRID=REAL(NR1,KIND=8)*REAL(NR2,KIND=8)*REAL(NR3,KIND=8)
@@ -2233,7 +2308,9 @@ END MODULE PLANEWAVE_MODULE
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                   :: ACCEL_T0
       REAL(8)                   :: ACCEL_T1
+      REAL(8)                   :: ACCEL_PHASE0
       REAL(8)                   :: ACCEL_GRID
+      REAL(8)                   :: ACCEL_BYTES
 #ENDIF
 !     ******************************************************************
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
@@ -2251,6 +2328,9 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == TRANSPOSE TO OPTIMIZE STRIDE                                 ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(FOFR1(NR3*NR2*NR1L))
       DO IR1L=1,NR1L
         DO IR2=1,NR2
@@ -2261,6 +2341,12 @@ END MODULE PLANEWAVE_MODULE
           ENDDO
         ENDDO
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NR3,KIND=8)*REAL(NR2,KIND=8) &
+     &           *REAL(NR1L,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_TRANSPOSE_IN',NR3,NR2 &
+     & ,NR1L,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == TRANSFORM 3 DIMENSION (NR3)                                  ==
@@ -2289,6 +2375,9 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == TRANSPOSE TO OPTIMIZE STRIDE                                 ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(FOFR2(NR2*NR3*NR1L))
       FOFR2=CMPLX(0.D0,0.D0,8)
       DO IR1L=1,NR1L
@@ -2306,6 +2395,15 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(FOFR1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NR2,KIND=8)*REAL(NR3,KIND=8) &
+     &           *REAL(NR1L,KIND=8) &
+     &           +32.D0*REAL(NR2,KIND=8) &
+     &           *REAL(NR3END1+NR3-NR3END2+1,KIND=8) &
+     &           *REAL(NR1L,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_TRANSPOSE_32',NR2,NR3 &
+     & ,NR1L,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == TRANSFORM 2ND DIMENSION (NR2)                                ==
@@ -2323,6 +2421,9 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == COMMUNICATE AMONG TASKS                                      ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(UIU(NR1LX,NSTRIPELX,NTASKS))
       UIU(:,:,:)=CMPLX(0.D0,0.D0,8)
       DO ITASK=1,NTASKS
@@ -2335,7 +2436,27 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(FOFR2)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NR1LX,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8) &
+     &           +32.D0*REAL(NR1L,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_PACK_MPI',NR1LX,NSTRIPELX &
+     & ,NTASKS,NSTRIPEL,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       CALL MPE$TRANSPOSE(CID,UIU)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NR1LX,KIND=8)*REAL(NSTRIPELX,KIND=8) &
+     &           *REAL(NTASKS,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_MPE_TRANSPOSE',NR1LX &
+     & ,NSTRIPELX,NTASKS,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       ALLOCATE(FOFG1(NR1*NSTRIPEL))
       FOFG1(:)=CMPLX(0.D0,0.D0,8)
       DO ISTRIPEL=1,NSTRIPEL
@@ -2348,6 +2469,12 @@ END MODULE PLANEWAVE_MODULE
         ENDDO
       ENDDO
       DEALLOCATE(UIU)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=16.D0*REAL(NR1,KIND=8)*REAL(NSTRIPEL,KIND=8) &
+     &           +32.D0*REAL(NR1,KIND=8)*REAL(NSTRIPEL,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_UNPACK_G',NR1,NSTRIPEL &
+     & ,NTASKS,0,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 !
 !     ==================================================================
 !     == TRANSFORM 1 ST DIMENSION (NR1)                               ==
@@ -2357,10 +2484,18 @@ END MODULE PLANEWAVE_MODULE
 !     ==================================================================
 !     == MAP STRIPES TO IG                                            ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_PHASE0)
+#ENDIF
       DO IG=1,NGL
         FOFG(IG)=FOFG1(IGTOSTRIPE(IG))
       ENDDO
       DEALLOCATE(FOFG1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_BYTES=32.D0*REAL(NGL,KIND=8)
+      CALL PLANEWAVE_PROFILE_PHASE('PW_RTOG_MAP_G',NR1,NSTRIPEL,NGL &
+     & ,NTASKS,ACCEL_BYTES,ACCEL_PHASE0)
+#ENDIF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_T1)
       ACCEL_GRID=REAL(NR1,KIND=8)*REAL(NR2,KIND=8)*REAL(NR3,KIND=8)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -84,6 +84,15 @@ NSTEPS=1 ./run_benchmark.sh
 NSTEPS=1 RANKS=8 CASES="cpu nvhpc_cpu" ./run_benchmark.sh
 ```
 
+`run_benchmark.sh` writes `benchmark.tsv` and `benchmark.md` for each run. The
+summary includes both wall time and rank-normalized wall time (`wall_rank_s`),
+the primary instrumented rank-seconds (`rank_s`), and a residual
+`gap_s = wall_rank_s - rank_s`. Use `gap_s` and `coverage_pct` to decide
+whether the current CSV timers already explain the run or whether additional
+instrumentation is needed. Diagnostic Plane-wave FFT local/MPI-envelope timers
+are reported separately as `pw_trace_s`; they are intentionally kept out of
+`rank_s` because they subdivide the existing `PW_FFT_*_TOTAL` envelope.
+
 The `nvhpc_gpu_acc_residency_*` target keeps the same accelerator choices but
 adds the `CPPAW_GPU_RESIDENCY=1` diagnostic mode. That currently switches the
 cuBLAS scalarproduct copy wrapper to `present_or_copyin`, so projection loops

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -46,21 +46,24 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | blas_s | lapack_s | fft_s | mpi_s | copy_gb | energy |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | copy_gb | energy |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
                 row.get("ok", ""),
                 number(row.get("wall_s")),
                 number(row.get("rank_s")),
+                number(row.get("gap_s")),
+                number(row.get("coverage_pct")),
                 number(row.get("blas_s")),
                 number(row.get("lapack_s")),
                 number(row.get("fft_s")),
                 number(row.get("mpi_s")),
+                number(row.get("pw_trace_s")),
                 number(row.get("copy_gb")),
                 number(row.get("energy")),
             )

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -13,6 +13,7 @@ def profile_totals(run_dir):
         "lapack": 0.0,
         "fft": 0.0,
         "mpi": 0.0,
+        "pw_trace": 0.0,
         "setup": 0.0,
         "copy_gb": 0.0,
     }
@@ -27,6 +28,9 @@ def profile_totals(run_dir):
                     continue
                 if op.startswith("ACC_SETUP"):
                     totals["setup"] += seconds
+                    continue
+                if op.startswith("PW_") and not op.startswith("PW_FFT"):
+                    totals["pw_trace"] += seconds
                     continue
                 totals["instrumented"] += seconds
                 if op.startswith("MPI_ALLTOALL"):
@@ -90,6 +94,15 @@ def run_ok(run_dir):
     return "NORMAL STOP" in text
 
 
+def wall_rank_time(wall, ranks):
+    if wall is None:
+        return None
+    try:
+        return wall * int(ranks)
+    except (TypeError, ValueError):
+        return None
+
+
 def main(argv):
     root = argv[1] if len(argv) > 1 else "."
     rows = []
@@ -98,6 +111,14 @@ def main(argv):
         repeat = os.path.basename(run_dir)
         totals = profile_totals(run_dir)
         env = run_env(run_dir)
+        wall = wall_time(run_dir)
+        wall_rank = wall_rank_time(wall, env.get("ranks"))
+        gap = None
+        coverage = None
+        if wall_rank is not None:
+            gap = wall_rank - totals["instrumented"]
+            if wall_rank > 0.0:
+                coverage = 100.0 * totals["instrumented"] / wall_rank
         rows.append(
             {
                 "case": case,
@@ -105,12 +126,16 @@ def main(argv):
                 "nsteps": env.get("nsteps") or env.get("nstps"),
                 "ranks": env.get("ranks"),
                 "ok": "yes" if run_ok(run_dir) else "no",
-                "wall_s": wall_time(run_dir),
+                "wall_s": wall,
+                "wall_rank_s": wall_rank,
                 "rank_s": totals["instrumented"],
+                "gap_s": gap,
+                "coverage_pct": coverage,
                 "blas_s": totals["blas"],
                 "lapack_s": totals["lapack"],
                 "fft_s": totals["fft"],
                 "mpi_s": totals["mpi"],
+                "pw_trace_s": totals["pw_trace"],
                 "setup_s": totals["setup"],
                 "copy_gb": totals["copy_gb"],
                 "energy": final_energy(run_dir),
@@ -129,11 +154,15 @@ def main(argv):
         "ranks",
         "ok",
         "wall_s",
+        "wall_rank_s",
         "rank_s",
+        "gap_s",
+        "coverage_pct",
         "blas_s",
         "lapack_s",
         "fft_s",
         "mpi_s",
+        "pw_trace_s",
         "setup_s",
         "copy_gb",
         "energy",

--- a/tests/profile/si64/profile_summary.py
+++ b/tests/profile/si64/profile_summary.py
@@ -10,6 +10,10 @@ def category(op):
         return "ACC copy est"
     if op.startswith("ACC_SETUP"):
         return "ACC setup"
+    if op.startswith("PW_") and not op.startswith("PW_FFT"):
+        if "MPE_TRANSPOSE" in op:
+            return "PW MPI envelope"
+        return "PW local trace"
     if op.startswith("MPI_ALLTOALL"):
         return "MPI alltoall"
     if op.startswith("FFT") or op.startswith("PW_FFT") or op.startswith("CUFFT"):
@@ -66,6 +70,11 @@ def main(argv):
     primary_total = sum(
         data["seconds"] for op, data in per_op.items()
         if not op.startswith("ACC_")
+        and not (op.startswith("PW_") and not op.startswith("PW_FFT"))
+    )
+    trace_total = sum(
+        data["seconds"] for op, data in per_op.items()
+        if op.startswith("PW_") and not op.startswith("PW_FFT")
     )
     setup_total = sum(
         data["seconds"] for op, data in per_op.items()
@@ -78,6 +87,8 @@ def main(argv):
 
     print("Profile files: {}".format(len(files)))
     print("Instrumented rank-seconds: {:.6f}".format(primary_total))
+    if trace_total:
+        print("Diagnostic PW trace rank-seconds: {:.6f}".format(trace_total))
     if setup_total or copy_gbyte:
         print(
             "Accelerator setup seconds: {:.6f}  copy estimate: {:.6f} GB".format(


### PR DESCRIPTION
## Summary
- Add diagnostic `PW_*` phase tracing for `PLANEWAVE_FFTGTOR` and `PLANEWAVE_FFTRTOG` under `CPPVAR_ACCEL_PROFILE`.
- Keep those plane-wave subphase traces diagnostic-only, so `rank_s` still reports the primary BLAS/LAPACK/FFT/MPI instrumented time without double-counting.
- Extend the profiling summaries and markdown output with `gap_s`, `coverage_pct`, and `pw_trace_s`.

## Validation
- Local macOS/gfortran: `tests/profile/si64/check_harness.sh`, Python byte-compile, `git diff --check`, `src/Buildtools/paw_build.sh -z -j 8 -c profile`, and `NSTEPS=1 CASES=cpu ./run_benchmark.sh`.
- Terok/A40: `tests/profile/si64/check_harness.sh`.
- Terok/A40 builds: `profile`, `profile_parallel`, `nvhpc_profile`, `nvhpc_profile_parallel`, `nvhpc_gpu_acc_profile`, plus the existing `nvhpc_gpu_acc_residency_profile` smoke build.
- Terok/A40 standard benchmark: `TEST=si64_bands EMPTY_BANDS=1024 NSTEPS=3`, all cases `ok=yes`.

## Benchmark

Source: `/home/kuehne88/work/cp-paw-nvhpc-profile-coverage-20260529-015157/tests/profile/si64/runs/si64_bands-nvhpc-standard-20260529-020026/combined_benchmark.tsv`

| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | copy_gb | energy |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| gpu_1rank | gpu_off | 1 | yes | 286.02 | 147.20 | 138.82 | 51.47 | 125.81 | 12.48 | 8.92 | 0.00 | 2.24 | 0.00 | 208.89 |
| gpu_1rank | gpu_resident | 1 | yes | 160.93 | 22.67 | 138.26 | 14.09 | 13.11 | 0.53 | 9.03 | 0.00 | 2.41 | 40.46 | 208.89 |
| gpu_1rank | gpu_resident_invbatch_off | 1 | yes | 182.02 | 42.45 | 139.57 | 23.32 | 33.24 | 0.53 | 8.68 | 0.00 | 2.03 | 945.19 | 208.89 |
| gpu_1rank | gpu_resident_no_cusolver | 1 | yes | 175.03 | 34.62 | 140.41 | 19.78 | 13.00 | 12.57 | 9.05 | 0.00 | 2.10 | 40.24 | 208.89 |
| cpu_1rank | cpu | 1 | yes | 286.88 | 149.26 | 137.62 | 52.03 | 127.38 | 12.66 | 9.22 | 0.00 | 2.52 | 0.00 | 208.89 |
| cpu_1rank | nvhpc_cpu | 1 | yes | 284.69 | 147.58 | 137.11 | 51.84 | 126.06 | 12.60 | 8.92 | 0.00 | 2.24 | 0.00 | 208.89 |
| cpu_8rank_ref | cpu | 8 | yes | 181.51 | 368.59 | 1083.49 | 25.38 | 246.03 | 101.76 | 15.93 | 4.87 | 8.30 | 0.00 | 208.89 |
| cpu_8rank_ref | nvhpc_cpu | 8 | yes | 184.12 | 371.56 | 1101.40 | 25.23 | 248.20 | 101.48 | 16.96 | 4.93 | 9.13 | 0.00 | 208.89 |

## Notes
- `gap_s = wall_rank_s - rank_s` captures wall time outside the primary instrumented buckets.
- `pw_trace_s` is diagnostic and excluded from `rank_s` because the `PW_*` rows are subphases of the plane-wave FFT wrappers.
- The standard run confirms the current resource picture: 1 MPI + 1 GPU resident is fastest in wall time here, while a large 1-rank gap remains and is now visible for the next profiling pass.
