### PR TITLE
Add Ortho-X no-sync diagnostic case

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -175,11 +175,13 @@ disappearance or reduction of `ACC_COPY_PROJ_PRO_IN`. The resident overlap
 cuBLAS kernels are timed separately as `CUBLAS_ZHERK_OVL_RES` and
 `CUBLAS_ZGEMM_OVL_RES`. This is the recommended NVHPC GPU performance path for
 the larger Si64 band benchmarks. Keep
-`gpu_resident_nosync` as a diagnostic candidate until longer correctness runs
-confirm that removing the explicit post-cuBLAS synchronization is safe for the
-target workload. For non-inversion wave sets, the residency mode also keeps the
-orthogonalization `WAVES_ADDOPSI` addproduct in a short OpenACC data region;
-`ACC_COPY_CUBLAS_ADDOPSI_RES_REGION` records that region's copy estimate.
+`gpu_resident_nosync` and `gpu_resident_orthox_nosync` as diagnostic candidates
+only; Spark Nsight traces show that removing the explicit post-cuBLAS
+synchronization mostly shifts waiting time into later stream synchronizations or
+copy calls for this workload. For non-inversion wave sets, the residency mode
+also keeps the orthogonalization `WAVES_ADDOPSI` addproduct in a short OpenACC
+data region; `ACC_COPY_CUBLAS_ADDOPSI_RES_REGION` records that region's copy
+estimate.
 
 The residency profile also records semantic OpenACC present checks for the PAW
 wavefunction arrays that dominate this follow-up. `ACC_PRESENT_*` rows count
@@ -249,6 +251,7 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_1coverlap` / `gpu_resident_1coverlap_host` | Residency diagnostics that force or disable the one-center overlap cuBLAS path via `CPPAW_GPU_1COVERLAP`. |
 | `gpu_resident_orthoconst` | Residency diagnostic with opt-in `WAVES_ORTHO_X` constant-input residency enabled via `CPPAW_GPU_ORTHO_CONST_RESIDENCY=1`. |
 | `gpu_resident_orthox` | Residency diagnostic with the real `WAVES_ORTHO_X` iteration workspace kept on the GPU via `CPPAW_GPU_ORTHO_X_RESIDENCY=1`. |
+| `gpu_resident_orthox_nosync` | Diagnostic that combines `gpu_resident_orthox` with `CPPAW_CUBLAS_ACC_SYNC=0`; use for profiling synchronization overhead, not as the default. |
 | `gpu_resident_projection_conservative` / `gpu_resident_overlap_conservative` / `gpu_resident_addproduct_conservative` / `gpu_resident_matmul_conservative` | Residency diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident_force_all` | Residency diagnostic that also forces cuFFT and small cuSOLVER offload. |
 | `gpu_resident_off` | Residency binary with native cuFFT/cuBLAS/cuSOLVER disabled for same-executable fallback comparison. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -750,6 +750,27 @@ Both 512-band traces produced `nsys.nsys-rep`, `nsys_profile.csv`, and
 `CUBLAS_DGEMM_ORTHOX_TRANSFORM`, and `CUBLAS_DGEMM_ORTHOX_BACKTRANS` in the
 profile CSV.
 
+The 2048-band Nsight comparison made the synchronization tradeoff explicit:
+
+```
+runs/nsys-case-gpu_resident-smoke2048-20260531-155236
+runs/nsys-case-gpu_resident_orthox-smoke2048-20260531-155323
+runs/nsys-case-gpu_resident_orthox_nosync-smoke2048-20260531-155936
+runs/orthox-nosync-case2048-20260531-155722
+```
+
+| Case | Wall time | Instrumented rank-s | Gap | Copy estimate | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_orthox` | 39.54 s | 24.7906 s | 14.7494 s | 8.2058 GB | 302.280854 Ha |
+| `gpu_resident_orthox_nosync` | 39.73 s | 17.2575 s | 22.4725 s | 8.2058 GB | 302.280854 Ha |
+| `gpu_resident_nosync` | 41.14 s | 24.4806 s | 16.6594 s | 22.1456 GB | 302.280854 Ha |
+
+`gpu_resident_orthox_nosync` removes the explicit cuBLAS-side
+`cudaDeviceSynchronize` time from the instrumented rows, but the Nsight trace
+then shows the waiting time reappearing in `cuStreamSynchronize` and
+device-to-host runtime calls. The case is therefore useful for profiling
+attribution, but it is not a new recommended default on Spark.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -227,6 +227,9 @@ case_note() {
     gpu_resident_orthox)
       echo "Residency diagnostic that keeps the WAVES_ORTHO_X iteration workspace on the GPU."
       ;;
+    gpu_resident_orthox_nosync)
+      echo "Residency diagnostic that combines WAVES_ORTHO_X workspace residency with disabled post-cuBLAS device synchronization."
+      ;;
     gpu_resident_1coverlap_host)
       echo "Residency diagnostic that disables only the one-center overlap cuBLAS path."
       ;;
@@ -410,6 +413,7 @@ case_env() {
     gpu_resident_forcepsi_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_FORCE_PSI_RESIDENCY=0 $(cublas_env)" ;;
     gpu_resident_orthoconst) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_CONST_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_orthox) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_X_RESIDENCY=1 $(cublas_env)" ;;
+    gpu_resident_orthox_nosync) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_X_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_SYNC=0" ;;
     gpu_resident_1coverlap_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=0 $(cublas_env)" ;;
     gpu_resident_gram_cholesky) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=1 $(cublas_env)" ;;
     gpu_resident_gram_legacy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=0 $(cublas_env)" ;;

--- a/tests/profile/si64/run_nsys.sh
+++ b/tests/profile/si64/run_nsys.sh
@@ -213,6 +213,7 @@ case_env() {
     gpu_resident) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_nosync) echo "CPPAW_GPU_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_SYNC=0" ;;
     gpu_resident_orthox) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_X_RESIDENCY=1 $(cublas_env)" ;;
+    gpu_resident_orthox_nosync) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_X_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_SYNC=0" ;;
     gpu_resident_orthoconst) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_CONST_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_addpro_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ADDPRO_CACHE=0 $(cublas_env)" ;;
     gpu_resident_pro_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PRO_EXPANSION=0 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary
- add `gpu_resident_orthox_nosync` to the benchmark and Nsight harnesses
- combine `CPPAW_GPU_ORTHO_X_RESIDENCY=1` with `CPPAW_CUBLAS_ACC_SYNC=0` for synchronization-attribution experiments
- document that this is a diagnostic case, not a new default

## Spark validation
- `TEST=si64_bands EMPTY_BANDS=2048 NSTEPS=1 RANKS=1 CASES="gpu_resident_orthox gpu_resident_orthox_nosync gpu_resident_nosync"`
- `gpu_resident_orthox`: 39.54 s, energy 302.280854 Ha, copy estimate 8.2058 GB
- `gpu_resident_orthox_nosync`: 39.73 s, energy 302.280854 Ha, copy estimate 8.2058 GB
- `gpu_resident_nosync`: 41.14 s, energy 302.280854 Ha, copy estimate 22.1456 GB
- Nsight for `gpu_resident_orthox_nosync`: 45.08 s under trace, energy 302.280854 Ha; explicit `cudaDeviceSynchronize` nearly disappears, but wait time moves into `cuStreamSynchronize` and device-to-host runtime calls

## Checks
- `bash -n tests/profile/si64/run_benchmark.sh`
- `bash -n tests/profile/si64/run_nsys.sh`
- `tests/profile/si64/check_harness.sh`
- `git diff --check`
