### PR TITLE
Add NVHPC high-level phase profiling

### DIFF
--- a/src/paw_driver.f90
+++ b/src/paw_driver.f90
@@ -23,20 +23,32 @@
       INTEGER(4)   :: NBEG      ! DECIDES IF RESTART FILE IS READ
       REAL(8)      :: DELT
       LOGICAL(4)   :: TCHK
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)      :: TACC
+#ENDIF
 !     **************************************************************************
                               CALL TRACE$PUSH('PAW')
                               CALL TIMING$CLOCKON('INITIALIZATION')
       CALL STOPIT$SETSTARTTIME
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
 !
 !     ==================================================================
 !     ====  READ CONTROL INPUT DATA FILE "CNTL"                     ====
 !     ==================================================================
       CALL READIN(NBEG,NOMORE,IPRINT,DELT,TMERMN,TNWSTR)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_READIN',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  READ STRUCTURAL DATA FROM FILE "STRC"                       ==
 !     ==================================================================
       CALL STRCIN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_STRCIN',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 
 !     ==================================================================
 !     ==  SET DIMER DIMENSION                                         ==
@@ -47,6 +59,9 @@
 !     ==  INITIALIZE ATOMS OBJECT                                     ==
 !     ==================================================================
       CALL ATOMS$INITIALIZE
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_ATOMS',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  GENERATE G-VECTORS                                          ==
@@ -54,6 +69,9 @@
                               CALL TIMING$CLOCKON('WAVES$INITIALIZE')
       CALL WAVES$INITIALIZE
                               CALL TIMING$CLOCKOFF('WAVES$INITIALIZE')
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_WAVES',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  READ RESTART FILE (WAVE FUNCTION COEFFICIENTS, ETC)         ==
@@ -63,6 +81,9 @@
         CALL READRESTART
                               CALL TIMING$CLOCKOFF('RESTART I/O')
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_RESTART',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ================================================================
 !     ==  REPORT INPUT DATA                                         ==
@@ -79,6 +100,9 @@
 !     == ACCOUNT FOR THE FACT THAT MANY ROUTINES INIITIALIZE THEMSELFES IN THE 
 !     == FIRST ITERATION. THE TIME TO THIS RESET IS NOT PRINTED 
                               CALL TIMING$START
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_INIT_REPORT',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  RETURN IF NO ITERATIONS ARE REQUIRED                        ==
@@ -103,6 +127,9 @@
 !     ==================================================================
 !     ==  ITERATION CONTROL (PROPER STOP ETC. )                       ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
       NFI=NFI+1
       CALL STOPIT$GETL4('STOP',TSTOP)
       IF(TSTOP) TLAST=.TRUE.
@@ -113,10 +140,16 @@
       CALL GRAPHICS$SETL4('WAKE',TPRINT.AND.TLAST)
       CALL OPTEELS$SETL4('ON',TLAST)
       CALL CORE$SETL4('ON',TLAST)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_LOOP_CONTROL',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==   WRITE RESTART_OUT                                          ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
       IF(TLAST.OR.(TPRINT.AND.(.NOT.TFIRST))) THEN
                               CALL TIMING$CLOCKON('RESTART I/O') 
         CALL WRITERESTART
@@ -125,6 +158,9 @@
                               CALL TIMING$CLOCKOFF('RESTART I/O')
 !       CALL MM_PAW_WRITE_RESTART (NFI) ! CALGARY QM/MM IMPLEMENTATION
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_RESTART_WRITE',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==   PERFORM ONE TIME STEP                                      ==
@@ -140,6 +176,9 @@
 !     ==   WRITE INFORMATION AND TRAJECTORIES                         ==
 !     ==================================================================
 !     __ADD TO TRAJECTORIES (TEMPORARY BUFFER)__________________________
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
       IF(.NOT.TLAST) THEN
         CALL WRITETRAJECTORY(NFI,DELT)
       END IF
@@ -147,17 +186,26 @@
       IF(TPRINT.OR.TLAST) THEN
         CALL TRAJECTORYIO$FLUSHALL
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_TRAJECTORY_IO',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     == RESET CLOCKS FOR TIMING                                      ==
 !     == THIS IS DONE AFTER THE FIRST ITERATION TO AVOID COUNTING     ==
 !     == THE TIME FOR SELF-INITIALIZATION OF OBJECTS                  ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
       IF(TFIRST) THEN
         CALL TIMING$START
       ELSE
         CALL TIMING$COUNT
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_TIMING_COUNT',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==   STOP OR CONTINUE LOOP                                      ==
@@ -298,8 +346,14 @@
       REAL(8)                 :: SVAR
       LOGICAL(4)              :: TCHK1,TCHK2
       REAL(8)                 :: FAV,FMAX
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                 :: TACC
+#ENDIF
 !     ******************************************************************      
                               CALL TRACE$PUSH('TIMESTEP')
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(TACC)
+#ENDIF
       CALL FILEHANDLER$UNIT('PROT',NFILO)
 !      
       DELTAT=DELT       !-> TIMESTEP_MODULE
@@ -323,6 +377,9 @@
       CALL THERMOSTAT$SELECT('WAVES') 
       CALL THERMOSTAT$SETR8('TIMESTEP',DELT)
       CALL DIALS$SETR8('TIMESTEP',DELT)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_TS_SETUP',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -331,20 +388,32 @@
 !     ==================================================================
 !     == LDA TOTAL ENERGY ==============================================
       CALL WAVES$ETOT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_ETOT_WAVES',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     == EXTERNAL POTENTIAL ACTING ON ATOMS ============================
       CALL VEXT$APPLY
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_ETOT_VEXT',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     == OCCUPATIONS ===================================================
       CALL DYNOCC$GETR8('EPOT',SVAR)
       CALL ENERGYLIST$SET('OCCUPATIONAL ENTROPY TERM (-TS)',SVAR)
       CALL ENERGYLIST$ADD('TOTAL ENERGY',SVAR)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_ETOT_OCC',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     == UNIT CELL ========= ===================================================
       CALL CELL$ETOT()
       CALL CELL$GETR8('EPOT',SVAR)
       CALL ENERGYLIST$SET('CELLOSTAT POTENTIAL',SVAR)     
       CALL ENERGYLIST$ADD('TOTAL ENERGY',SVAR)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_ETOT_CELL',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -357,6 +426,9 @@
         CALL FILEHANDLER$UNIT('PROT',NFILO)
         WRITE(NFILO,*)'STOP SIGNAL FROM AUTOPILOT'
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_AUTOPILOT',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 ! 
 !     ==================================================================
 !     ==  OBTAIN INSTANTANEOUS FRICTION VALUES FROM THERMOSTATS       ==
@@ -399,6 +471,9 @@
 !!$          CALL ATOMS$SETR8('ANNEE',ANNER)
 !!$        END IF
 !!$      END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_FRICTION',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -417,27 +492,45 @@
          CALL ATOMS$PROPAGATE()
       END IF
 !---END DIMERMERGE FIX      
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_PROP_ATOMS',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 ! 
 !     ==================================================================
 !     ==  PROPAGATE UNIT CELL                                         ==
 !     ==================================================================
       CALL CELL$PROPAGATE()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_PROP_CELL',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 ! 
 !     ==================================================================
 !     ==  APPLY CONSTRAINTS TO ATOMIC COORDINATES                     ==
 !     ==================================================================
       CALL ATOMS$CONSTRAINTS()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_CONSTRAINTS',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 ! 
 !     ==================================================================
 !     ==  PROPAGATE WAVE FUNCTIONS                                    ==
 !     ==================================================================
       CALL WAVES$PROPAGATE()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_PROP_WAVES',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
       CALL WAVES$ORTHOGONALIZE()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_ORTHOGONALIZE',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  PROPAGATE OCCUPATIONS                                       ==
 !     ==================================================================
       CALL DYNOCC$PROPAGATE()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_PROP_OCC',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 ! 
 !     ==================================================================
 !     ==  PROPAGATE THERMOSTAT FOR THE NUCLEI                         ==
@@ -451,6 +544,9 @@
 !       __PROPAGATE THERMOSTAT AND RECORD ITS ENERGY____________________
         CALL THERMOSTAT$PROPAGATE()
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_THERMO_ATOMS',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==  PROPAGATE THERMOSTAT FOR THE WAVE FUNCTIONS                 ==
@@ -466,6 +562,9 @@
         CALL THERMOSTAT$SETR8('EKIN(SYSTEM)',EKIN)
         CALL THERMOSTAT$PROPAGATE()
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_THERMO_WAVES',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -535,6 +634,9 @@
         CALL ENERGYLIST$ADD('CONSTANT ENERGY',ENOSE)
       END IF
 !     EFLUXE=-EKINC*(2.D0*ANNEE/DELT)/EMASS
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_COLLECT_ENERGY',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -543,6 +645,9 @@
 !     ==================================================================
       CALL ATOMS$FORCECRITERION(FAV,FMAX)
 !PRINT*,'FORCE FAV=',FAV,' FMAX=',FMAX
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_FORCE_CRITERION',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -551,6 +656,9 @@
 !     ==================================================================
 !     __WRITE PROTOCOL__________________________________________________
       CALL PRINFO(TPRINT,TSTOP,NFI,DELT)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_PRINFO',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     ==================================================================
@@ -573,11 +681,17 @@
 !     __ATOM THERMOSTAT_________________________________________________
       CALL THERMOSTAT$SELECT('ATOMS')
       CALL THERMOSTAT$SWITCH()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_SWITCH',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
 !
 !     ==================================================================
 !     == TURN DIALS                                                   ==
 !     ==================================================================
       CALL DIALS$APPLY
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$PHASE('PHASE_DIALS',TACC,0_8,0_8,0_8,0_8)
+#ENDIF
                               CALL TRACE$POP()
       RETURN
       END SUBROUTINE TIMESTEP
@@ -1438,5 +1552,3 @@ PRINT*,'CONSTANT ENERGY ',ECONS,SVAR
       RETURN
       END
 !#END IF
-
-

--- a/src/paw_timing.f90
+++ b/src/paw_timing.f90
@@ -564,6 +564,23 @@ END MODULE ACCELPROFILE_MODULE
       END SUBROUTINE ACCELPROFILE$ADD
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
+      SUBROUTINE ACCELPROFILE$PHASE(NAME,TSTART,N1,N2,N3,N4)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN)    :: NAME
+      REAL(8)     ,INTENT(INOUT) :: TSTART
+      INTEGER(8)  ,INTENT(IN)    :: N1
+      INTEGER(8)  ,INTENT(IN)    :: N2
+      INTEGER(8)  ,INTENT(IN)    :: N3
+      INTEGER(8)  ,INTENT(IN)    :: N4
+      REAL(8)                    :: TNOW
+!     **************************************************************************
+      CALL ACCELPROFILE$NOW(TNOW)
+      CALL ACCELPROFILE$ADD(NAME,N1,N2,N3,N4,0.D0,0.D0,TNOW-TSTART)
+      TSTART=TNOW
+      RETURN
+      END SUBROUTINE ACCELPROFILE$PHASE
+!
+!     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE ACCELPROFILE$REPORT(CID,NFIL)
       USE ACCELPROFILE_MODULE
       IMPLICIT NONE

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -92,6 +92,11 @@ whether the current CSV timers already explain the run or whether additional
 instrumentation is needed. Diagnostic Plane-wave FFT local/MPI-envelope timers
 are reported separately as `pw_trace_s`; they are intentionally kept out of
 `rank_s` because they subdivide the existing `PW_FFT_*_TOTAL` envelope.
+High-level `PHASE_*` timers are reported separately as `phase_s` and
+`phase_gap_s = wall_rank_s - phase_s`; they are also kept out of `rank_s`
+because they are coarse envelopes around existing numerical kernel timers. Use
+the phase columns to localize unexplained wall time before adding lower-level
+kernel instrumentation.
 
 The `nvhpc_gpu_acc_residency_*` target keeps the same accelerator choices but
 adds the `CPPAW_GPU_RESIDENCY=1` diagnostic mode. That currently switches the

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -46,11 +46,11 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | copy_gb | energy |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | phase_s | phase_gap_s | copy_gb | energy |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
@@ -64,6 +64,8 @@ def main(argv):
                 number(row.get("fft_s")),
                 number(row.get("mpi_s")),
                 number(row.get("pw_trace_s")),
+                number(row.get("phase_s")),
+                number(row.get("phase_gap_s")),
                 number(row.get("copy_gb")),
                 number(row.get("energy")),
             )

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -14,6 +14,7 @@ def profile_totals(run_dir):
         "fft": 0.0,
         "mpi": 0.0,
         "pw_trace": 0.0,
+        "phase": 0.0,
         "setup": 0.0,
         "copy_gb": 0.0,
     }
@@ -28,6 +29,9 @@ def profile_totals(run_dir):
                     continue
                 if op.startswith("ACC_SETUP"):
                     totals["setup"] += seconds
+                    continue
+                if op.startswith("PHASE_"):
+                    totals["phase"] += seconds
                     continue
                 if op.startswith("PW_") and not op.startswith("PW_FFT"):
                     totals["pw_trace"] += seconds
@@ -115,8 +119,10 @@ def main(argv):
         wall_rank = wall_rank_time(wall, env.get("ranks"))
         gap = None
         coverage = None
+        phase_gap = None
         if wall_rank is not None:
             gap = wall_rank - totals["instrumented"]
+            phase_gap = wall_rank - totals["phase"]
             if wall_rank > 0.0:
                 coverage = 100.0 * totals["instrumented"] / wall_rank
         rows.append(
@@ -136,6 +142,8 @@ def main(argv):
                 "fft_s": totals["fft"],
                 "mpi_s": totals["mpi"],
                 "pw_trace_s": totals["pw_trace"],
+                "phase_s": totals["phase"],
+                "phase_gap_s": phase_gap,
                 "setup_s": totals["setup"],
                 "copy_gb": totals["copy_gb"],
                 "energy": final_energy(run_dir),
@@ -163,6 +171,8 @@ def main(argv):
         "fft_s",
         "mpi_s",
         "pw_trace_s",
+        "phase_s",
+        "phase_gap_s",
         "setup_s",
         "copy_gb",
         "energy",

--- a/tests/profile/si64/profile_summary.py
+++ b/tests/profile/si64/profile_summary.py
@@ -6,6 +6,8 @@ import sys
 
 
 def category(op):
+    if op.startswith("PHASE_"):
+        return "Phase trace"
     if op.startswith("ACC_COPY"):
         return "ACC copy est"
     if op.startswith("ACC_SETUP"):
@@ -71,6 +73,11 @@ def main(argv):
         data["seconds"] for op, data in per_op.items()
         if not op.startswith("ACC_")
         and not (op.startswith("PW_") and not op.startswith("PW_FFT"))
+        and not op.startswith("PHASE_")
+    )
+    phase_total = sum(
+        data["seconds"] for op, data in per_op.items()
+        if op.startswith("PHASE_")
     )
     trace_total = sum(
         data["seconds"] for op, data in per_op.items()
@@ -87,6 +94,8 @@ def main(argv):
 
     print("Profile files: {}".format(len(files)))
     print("Instrumented rank-seconds: {:.6f}".format(primary_total))
+    if phase_total:
+        print("Diagnostic phase rank-seconds: {:.6f}".format(phase_total))
     if trace_total:
         print("Diagnostic PW trace rank-seconds: {:.6f}".format(trace_total))
     if setup_total or copy_gbyte:
@@ -123,6 +132,19 @@ def main(argv):
             print(
                 "  {:<24s} calls={:8d} GB={:10.4f}".format(
                     op, data["calls"], data["gbyte"]
+                )
+            )
+
+    phase_ops = [
+        (op, data) for op, data in per_op.items() if op.startswith("PHASE_")
+    ]
+    if phase_ops:
+        print("")
+        print("Top high-level phases")
+        for op, data in sorted(phase_ops, key=lambda item: -item[1]["seconds"])[:15]:
+            print(
+                "  {:<24s} calls={:8d} seconds={:9.4f}".format(
+                    op, data["calls"], data["seconds"]
                 )
             )
 


### PR DESCRIPTION
## Summary

Adds a diagnostic high-level phase profiling layer for NVHPC profiling builds.

- add `ACCELPROFILE$PHASE` helper for non-overlapping elapsed-time phase envelopes
- instrument PAW initialization, outer loop control/I/O, and `TIMESTEP` phases with `PHASE_*` records
- keep `PHASE_*` records out of the existing `rank_s` instrumented total so existing BLAS/LAPACK/FFT/MPI accounting is not double counted
- report `phase_s`, `phase_gap_s`, and “Top high-level phases” in the Si64 profiling harness

## Validation

Local:

- `bash tests/profile/si64/check_harness.sh`
- `python3 -m py_compile tests/profile/si64/profile_summary.py tests/profile/si64/benchmark_summary.py tests/profile/si64/benchmark_markdown.py`
- `git diff --check`
- `src/Buildtools/paw_build.sh -z -j 8 -c profile`
- `NSTEPS=1 CASES=cpu TIMEOUT=600 ./run_benchmark.sh`

Terok (`kuehne88@terok.casus.science`, NVHPC 24.5, shared node):

- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -j 16 -c nvhpc_gpu_acc_residency_profile`
- built CPU reference profiles: `profile`, `profile_parallel`, `nvhpc_profile`, `nvhpc_profile_parallel`
- GPU smoke: `CUDA_VISIBLE_DEVICES=0 TEST=si64_bands EMPTY_BANDS=128 NSTEPS=1 CASES="gpu_resident gpu_resident_no_cusolver" ./run_benchmark.sh`
- standard comparison: `TEST=si64_bands EMPTY_BANDS=1024 NSTEPS=3`

### CP-PAW Benchmark Summary

Source: `combined_benchmark.tsv`

| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | phase_s | phase_gap_s | copy_gb | energy |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| gpu_1rank | gpu_resident | 1 | yes | 161.67 | 21.24 | 140.43 | 13.13 | 11.17 | 0.50 | 9.57 | 0.00 | 2.91 | 161.47 | 0.20 | 40.46 | 208.89 |
| gpu_1rank | gpu_resident_invbatch_off | 1 | yes | 189.65 | 43.24 | 146.41 | 22.80 | 31.82 | 0.53 | 10.89 | 0.00 | 4.00 | 189.46 | 0.19 | 945.19 | 208.89 |
| gpu_1rank | gpu_resident_no_cusolver | 1 | yes | 178.08 | 34.34 | 143.74 | 19.28 | 12.33 | 12.78 | 9.23 | 0.00 | 2.62 | 177.89 | 0.19 | 40.24 | 208.89 |
| cpu_1rank | cpu | 1 | yes | 304.67 | 161.55 | 143.12 | 53.03 | 138.91 | 12.76 | 9.89 | 0.00 | 2.84 | 304.66 | 0.01 | 0.00 | 208.89 |
| cpu_1rank | nvhpc_cpu | 1 | yes | 310.14 | 162.90 | 147.24 | 52.52 | 139.06 | 13.27 | 10.56 | 0.00 | 3.37 | 310.13 | 0.01 | 0.00 | 208.89 |
| cpu_8rank_ref | cpu | 8 | yes | 199.40 | 398.04 | 1197.16 | 24.95 | 264.85 | 114.54 | 15.00 | 3.66 | 7.01 | 1587.73 | 7.47 | 0.00 | 208.89 |
| cpu_8rank_ref | nvhpc_cpu | 8 | yes | 201.73 | 389.14 | 1224.70 | 24.11 | 263.24 | 105.86 | 15.89 | 4.15 | 7.77 | 1605.57 | 8.27 | 0.00 | 208.89 |

Notes:

- all benchmark rows completed with `ok=yes`
- energies agree across all rows (`208.886424`)
- `phase_s` tracks `wall_rank_s` closely; the remaining `phase_gap_s` is small, while the old `gap_s` remains large because lower-level instrumentation intentionally excludes high-level phase envelopes
- absolute timings were collected on a shared Terok node and should be read as validation/diagnostics, not as final performance claims
