### PR TITLE
Profile real Ortho-X solver phases

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -2469,6 +2469,13 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
       REAL(8)                  :: U(NB,NB)       
       REAL(8)                  :: OCCI,OCCJ
       LOGICAL(4)               :: TCONVERGED
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      INTEGER(4)               :: ACCEL_ORTHOX_ITER
+      REAL(8)                  :: ACCEL_ORTHOX_T0
+      REAL(8)                  :: ACCEL_ORTHOX_T1
+      REAL(8)                  :: ACCEL_ORTHOX_RESIDUAL_T
+      REAL(8)                  :: ACCEL_ORTHOX_UPDATE_T
+#ENDIF
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       LOGICAL(4)               :: TRESIDENTORTHOCONST
 #ENDIF
@@ -2476,6 +2483,11 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
                              CALL TRACE$PUSH('WAVES_ORTHO_X')
       ALLOCATE(GAMN(NB,NB))
       TCONVERGED=.FALSE.
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      ACCEL_ORTHOX_ITER=0
+      ACCEL_ORTHOX_RESIDUAL_T=0.D0
+      ACCEL_ORTHOX_UPDATE_T=0.D0
+#ENDIF
 !
 !     ==========================================================================
 !     ==  CALCULATE  PSIPSI(I,J)= <PSIBAR(I)|PSIBAR(J)>-1                     ==
@@ -2485,7 +2497,16 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !     ==========================================================================
 !     ==  DIAGONALIZE 0.5*(CHIPSI(I,J)+CHIPSI(J,I))                           ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T0)
+#ENDIF
       CALL LIB$DIAGR8(NB,CHIPSI,EIG,U)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T1)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_X_DIAG' &
+     &    ,INT(NB,KIND=8),0_8,0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_ORTHOX_T1-ACCEL_ORTHOX_T0)
+#ENDIF
 !CALL DIAG(NB,NB,CHIPSI,EIG,U)
 !WRITE(*,FMT='("EIG",20E10.3)')EIG
 !DO I=1,NB
@@ -2513,6 +2534,10 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !     ==========================================================================
 !     ==========================================================================
       DO ITER=1,MAX
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        ACCEL_ORTHOX_ITER=ITER
+        CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T0)
+#ENDIF
 !PRINT*,'==================',ITER,'==========================='
 !       ========================================================================
 !       ==  CALCULATE <PHI(+)|PHI(+)>-1 WITH PRESENT LAMBDA                   ==
@@ -2547,6 +2572,11 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !       == CHECK CONVERGENCE MAXVAL(ABS(OVERLAP-1))<EPS ; GAMN=OVERLAP-1      ==
 !       ========================================================================
         DIGAM=MAXVAL(ABS(GAMN))
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T1)
+        ACCEL_ORTHOX_RESIDUAL_T=ACCEL_ORTHOX_RESIDUAL_T &
+     &                         +ACCEL_ORTHOX_T1-ACCEL_ORTHOX_T0
+#ENDIF
 !       __CHECK CONVERGENCE_____________________________________________________
         IF(DIGAM.LT.EPS) THEN
           TCONVERGED=.TRUE.
@@ -2568,6 +2598,9 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !       ========================================================================
 !       ==  OBTAIN CHANGE OF THE LAMBDA MATRIX                                ==
 !       ========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T0)
+#ENDIF
 !       == TRANSFORM OVERLAP MATRIX GAMN
 !       ----  HAUX(I,L)=U(K,I)*H0(K,L)
         CALL LIB$SCALARPRODUCTR8(.FALSE.,NB,NB,U,NB,GAMN,HAUX)
@@ -2620,6 +2653,11 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
             END IF
           ENDDO
         ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_ORTHOX_T1)
+        ACCEL_ORTHOX_UPDATE_T=ACCEL_ORTHOX_UPDATE_T &
+     &                       +ACCEL_ORTHOX_T1-ACCEL_ORTHOX_T0
+#ENDIF
       ENDDO
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
 !$ACC END DATA
@@ -2637,6 +2675,17 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
       
 !
 9000  CONTINUE
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_X_RESIDUAL' &
+     &    ,INT(NB,KIND=8),INT(ACCEL_ORTHOX_ITER,KIND=8),0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_ORTHOX_RESIDUAL_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_X_UPDATE' &
+     &    ,INT(NB,KIND=8),INT(ACCEL_ORTHOX_ITER,KIND=8),0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_ORTHOX_UPDATE_T)
+      CALL ACCELPROFILE$ADD('PAW_ORTHO_X_ITERATIONS' &
+     &    ,INT(NB,KIND=8),INT(ACCEL_ORTHOX_ITER,KIND=8),0_8,0_8 &
+     &    ,0.D0,0.D0,0.D0)
+#ENDIF
       DEALLOCATE(GAMN)
                              CALL TRACE$POP
       RETURN

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -102,6 +102,9 @@ kernel instrumentation.
 Gram-Schmidt setup is split by `PAW_GRAM_*` rows. These are nested PAW
 diagnostic envelopes: use them to identify the next target, not as additive
 wall-clock accounting.
+The real safe-orthogonalization solver is split further by `PAW_ORTHO_X_DIAG`,
+`PAW_ORTHO_X_RESIDUAL`, `PAW_ORTHO_X_UPDATE`, and
+`PAW_ORTHO_X_ITERATIONS`. These rows are nested inside `PAW_ORTHO_SOLVE`.
 Residency-profile builds enable the initial Gram-Schmidt Cholesky solve by
 default. It replaces only the initial `WAVES$GRAMMSCHMIDT` solve with a LAPACK
 Cholesky orthogonalization when the overlap matrix is positive definite;

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -615,6 +615,37 @@ enough to remove the dominant bottleneck; a later cuSOLVER `potrf/trtri` variant
 is only worth pursuing if larger runs show that this remaining sub-second block
 grows again.
 
+## Real Ortho-X Solver Profiling
+
+The next diagnostic patch keeps the numerical path unchanged and splits the
+real `WAVES_ORTHO_X` solver inside `PAW_ORTHO_SOLVE` into diagonalization,
+residual construction, update, and iteration-count rows. This was added after a
+naive exact Cholesky-root experiment was rejected: on the 512-band smoke it
+completed but changed the final energy from 302.280854 Ha to 322.671562 Ha.
+That means any future exact solve must preserve the physically relevant root
+near the current `LAMBDA`, not merely satisfy the quadratic orthogonality
+equation.
+
+Spark C86C validation:
+
+```
+runs/orthox-profile-smoke512-20260531-145356
+runs/orthox-profile-smoke2048-20260531-145404
+runs/orthox-profile-parallel-smoke512-20260531-145527
+```
+
+| Case | Empty bands | Ranks | Wall time | `PAW_ORTHO_SOLVE` | `PAW_ORTHO_X_DIAG` | `PAW_ORTHO_X_RESIDUAL` | `PAW_ORTHO_X_UPDATE` | Iterations | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Serial smoke | 512 | 1 | 7.17 s | - | - | - | - | - | 302.280854 Ha |
+| Serial large-band smoke | 2048 | 1 | 40.27 s | 8.5702 s | 0.2726 s | 2.8195 s | 5.2874 s | 24 | 302.280854 Ha |
+| Parallel smoke | 512 | 4 | 9.31 s | - | - | - | - | - | 302.280854 Ha |
+
+The 2048-band solve now has a precise split: the update half dominates, not the
+initial diagonalization. The next implementation attempt should therefore aim
+to reduce the 24 Newton-style update iterations or keep the update operands
+resident across the transform/back-transform sequence, while preserving the
+root selected by the current iterative algorithm.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Summary
- split the real `WAVES_ORTHO_X` solver into diagnostic profile rows for diagonalization, residual construction, update, and iteration count
- document the rows in the profiling README and Spark benchmark summary
- keep the numerical path unchanged; this is diagnostic-only follow-up after the initial Gram-Schmidt Cholesky speedup

## Spark C86C validation
Serial and parallel builds both completed:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

| Case | Empty bands | Ranks | Wall time | `PAW_ORTHO_SOLVE` | `PAW_ORTHO_X_DIAG` | `PAW_ORTHO_X_RESIDUAL` | `PAW_ORTHO_X_UPDATE` | Iterations | Final energy |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial smoke | 512 | 1 | 7.17 s | - | - | - | - | - | 302.280854 Ha |
| Serial large-band smoke | 2048 | 1 | 40.27 s | 8.5702 s | 0.2726 s | 2.8195 s | 5.2874 s | 24 | 302.280854 Ha |
| Parallel smoke | 512 | 4 | 9.31 s | - | - | - | - | - | 302.280854 Ha |

Run directories:
- `runs/orthox-profile-smoke512-20260531-145356`
- `runs/orthox-profile-smoke2048-20260531-145404`
- `runs/orthox-profile-parallel-smoke512-20260531-145527`

Note: a naive exact Cholesky-root experiment was rejected before this PR because it changed the 512-band final energy from 302.280854 Ha to 322.671562 Ha. This PR keeps only the safe instrumentation and records that future exact-solve work must preserve the root selected by the iterative algorithm.

## Local checks
- `git diff --check`
- `tests/profile/si64/check_harness.sh`