### PR TITLE
Profile NVHPC orthogonalization overlap phases

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -71,9 +71,38 @@
       REAL(8)   ,ALLOCATABLE :: RMAT(:,:),ROMAT(:,:),ROOMAT(:,:),RLAMBDA(:,:)
       INTEGER(4),ALLOCATABLE :: SMAP(:)
       INTEGER(4)             :: I1,J1,K
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                :: ACCEL_T0
+      REAL(8)                :: ACCEL_T1
+      REAL(8)                :: ACCEL_TOTAL_T0
+      REAL(8)                :: ACCEL_TOTAL_T1
+      REAL(8)                :: ACCEL_OPSI_T
+      REAL(8)                :: ACCEL_MASS_T
+      REAL(8)                :: ACCEL_STRESS_T
+      REAL(8)                :: ACCEL_PROJ_T
+      REAL(8)                :: ACCEL_1C_T
+      REAL(8)                :: ACCEL_PWOVL_T
+      REAL(8)                :: ACCEL_SOLVE_T
+      REAL(8)                :: ACCEL_ADDOPSI_T
+      REAL(8)                :: ACCEL_ADDOPROJ_T
+      REAL(8)                :: ACCEL_WAVEKIN_T
+#ENDIF
 !     **************************************************************************
                              CALL TRACE$PUSH('WAVES$ORTHOGONALIZE')
                              CALL TIMING$CLOCKON('WAVES$ORTHOGONALIZE')
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_OPSI_T=0.D0
+      ACCEL_MASS_T=0.D0
+      ACCEL_STRESS_T=0.D0
+      ACCEL_PROJ_T=0.D0
+      ACCEL_1C_T=0.D0
+      ACCEL_PWOVL_T=0.D0
+      ACCEL_SOLVE_T=0.D0
+      ACCEL_ADDOPSI_T=0.D0
+      ACCEL_ADDOPROJ_T=0.D0
+      ACCEL_WAVEKIN_T=0.D0
+      CALL ACCELPROFILE$NOW(ACCEL_TOTAL_T0)
+#ENDIF
       NPRO=MAP%NPRO
       NAT=MAP%NAT
       TRESIDENTOVERLAP=.FALSE.
@@ -102,6 +131,9 @@
           NGL=GSET%NGL
           NBH=THIS%NBH
           NB=THIS%NB
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 IF(1.EQ.0) THEN ! CHANGE FOR KAESTNERS CONJUGATE GRADIENT
 !
 !         ======================================================================
@@ -147,10 +179,17 @@ ELSE
           CALL WAVES_OPSI(NB,NBH,NPRO,NAT,NGL,R0,THIS%PROJ,THIS%OPSI)
 !++++++++++++++++++++++++ TO HERE +++++++++++++++++++++++++++++++++++++++
 END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_OPSI_T=ACCEL_OPSI_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !
 !         ======================================================================
 !         ==  DIVIDE BY WAVE FUNCTION MASS                                    ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
           ALLOCATE(MARR(NGL))
           CALL PLANEWAVE$GETR8A('G2',NGL,MARR)
 !PB070802          IF(ASSOCIATED(GSET%DMPSI)) THEN
@@ -175,6 +214,10 @@ END IF
             ENDDO
           ENDDO
           DEALLOCATE(MARR)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_MASS_T=ACCEL_MASS_T+ACCEL_T1-ACCEL_T0
+#ENDIF
         ENDDO
       ENDDO
 !
@@ -184,6 +227,9 @@ END IF
       ALLOCATE(RP(3,NAT))
       CALL ATOMLIST$GETR8A('R(+)',0,3*NAT,RP)
       IF(TSTRESS) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 !       == PREDICT NEW POSITIONS =======================================
         CALL CELL$GETR8A('TP',9,RBAS)
         CALL CELL$GETR8A('MAPTOCELL',9,MAPTOCELL)
@@ -243,6 +289,10 @@ END IF
             THIS%OPSI(:,:,:)=THIS%OPSI(:,:,:)*CELLSCALE 
           ENDDO
         ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        ACCEL_STRESS_T=ACCEL_T1-ACCEL_T0
+#ENDIF
       ELSE
         CELLSCALE=1.D0
       END IF
@@ -261,6 +311,9 @@ END IF
 !         ======================================================================
 !         ==  CALCULATE PROJECTIONS FOR THE NEW POSITIONS                     ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           IF(TRESIDENTOVERLAP) THEN
             CALL ACCELPROFILE$ADD('ACC_COPY_CUBLAS_OVERLAP_RES_REGION' &
@@ -291,16 +344,28 @@ END IF
           CALL WAVES_PROJECTIONS(MAP,GSET,NAT,RP,NGL,NDIM,NBH,NPRO &
      &                                                         ,THIS%OPSI,OPROJ)
           CALL MPE$COMBINE('K','+',OPROJ)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_PROJ_T=ACCEL_PROJ_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !
 !         ======================================================================
 !         ==  1C-OVERLAP OF <PSI0|PSI0>, <OPSI|PSI0> AND <OPSI|OPSI>          ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
           ALLOCATE(MAT(NB,NB))
           CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,THIS%PROJ,THIS%PROJ,MAT)
           ALLOCATE(OMAT(NB,NB))
           CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,OPROJ,THIS%PROJ,OMAT)
           ALLOCATE(OOMAT(NB,NB))
           CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,OPROJ,OPROJ,OOMAT)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_1C_T=ACCEL_1C_T+ACCEL_T1-ACCEL_T0
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 !
 !         ======================================================================
 !         ==  NOW ADD OVERLAP OF PSEUDO WAVE FUNCTIONS                        ==
@@ -325,6 +390,10 @@ END IF
             ENDDO
           ENDDO
           DEALLOCATE(AUXMAT)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_PWOVL_T=ACCEL_PWOVL_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !$ACC END DATA
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
           IF(TRESIDENTOVERLAP) THEN
@@ -335,6 +404,9 @@ END IF
 !         ======================================================================
 !         ==  CALCULATE LAGRANGE PARAMETERS                                   ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
           ALLOCATE(LAMBDA(NB,NB))
           LAMBDA(:,:)=THIS%RLAM0(:,:)
           DO I=1,NB
@@ -429,10 +501,17 @@ END IF
           DEALLOCATE(OMAT)
           DEALLOCATE(OOMAT)
           IF(.NOT.TSAFEORTHO)DEALLOCATE(SMAP)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_SOLVE_T=ACCEL_SOLVE_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !
 !         ======================================================================
 !         ==  CALCULATE |PSI(+)>=|PSI>+|CHI>LAMBDA                            ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
           TRESIDENTADDOPSI=TRESIDENTOVERLAP.AND.(NBH.EQ.NB)
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           IF(TRESIDENTADDOPSI) THEN
@@ -460,11 +539,22 @@ END IF
           CALL WAVES_ADDOPSI(NGL,NDIM,NBH,NB,THIS%PSIM,THIS%OPSI,LAMBDA)
 !$ACC END DATA
           DEALLOCATE(THIS%OPSI)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_ADDOPSI_T=ACCEL_ADDOPSI_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !PRINT*,'WARNING FROM WAVES$ORTHOGONALIZE:'
 !PRINT*,'MAKE SURE THAT PDOS AND GRAPHICS PICK UP A CONSISTENT SET OF '
 !PRINT*,'WAVE FUNCTIONS  AND PROJECTOR FUNCTIONS'
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
           CALL WAVES_ADDOPROJ(NPRO,NDIM,NBH,NB,THIS%PROJ,OPROJ,LAMBDA)
           DEALLOCATE(OPROJ)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_ADDOPROJ_T=ACCEL_ADDOPROJ_T+ACCEL_T1-ACCEL_T0
+#ENDIF
 !
 !         ======================================================================
 !         ======================================================================
@@ -555,7 +645,50 @@ END IF
 !     ==================================================================
 !     ==  CALCULATE SECOND PART OF WAVE FUNCTION KINETIC ENERGY       ==
 !     ==================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL WAVES_WAVEKINETIC(WAVEEKIN2)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      ACCEL_WAVEKIN_T=ACCEL_T1-ACCEL_T0
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_OPSI' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_OPSI_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_MASS' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_MASS_T)
+      IF(TSTRESS) THEN
+        CALL ACCELPROFILE$ADD('PAW_ORTHO_STRESS' &
+     &      ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &      ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_STRESS_T)
+      END IF
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_PROJ' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_PROJ_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_1COVERLAP' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_1C_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_PW_OVERLAP' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_PWOVL_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_SOLVE' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_SOLVE_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_ADDOPSI' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_ADDOPSI_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_ADDOPROJ' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_ADDOPROJ_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_WAVEKIN' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_WAVEKIN_T)
+      CALL ACCELPROFILE$NOW(ACCEL_TOTAL_T1)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_TOTAL' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(NAT,KIND=8),0.D0,0.D0,ACCEL_TOTAL_T1-ACCEL_TOTAL_T0)
+#ENDIF
                              CALL TIMING$CLOCKOFF('WAVES$ORTHOGONALIZE')
                                     CALL TRACE$POP
       RETURN
@@ -1054,11 +1187,20 @@ END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                   :: ACCEL_T0
       REAL(8)                   :: ACCEL_T1
+      REAL(8)                   :: ACCEL_TOTAL_T0
+      REAL(8)                   :: ACCEL_TOTAL_T1
+      REAL(8)                   :: ACCEL_PACK_T
+      REAL(8)                   :: ACCEL_CONTRACT_T
+      REAL(8)                   :: ACCEL_UNRAVEL_T
       REAL(8)                   :: ACCEL_CUBLAS_T0
       REAL(8)                   :: ACCEL_CUBLAS_T1
 #ENDIF
 !     **************************************************************************
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_PACK_T=0.D0
+      ACCEL_CONTRACT_T=0.D0
+      ACCEL_UNRAVEL_T=0.D0
+      CALL ACCELPROFILE$NOW(ACCEL_TOTAL_T0)
       CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
       CALL MPE$QUERY('K',NTASKS,THISTASK)
@@ -1129,6 +1271,11 @@ END IF
         IPRO=IPRO+LMNX
         IPROX=IPROX+LMNX
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      ACCEL_PACK_T=ACCEL_T1-ACCEL_T0
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================     
 !     ==  MAT(I,J)= SUM_{K,L} <PSI_I|P_K>   * [ DO(K,L)*<P_L|PSI_J>]          ==
@@ -1260,6 +1407,11 @@ END IF
 #ENDIF
       DEALLOCATE(PROJ1A)
       DEALLOCATE(PROJ2A)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      ACCEL_CONTRACT_T=ACCEL_T1-ACCEL_T0
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================     
 !     ==  UNRAVEL SUPER WAVE FUNCTIONS  PSISUP=PSI1+CI*PSI2 WITH REAL PSI1/2  ==
@@ -1285,10 +1437,25 @@ END IF
         CALL MPE$COMBINE('K','+',MAT)
       ENDIF  
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      IF(TINV) THEN
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        ACCEL_UNRAVEL_T=ACCEL_T1-ACCEL_T0
+      END IF
+      CALL ACCELPROFILE$ADD('PAW_1COVERLAP_PACK' &
+     &    ,INT(NB,KIND=8),INT(NBH,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(MAP%NAT,KIND=8),0.D0,0.D0,ACCEL_PACK_T)
+      CALL ACCELPROFILE$ADD('PAW_1COVERLAP_CONTRACT' &
+     &    ,INT(NB,KIND=8),INT(NBH,KIND=8),INT(NPRO,KIND=8) &
+     &    ,INT(MAP%NAT,KIND=8),0.D0,0.D0,ACCEL_CONTRACT_T)
+      IF(TINV) THEN
+        CALL ACCELPROFILE$ADD('PAW_1COVERLAP_UNRAVEL' &
+     &      ,INT(NB,KIND=8),INT(NBH,KIND=8),INT(NPRO,KIND=8) &
+     &      ,INT(MAP%NAT,KIND=8),0.D0,0.D0,ACCEL_UNRAVEL_T)
+      END IF
+      CALL ACCELPROFILE$NOW(ACCEL_TOTAL_T1)
       CALL ACCELPROFILE$ADD('PAW_1COVERLAP_TOTAL' &
      &    ,INT(NB,KIND=8),INT(NBH,KIND=8),INT(NPRO,KIND=8) &
-     &    ,INT(MAP%NAT,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+     &    ,INT(MAP%NAT,KIND=8),0.D0,0.D0,ACCEL_TOTAL_T1-ACCEL_TOTAL_T0)
 #ENDIF
       RETURN
       END

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -354,6 +354,33 @@ larger unresolved algorithmic hotspot remains the dense Gram/overlap side:
 and matmul rows. That is the better next design target than another local loop
 offload.
 
+## Orthogonalization and 1COVERLAP Phase Profiling
+
+The next profiling patch splits the orthogonalization step into context rows and
+breaks `WAVES_1COVERLAP` into pack, contraction, and superwave-unravel phases.
+This is a diagnostic-only change; it does not alter the numerical path or any
+NVHPC defaults.
+
+Spark C86C validation after the split:
+
+| Run | Empty bands | Ranks | Wall time | Energy | Main new signal |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `si64_bands-nstep1-1ranks-20260531-120036` | 512 | 1 | 11.09 s | 302.280854 Ha | `PAW_1COVERLAP_CONTRACT=1.0021 s` of `1.0320 s`; `PAW_ORTHO_1COVERLAP=0.6184 s`. |
+| `si64_bands-nstep1-4ranks-20260531-120104` | 512 | 4 | 21.93 s | 302.280854 Ha | `PAW_ORTHO_SOLVE=2.3215 s`, `PAW_ORTHO_ADDOPROJ=2.1621 s`, `PAW_1COVERLAP_CONTRACT=1.6548 s` rank-summed. |
+| `si64_bands-nstep1-1ranks-20260531-120141` | 2048 | 1 | 280.99 s | 302.280854 Ha | `PAW_ORTHO_TOTAL=21.5684 s`, with `PAW_ORTHO_SOLVE=8.6428 s` and `PAW_ORTHO_1COVERLAP=7.5910 s`. |
+
+The 2048/1 result sharpens the next implementation choice. The one-center
+overlap bottleneck is not packing or superwave expansion:
+`PAW_1COVERLAP_PACK=0.1396 s`,
+`PAW_1COVERLAP_UNRAVEL=0.0149 s`, but
+`PAW_1COVERLAP_CONTRACT=12.3631 s` out of
+`PAW_1COVERLAP_TOTAL=12.5175 s`. The earlier opt-in cuBLAS 1C path should
+therefore not be replaced by more host packing work; it needs either a robust
+contract-only GPU implementation or an algorithmic change that avoids repeating
+the dense contraction in the current form. Orthogonalization also exposes a
+second CPU-side target at large band count: the overlap solve/update phase
+(`PAW_ORTHO_SOLVE`) is now comparable to the 1C contribution.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Changes

- Add diagnostic `PAW_ORTHO_*` profile rows around `WAVES$ORTHOGONALIZE` phases: `OPSI`, mass scaling, optional stress update, projection, one-center overlap, pseudo-wave overlap, solve, `ADDOPSI`, `ADDOPROJ`, wave kinetic, and total.
- Split `WAVES_1COVERLAP` profiling into `PAW_1COVERLAP_PACK`, `PAW_1COVERLAP_CONTRACT`, optional `PAW_1COVERLAP_UNRAVEL`, and total.
- Document Spark C86C validation and the main conclusion: at 2048/1 the one-center overlap time is almost entirely contraction, while orthogonalization is dominated by solve plus one-center overlap.

## Validation

- `git diff --check`
- `tests/profile/si64/check_harness.sh`
- local `profile` build: `src/Buildtools/paw_build.sh -v -j8 -c profile -z`
- Spark C86C builds:
  - `nvhpc_gpu_acc_residency_profile`
  - `nvhpc_gpu_acc_residency_profile_parallel`
- Spark C86C benchmark smokes:
  - `TEST=si64_bands EMPTY_BANDS=512 NSTEPS=1 RANKS=1 CASES="gpu_resident"`: `11.09 s`, `302.280854 Ha`
  - `TEST=si64_bands EMPTY_BANDS=512 NSTEPS=1 RANKS=4 CASES="gpu_resident"`: `21.93 s`, `302.280854 Ha`
  - `TEST=si64_bands EMPTY_BANDS=2048 NSTEPS=1 RANKS=1 CASES="gpu_resident"`: `280.99 s`, `302.280854 Ha`
