### PR TITLE
Keep force PSI resident for NVHPC

### DIFF
--- a/src/paw_accel_cublas.f90
+++ b/src/paw_accel_cublas.f90
@@ -29,10 +29,12 @@
       LOGICAL(4)         :: RESIDENCY_ENABLED=.TRUE.
       LOGICAL(4)         :: PRO_EXPANSION_ENABLED=.TRUE.
       LOGICAL(4)         :: ADDPRO_CACHE_ENABLED=.TRUE.
+      LOGICAL(4)         :: FORCE_PSI_RESIDENCY_ENABLED=.TRUE.
 #ELSE
       LOGICAL(4)         :: RESIDENCY_ENABLED=.FALSE.
       LOGICAL(4)         :: PRO_EXPANSION_ENABLED=.FALSE.
       LOGICAL(4)         :: ADDPRO_CACHE_ENABLED=.FALSE.
+      LOGICAL(4)         :: FORCE_PSI_RESIDENCY_ENABLED=.FALSE.
 #ENDIF
       LOGICAL(4)         :: ONECENTER_OVERLAP_ENABLED=.FALSE.
       LOGICAL(4)         :: INVERSION_BATCH_ENABLED=.TRUE.
@@ -289,6 +291,23 @@
           END SELECT
         END IF
       END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_FORCE_PSI_RESIDENCY',VALUE &
+     &                             ,STATUS=STATUS)
+      IF(STATUS.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY' &
+     &                               ,VALUE,STATUS=STATUS)
+      END IF
+      IF(STATUS.EQ.0) THEN
+        VALUE=ADJUSTL(VALUE)
+        IF(LEN_TRIM(VALUE).GT.0) THEN
+          SELECT CASE(VALUE(1:MIN(LEN(VALUE),LEN_TRIM(VALUE))))
+          CASE('0','no','NO','false','FALSE','off','OFF')
+            FORCE_PSI_RESIDENCY_ENABLED=.FALSE.
+          CASE DEFAULT
+            FORCE_PSI_RESIDENCY_ENABLED=.TRUE.
+          END SELECT
+        END IF
+      END IF
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_1COVERLAP',VALUE &
      &                             ,STATUS=STATUS)
       IF(STATUS.NE.0) THEN
@@ -405,6 +424,16 @@
      &     .AND.ADDPRO_CACHE_ENABLED
       RETURN
       END FUNCTION CPPAW_CUBLAS_ACC_ADDPRO_CACHE_ENABLED
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY_ENABLED()
+      IMPLICIT NONE
+!     **************************************************************************
+      CALL CPPAW_CUBLAS_ACC_INITCONFIG
+      CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY_ENABLED=ENABLED &
+     &     .AND.RESIDENCY_ENABLED.AND.FORCE_PSI_RESIDENCY_ENABLED
+      RETURN
+      END FUNCTION CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY_ENABLED
 !
 !     ..........................................................................
       LOGICAL(4) FUNCTION CPPAW_CUBLAS_ACC_1COVERLAP_ENABLED(FLOPS)

--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4770,6 +4770,11 @@ RETURN
 !     ************P.E. BLOECHL, TU-CLAUSTHAL (2005)*****************************
       USE MPE_MODULE
       USE WAVES_MODULE
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &       CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY_ENABLED &
+     &      ,CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D
+#ENDIF
       IMPLICIT NONE
       INTEGER(4),INTENT(IN)  :: NAT
       INTEGER(4),INTENT(IN)  :: LMNXX
@@ -4800,6 +4805,9 @@ RETURN
       REAL(8)                :: SVAR
       REAL(8)                :: R(3,NAT)
       REAL(8)   ,PARAMETER   :: RSMALL=1.D-20
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      LOGICAL(4)             :: TRESIDENTFORCEPSI
+#ENDIF
 !     **************************************************************************
                               CALL TRACE$PUSH('WAVES$FORCE')
                               CALL TIMING$CLOCKON('W:FORCE')
@@ -4861,6 +4869,18 @@ RETURN
 !         ======================================================================
 !         ==                                                                  ==
 !         ======================================================================
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+          TRESIDENTFORCEPSI=CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY_ENABLED()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          IF(TRESIDENTFORCEPSI) THEN
+            CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D &
+     &          ('ACC_PRESENT_FORCE_PSI0','ACC_COPY_FORCE_PSI0_IN' &
+     &          ,NGL,NDIM,NBH,THIS%PSI0)
+          END IF
+#ENDIF
+!$ACC DATA PRESENT_OR_COPYIN(THIS%PSI0(1:NGL,1:NDIM,1:NBH)) &
+!$ACC& IF(TRESIDENTFORCEPSI)
+#ENDIF
           IPRO=1
           DO IAT=1,NAT
             ISP=MAP%ISP(IAT)
@@ -4919,6 +4939,9 @@ RETURN
             IPRO=IPRO+LMNX
             CALL SETUP$UNSELECT()
           ENDDO ! END OF LOOP OVER IAT
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+!$ACC END DATA
+#ENDIF
           DEALLOCATE(GIJ)
           DEALLOCATE(GVEC)
         ENDDO  ! END OF LOOP OVER ISPIN

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -124,7 +124,10 @@ superwave overlaps it also keeps the `<PSI_+|PSI_+>` part on the same
 present-input path and batches the `<PSI_-|PSI_+>` inversion pass into one larger
 scalarproduct when the cuBLAS overlap threshold allows it. `WAVES_GRAMSCHMIDT`
 also has a narrow resident projection/overlap region for wavefunctions outside
-the main orthogonalization loop. Set `CPPAW_CUBLAS_ACC_INVERSION_BATCH=0` to keep
+the main orthogonalization loop. The force loop keeps `THIS%PSI0` resident
+across per-atom `WAVES_DEDPRO` MATMUL calls; set
+`CPPAW_GPU_FORCE_PSI_RESIDENCY=0` to compare against the previous per-atom copy
+behavior. Set `CPPAW_CUBLAS_ACC_INVERSION_BATCH=0` to keep
 the older per-column inversion scalarproduct path for comparison. It also lets
 `ZGEMM_NN` addproduct calls reuse a present output matrix, which targets
 `WAVES_ADDPRO`. `ACC_COPY_*_RES` profile rows report the reduced copy estimate
@@ -207,6 +210,7 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_no_cusolver` | Residency diagnostic with cuSOLVER disabled in the same residency binary. |
 | `gpu_resident_pro_host` | Residency diagnostic with GPU projector expansion disabled via `CPPAW_GPU_PRO_EXPANSION=0`. |
 | `gpu_resident_addpro_host` | Residency diagnostic with the GPU projection cache kept enabled but its `WAVES_ADDPRO` reuse disabled via `CPPAW_GPU_ADDPRO_CACHE=0`. |
+| `gpu_resident_forcepsi_host` | Residency diagnostic with force-loop `THIS%PSI0` residency disabled via `CPPAW_GPU_FORCE_PSI_RESIDENCY=0`. |
 | `gpu_resident_projection_conservative` / `gpu_resident_overlap_conservative` / `gpu_resident_addproduct_conservative` / `gpu_resident_matmul_conservative` | Residency diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident_force_all` | Residency diagnostic that also forces cuFFT and small cuSOLVER offload. |
 | `gpu_resident_off` | Residency binary with native cuFFT/cuBLAS/cuSOLVER disabled for same-executable fallback comparison. |
@@ -336,6 +340,9 @@ be overridden by kernel category:
 - `CPPAW_GPU_ADDPRO_CACHE`: keep enabled by default in residency-profile builds
   so `WAVES_ADDPRO` reuses the GPU-resident `PRO` cache; set to `0` to test
   projection caching without the cached addproduct path.
+- `CPPAW_GPU_FORCE_PSI_RESIDENCY`: keep enabled by default in residency-profile
+  builds so `WAVES$FORCE` reuses `THIS%PSI0` across the per-atom
+  `WAVES_DEDPRO` MATMUL calls; set to `0` for the previous per-call copy path.
 
 The benchmark harness exposes conservative diagnostic cases such as
 `gpu_resident_projection_conservative`, `gpu_resident_overlap_conservative`,

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -439,6 +439,55 @@ step is to identify that caller's producer and either keep that operand resident
 or route it through a more semantic present-data path instead of treating it as
 an opaque `LIB$MATMUL` temporary.
 
+## Force PSI Residency
+
+The dominant complex MATMUL transfer from the previous section was traced to
+`WAVES_DEDPRO`:
+
+```
+CALL LIB$MATMULC8(NGL,NDIM*NBH,LMNX,PSI,DEDPROJ1,DEDPRO)
+```
+
+For the Si64 band profile this is the `13133 x 576 x 13` shape. The follow-up
+patch keeps `THIS%PSI0` resident across the per-atom `WAVES$FORCE` loop, so the
+64 per-atom `WAVES_DEDPRO` calls can reuse the same left MATMUL operand. The
+path is enabled by default in residency-profile builds and can be disabled with
+`CPPAW_GPU_FORCE_PSI_RESIDENCY=0`.
+
+Spark C86C builds succeeded for both:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+```
+
+Smoke run:
+
+```
+runs/forcepsi-residency-smoke-20260531-130956
+```
+
+| Case | Ranks | Wall time | Total copy estimate | Final energy | Interpretation |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `gpu_resident` | 1 | 42.85 s | 7.7153 GB | 302.280854 Ha | New default path with force-loop `THIS%PSI0` residency. |
+| `gpu_resident_forcepsi_host` | 1 | 45.56 s | 15.3405 GB | 302.280854 Ha | Same binary with `CPPAW_GPU_FORCE_PSI_RESIDENCY=0`. |
+
+Key profile rows:
+
+| Profile row | `gpu_resident` | `gpu_resident_forcepsi_host` | Meaning |
+| --- | ---: | ---: | --- |
+| `ACC_COPY_FORCE_PSI0_IN` | 1 call, 0.1210 GB | - | One copy into the force-loop resident region. |
+| `ACC_PRESENT_ZGEMM_MAT_A` | 64 calls | - | `WAVES_DEDPRO` reuses the resident `PSI0` operand. |
+| `ACC_COPY_ZGEMM_MAT_A_IN` | - | 64 calls, 7.7462 GB | Previous per-atom copy of the same left operand. |
+| `ACC_COPY_ZGEMM_MAT_B_IN` | 64 calls, 0.0077 GB | 64 calls, 0.0077 GB | Small per-atom derivative-projector operand. |
+| `ACC_COPY_ZGEMM_MAT_C_OUT` | 64 calls, 0.1748 GB | 64 calls, 0.1748 GB | Per-atom `DEDPRO` output. |
+
+Conclusion: this is the first broad force-side wavefunction-residency win. It
+does not solve the remaining DGEMM MATMUL traffic or one-center overlap
+contraction, but it removes the largest previously ambiguous complex MATMUL copy
+without changing the energy and with a positive one-step wall-time signal on
+Spark.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -218,6 +218,9 @@ case_note() {
     gpu_resident_addpro_host)
       echo "Residency diagnostic that keeps the GPU projector cache for projections but disables its WAVES_ADDPRO reuse."
       ;;
+    gpu_resident_forcepsi_host)
+      echo "Residency diagnostic that disables the force-loop PSI0 resident data region."
+      ;;
     gpu_resident_1coverlap_host)
       echo "Residency diagnostic that disables only the one-center overlap cuBLAS path."
       ;;
@@ -398,6 +401,7 @@ case_env() {
     gpu_resident_1coverlap) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=1 $(cublas_env)" ;;
     gpu_resident_pro_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PRO_EXPANSION=0 $(cublas_env)" ;;
     gpu_resident_addpro_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ADDPRO_CACHE=0 $(cublas_env)" ;;
+    gpu_resident_forcepsi_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_FORCE_PSI_RESIDENCY=0 $(cublas_env)" ;;
     gpu_resident_1coverlap_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=0 $(cublas_env)" ;;
     gpu_resident_projection_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_projection_conservative_env)" ;;
     gpu_resident_overlap_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_overlap_conservative_env)" ;;


### PR DESCRIPTION
## Summary

This follow-up targets the dominant copy source identified by the previous MATMUL residency diagnostics.

- trace the `13133 x 576 x 13` complex MATMUL copy to `WAVES_DEDPRO`
- keep `THIS%PSI0` resident across the per-atom `WAVES$FORCE` loop in NVHPC residency builds
- add `CPPAW_GPU_FORCE_PSI_RESIDENCY=0` / `CPPAW_CUBLAS_ACC_FORCE_PSI_RESIDENCY=0` to disable the new path for diagnostics
- add the `gpu_resident_forcepsi_host` benchmark case
- document the new default and Spark validation results

## Spark validation

Spark C86C builds succeeded for both targets:

- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Smoke run:

`tests/profile/si64/runs/forcepsi-residency-smoke-20260531-130956`

| Case | Ranks | Wall time | Copy estimate | Energy |
| --- | ---: | ---: | ---: | ---: |
| `gpu_resident` | 1 | 42.85 s | 7.7153 GB | 302.280854 Ha |
| `gpu_resident_forcepsi_host` | 1 | 45.56 s | 15.3405 GB | 302.280854 Ha |

Key profile rows:

| Profile row | `gpu_resident` | `gpu_resident_forcepsi_host` |
| --- | ---: | ---: |
| `ACC_COPY_FORCE_PSI0_IN` | 1 call, 0.1210 GB | - |
| `ACC_PRESENT_ZGEMM_MAT_A` | 64 calls | - |
| `ACC_COPY_ZGEMM_MAT_A_IN` | - | 64 calls, 7.7462 GB |
| `ACC_COPY_ZGEMM_MAT_B_IN` | 64 calls, 0.0077 GB | 64 calls, 0.0077 GB |
| `ACC_COPY_ZGEMM_MAT_C_OUT` | 64 calls, 0.1748 GB | 64 calls, 0.1748 GB |

## Checks

- `tests/profile/si64/check_harness.sh`
- `git diff --check`
- Spark build: `nvhpc_gpu_acc_residency_profile`
- Spark build: `nvhpc_gpu_acc_residency_profile_parallel`
- Spark smoke: `runs/forcepsi-residency-smoke-20260531-130956`

## Follow-up signal

This removes the largest previously ambiguous complex MATMUL copy in the Si64 profile. Remaining candidates are the real generic DGEMM MATMUL traffic and the one-center overlap contraction path, but the force-side wavefunction residency step is now validated independently.
