### PR TITLE
Use Cholesky for initial Gram-Schmidt solve

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -1495,6 +1495,122 @@ END IF
       END
 !
 !      .................................................................
+       LOGICAL(4) FUNCTION WAVES_GRAM_CHOLESKY_ENABLED()
+!      *****************************************************************
+!      **  OPT-IN FAST PATH FOR INITIAL GRAM-SCHMIDT ORTHOGONALIZATION **
+!      *****************************************************************
+       IMPLICIT NONE
+       CHARACTER(32)              :: VALUE
+       INTEGER(4)                 :: STATUS
+!      *****************************************************************
+#IF DEFINED(CPPVAR_GPU_RESIDENCY_PROFILE)
+       WAVES_GRAM_CHOLESKY_ENABLED=.TRUE.
+#ELSE
+       WAVES_GRAM_CHOLESKY_ENABLED=.FALSE.
+#ENDIF
+       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GRAM_CHOLESKY',VALUE &
+     &                              ,STATUS=STATUS)
+       IF(STATUS.NE.0) THEN
+         CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_GRAM_CHOLESKY',VALUE &
+     &                                ,STATUS=STATUS)
+       END IF
+       IF(STATUS.EQ.0) THEN
+         VALUE=ADJUSTL(VALUE)
+         IF(LEN_TRIM(VALUE).GT.0) THEN
+           SELECT CASE(VALUE(1:MIN(LEN(VALUE),LEN_TRIM(VALUE))))
+           CASE('0','no','NO','false','FALSE','off','OFF')
+             WAVES_GRAM_CHOLESKY_ENABLED=.FALSE.
+           CASE DEFAULT
+             WAVES_GRAM_CHOLESKY_ENABLED=.TRUE.
+           END SELECT
+         END IF
+       END IF
+       RETURN
+       END FUNCTION WAVES_GRAM_CHOLESKY_ENABLED
+!
+!      .................................................................
+       SUBROUTINE WAVES_GRAM_CHOLESKY(NB,OVERLAP,X,TOK)
+!      *****************************************************************
+!      **  INITIAL GRAM-SCHMIDT SPECIAL CASE:                          **
+!      **    PHIPHI=CHIPHI=CHICHI=S, SO T=INV(U) WITH S=U^H U          **
+!      **    GIVES (I+X)^H S (I+X)=I AND X=T-I.                        **
+!      *****************************************************************
+       IMPLICIT NONE
+       INTEGER(4),INTENT(IN)      :: NB
+       COMPLEX(8),INTENT(IN)      :: OVERLAP(NB,NB)
+       COMPLEX(8),INTENT(OUT)     :: X(NB,NB)
+       LOGICAL(4),INTENT(OUT)     :: TOK
+       COMPLEX(8),ALLOCATABLE     :: A(:,:)
+       INTEGER(4)                 :: I,J,INFO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       REAL(8)                    :: ACCEL_CHOL_T0
+       REAL(8)                    :: ACCEL_CHOL_T1
+       REAL(8)                    :: ACCEL_CHOL_TOTAL_T0
+#ENDIF
+       EXTERNAL ZPOTRF
+       EXTERNAL ZTRTRI
+!      *****************************************************************
+       TOK=.FALSE.
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_TOTAL_T0)
+#ENDIF
+       ALLOCATE(A(NB,NB))
+       A(:,:)=OVERLAP(:,:)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_T0)
+#ENDIF
+       CALL ZPOTRF('U',NB,A,NB,INFO)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_T1)
+       CALL ACCELPROFILE$ADD('LAPACK_ZPOTRF_GRAM' &
+     &    ,INT(NB,KIND=8),0_8,0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_CHOL_T1-ACCEL_CHOL_T0)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_T0)
+#ENDIF
+       IF(INFO.NE.0) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+         CALL ACCELPROFILE$ADD('PAW_GRAM_CHOL_FALLBACK' &
+     &      ,INT(NB,KIND=8),INT(INFO,KIND=8),0_8,0_8 &
+     &      ,0.D0,0.D0,ACCEL_CHOL_T1-ACCEL_CHOL_TOTAL_T0)
+#ENDIF
+         DEALLOCATE(A)
+         RETURN
+       END IF
+       CALL ZTRTRI('U','N',NB,A,NB,INFO)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_T1)
+       CALL ACCELPROFILE$ADD('LAPACK_ZTRTRI_GRAM' &
+     &    ,INT(NB,KIND=8),0_8,0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_CHOL_T1-ACCEL_CHOL_T0)
+#ENDIF
+       IF(INFO.NE.0) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+         CALL ACCELPROFILE$ADD('PAW_GRAM_CHOL_FALLBACK' &
+     &      ,INT(NB,KIND=8),INT(INFO,KIND=8),0_8,0_8 &
+     &      ,0.D0,0.D0,ACCEL_CHOL_T1-ACCEL_CHOL_TOTAL_T0)
+#ENDIF
+         DEALLOCATE(A)
+         RETURN
+       END IF
+       X(:,:)=(0.D0,0.D0)
+       DO J=1,NB
+         DO I=1,J
+           X(I,J)=A(I,J)
+         ENDDO
+         X(J,J)=X(J,J)-(1.D0,0.D0)
+       ENDDO
+       DEALLOCATE(A)
+       TOK=.TRUE.
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+       CALL ACCELPROFILE$NOW(ACCEL_CHOL_T1)
+       CALL ACCELPROFILE$ADD('PAW_GRAM_SOLVE' &
+     &    ,INT(NB,KIND=8),0_8,0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_CHOL_T1-ACCEL_CHOL_TOTAL_T0)
+#ENDIF
+       RETURN
+       END SUBROUTINE WAVES_GRAM_CHOLESKY
+!
+!      .................................................................
        SUBROUTINE WAVES_ORTHO_Y_C(NB,PHIPHI,CHIPHI,CHICHI,X,MAP)
 !      **                                                             **
 !      **  CALCULATE LAGRANGE MULTIPLIERS FOR ORTHOGONALIZATION       **
@@ -2569,6 +2685,8 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
       COMPLEX(8)                  :: XTWOBYTWO(2,2)
       INTEGER(4)      ,ALLOCATABLE:: SMAP(:)
       LOGICAL(4)                  :: TRESIDENTGRAM
+      LOGICAL(4)                  :: TCHOLESKY
+      LOGICAL(4)                  :: WAVES_GRAM_CHOLESKY_ENABLED
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                     :: ACCEL_GRAM_T0
       REAL(8)                     :: ACCEL_GRAM_T1
@@ -2679,12 +2797,20 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
       ENDDO 
       ALLOCATE(X(NB,NB))
 !== SPEICHERZUGRIFFSFEHLER IFC10
-      CALL WAVES_ORTHO_Y_C(NB,OVERLAP,OVERLAP,OVERLAP,X,SMAP)
+      TCHOLESKY=.FALSE.
+      IF(WAVES_GRAM_CHOLESKY_ENABLED()) THEN
+        CALL WAVES_GRAM_CHOLESKY(NB,OVERLAP,X,TCHOLESKY)
+      END IF
+      IF(.NOT.TCHOLESKY) THEN
+        CALL WAVES_ORTHO_Y_C(NB,OVERLAP,OVERLAP,OVERLAP,X,SMAP)
+      END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_GRAM_T1)
-      CALL ACCELPROFILE$ADD('PAW_GRAM_SOLVE' &
-     &   ,INT(NB,KIND=8),0_8,0_8,0_8 &
-     &   ,0.D0,0.D0,ACCEL_GRAM_T1-ACCEL_GRAM_T0)
+      IF(.NOT.TCHOLESKY) THEN
+        CALL ACCELPROFILE$ADD('PAW_GRAM_SOLVE' &
+     &     ,INT(NB,KIND=8),0_8,0_8,0_8 &
+     &     ,0.D0,0.D0,ACCEL_GRAM_T1-ACCEL_GRAM_T0)
+      END IF
       CALL ACCELPROFILE$NOW(ACCEL_GRAM_T0)
 #ENDIF
       DEALLOCATE(OVERLAP)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -102,6 +102,12 @@ kernel instrumentation.
 Gram-Schmidt setup is split by `PAW_GRAM_*` rows. These are nested PAW
 diagnostic envelopes: use them to identify the next target, not as additive
 wall-clock accounting.
+Residency-profile builds enable the initial Gram-Schmidt Cholesky solve by
+default. It replaces only the initial `WAVES$GRAMMSCHMIDT` solve with a LAPACK
+Cholesky orthogonalization when the overlap matrix is positive definite;
+otherwise it falls back to the legacy solver. Set `CPPAW_GRAM_CHOLESKY=0` or
+use `gpu_resident_gram_legacy` to compare against the old path; use
+`gpu_resident_gram_cholesky` to force the new path explicitly.
 
 The `nvhpc_gpu_acc_residency_*` target keeps the same accelerator choices but
 defaults to `CPPAW_GPU_RESIDENCY=1`. Set `CPPAW_GPU_RESIDENCY=0` to disable the

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -82,9 +82,9 @@ The latest full-matrix run lives at:
    sweeps because its wall time can be marginally better at 1024-band size.
 
 6. The one-center overlap GPU-pack path removes the previous large
-   `WAVES_1COVERLAP` bottleneck. The next large-band hotspot is now the initial
-   Gram-Schmidt solve inside `WAVES_ORTHO_Y_C`, not another FFT/LAPACK library
-   toggle.
+   `WAVES_1COVERLAP` bottleneck. The next large-band hotspot became the initial
+   Gram-Schmidt solve inside `WAVES_ORTHO_Y_C`; the Cholesky follow-up below is
+   the first direct fix for that path.
 
 ## Present-Check Smoke
 
@@ -574,6 +574,46 @@ Practical conclusion: the next implementation PR should target
 more accelerator-friendly dense linear algebra path. Moving more FFT calls to
 cuFFT or adding more projector packing will not move the 2048-band wall time
 until this solve is addressed.
+
+## Initial Gram-Schmidt Cholesky Solve
+
+The follow-up implementation replaces only the initial
+`WAVES$GRAMMSCHMIDT` special case where `PHIPHI=CHIPHI=CHICHI=S`. For a
+positive-definite overlap matrix, it computes `S=U^H U` with LAPACK `ZPOTRF`,
+uses `ZTRTRI` to form `T=inv(U)`, and applies `X=T-I`. If the Cholesky path
+fails, the code falls back to the legacy `WAVES_ORTHO_Y_C` solver. Residency
+profile builds enable the path by default; set `CPPAW_GRAM_CHOLESKY=0` to use
+the legacy solver for comparison.
+
+Spark C86C validation:
+
+```
+runs/gram-cholesky-smoke1024-20260531-143107
+runs/gram-cholesky-smoke2048-20260531-143226
+runs/gram-cholesky-nstep3-1024-20260531-143332
+runs/gram-cholesky-default1024-20260531-143825
+runs/gram-cholesky-parallel-smoke512-20260531-144006
+```
+
+| Case | Empty bands | NSTEPS | Ranks | Wall time | `PAW_ETOT_SETUP_GRAM` | `PAW_GRAM_SOLVE` | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Legacy default before Cholesky | 1024 | 1 | 1 | 42.10 s | 30.2490 s | 28.2038 s | 302.280854 Ha |
+| Cholesky opt-in | 1024 | 1 | 1 | 13.57 s | 2.2011 s | 0.1479 s | 302.280854 Ha |
+| New default Cholesky | 1024 | 1 | 1 | 14.05 s | - | - | 302.280854 Ha |
+| Explicit legacy override | 1024 | 1 | 1 | 41.74 s | - | - | 302.280854 Ha |
+| Legacy default before Cholesky | 2048 | 1 | 1 | 279.67 s | 241.9808 s | 237.5816 s | 302.280854 Ha |
+| Cholesky opt-in | 2048 | 1 | 1 | 41.34 s | 5.0733 s | 0.8782 s | 302.280854 Ha |
+| Legacy default before Cholesky | 1024 | 3 | 1 | 60.59 s | - | - | 208.886424 Ha |
+| Cholesky opt-in | 1024 | 3 | 1 | 32.85 s | - | - | 208.886424 Ha |
+| Parallel Cholesky smoke | 512 | 1 | 4 | 9.31 s | - | - | 302.280854 Ha |
+
+The 2048-band result is the clearest design signal: the previous 237.6 s
+initial Gram-Schmidt solve shrinks below 0.9 s, and the total run drops from
+279.67 s to 41.34 s with the same final energy. This path currently uses CPU
+LAPACK through the active NVHPC/NVPL linkage, not a GPU kernel. That is already
+enough to remove the dominant bottleneck; a later cuSOLVER `potrf/trtri` variant
+is only worth pursuing if larger runs show that this remaining sub-second block
+grows again.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -407,6 +407,8 @@ case_env() {
     gpu_resident_forcepsi_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_FORCE_PSI_RESIDENCY=0 $(cublas_env)" ;;
     gpu_resident_orthoconst) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_CONST_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_1coverlap_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=0 $(cublas_env)" ;;
+    gpu_resident_gram_cholesky) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=1 $(cublas_env)" ;;
+    gpu_resident_gram_legacy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=0 $(cublas_env)" ;;
     gpu_resident_projection_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_projection_conservative_env)" ;;
     gpu_resident_overlap_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_overlap_conservative_env)" ;;
     gpu_resident_addproduct_conservative) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_addproduct_conservative_env)" ;;


### PR DESCRIPTION
## Summary
- add a Cholesky fast path for the initial `WAVES$GRAMMSCHMIDT` special case where `PHIPHI=CHIPHI=CHICHI=S`
- enable it by default for residency-profile builds, with `CPPAW_GRAM_CHOLESKY=0` / `gpu_resident_gram_legacy` as the legacy override
- document Spark benchmark results and add harness cases for Cholesky/legacy comparisons

## Spark C86C validation
Serial and parallel builds both completed:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

| Case | Empty bands | NSTEPS | Ranks | Wall time | `PAW_GRAM_SOLVE` | Final energy |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| legacy before Cholesky | 1024 | 1 | 1 | 42.10 s | 28.2038 s | 302.280854 Ha |
| Cholesky opt-in | 1024 | 1 | 1 | 13.57 s | 0.1479 s | 302.280854 Ha |
| new default Cholesky | 1024 | 1 | 1 | 14.05 s | - | 302.280854 Ha |
| explicit legacy override | 1024 | 1 | 1 | 41.74 s | - | 302.280854 Ha |
| legacy before Cholesky | 2048 | 1 | 1 | 279.67 s | 237.5816 s | 302.280854 Ha |
| Cholesky opt-in | 2048 | 1 | 1 | 41.34 s | 0.8782 s | 302.280854 Ha |
| legacy before Cholesky | 1024 | 3 | 1 | 60.59 s | - | 208.886424 Ha |
| Cholesky opt-in | 1024 | 3 | 1 | 32.85 s | - | 208.886424 Ha |
| parallel Cholesky smoke | 512 | 1 | 4 | 9.31 s | - | 302.280854 Ha |

Run directories:
- `runs/gram-cholesky-smoke1024-20260531-143107`
- `runs/gram-cholesky-smoke2048-20260531-143226`
- `runs/gram-cholesky-nstep3-1024-20260531-143332`
- `runs/gram-cholesky-default1024-20260531-143825`
- `runs/gram-cholesky-parallel-smoke512-20260531-144006`

## Local checks
- `git diff --check`
- `tests/profile/si64/check_harness.sh`