### PR TITLE
Summarize Nsight SQLite traces

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -462,7 +462,10 @@ CASE=gpu_resident NSTEPS=1 ./run_nsys.sh
 `run_nsys.sh` accepts the same GPU-oriented case names as the benchmark harness,
 for example `gpu_resident`, `gpu_resident_orthox`, `gpu_all`, `gpu_no_cufft`,
 `cublas`, `cusolver`, and `cufft`. It writes `nsys_case.env` into the run
-directory so a trace can be matched to the executable and runtime switches.
+directory so a trace can be matched to the executable and runtime switches. If
+Nsight leaves a SQLite export next to the report, the harness also writes
+`nsys_sql_summary.txt` with the top CUDA kernels, runtime calls, memcpy totals,
+and synchronization totals.
 For `RANKS>1` the Nsight harness wraps `mpirun` and writes one combined
 `nsys_mpi.nsys-rep` report, which is robust for CP-PAW's current `MPI_ABORT(0)`
 shutdown path. For runs that finalize MPI normally, `NSYS_MPI_MODE=per_rank`

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -27,7 +27,8 @@ bash -n src/Tools/Scripts/paw_gpu_capabilities.sh
 python3 -m py_compile \
   tests/profile/si64/profile_summary.py \
   tests/profile/si64/benchmark_summary.py \
-  tests/profile/si64/benchmark_markdown.py
+  tests/profile/si64/benchmark_markdown.py \
+  tests/profile/si64/nsys_sql_summary.py
 
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc

--- a/tests/profile/si64/nsys_sql_summary.py
+++ b/tests/profile/si64/nsys_sql_summary.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Summarize Nsight Systems SQLite exports for CP-PAW traces."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+from collections.abc import Iterable
+
+
+def has_table(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "select 1 from sqlite_master where type='table' and name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def enum_labels(conn: sqlite3.Connection, table: str) -> dict[int, str]:
+    if not has_table(conn, table):
+        return {}
+    labels: dict[int, str] = {}
+    for row in conn.execute(f"select id, coalesce(label, name) from {table}"):
+        labels[int(row[0])] = str(row[1])
+    return labels
+
+
+def print_rows(title: str, rows: Iterable[tuple[object, ...]]) -> None:
+    print(title)
+    for row in rows:
+        print("  " + "  ".join(str(value) for value in row))
+    print()
+
+
+def top_stringid_rows(
+    conn: sqlite3.Connection, table: str, id_column: str, limit: int
+) -> list[tuple[str, int, str]]:
+    if not has_table(conn, table) or not has_table(conn, "StringIds"):
+        return []
+    return conn.execute(
+        f"""
+        select s.value, count(*) as calls,
+               printf('%.6f s', sum(t.end - t.start) / 1e9) as seconds
+          from {table} t
+          join StringIds s on s.id = t.{id_column}
+         group by s.value
+         order by sum(t.end - t.start) desc
+         limit ?
+        """,
+        (limit,),
+    ).fetchall()
+
+
+def summarize_memcpy(conn: sqlite3.Connection) -> list[tuple[str, int, str, str]]:
+    if not has_table(conn, "CUPTI_ACTIVITY_KIND_MEMCPY"):
+        return []
+    labels = enum_labels(conn, "ENUM_CUDA_MEMCPY_OPER")
+    rows = conn.execute(
+        """
+        select copyKind, count(*) as calls, sum(bytes) as bytes,
+               sum(end - start) / 1e9 as seconds
+          from CUPTI_ACTIVITY_KIND_MEMCPY
+         group by copyKind
+         order by sum(end - start) desc
+        """
+    ).fetchall()
+    return [
+        (
+            labels.get(int(kind), str(kind)),
+            int(calls),
+            f"{int(byte_count) / 1e9:.6f} GB",
+            f"{float(seconds):.6f} s",
+        )
+        for kind, calls, byte_count, seconds in rows
+    ]
+
+
+def summarize_sync(conn: sqlite3.Connection) -> list[tuple[str, int, str]]:
+    if not has_table(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"):
+        return []
+    labels = enum_labels(conn, "ENUM_CUPTI_SYNC_TYPE")
+    rows = conn.execute(
+        """
+        select syncType, count(*) as calls, sum(end - start) / 1e9 as seconds
+          from CUPTI_ACTIVITY_KIND_SYNCHRONIZATION
+         group by syncType
+         order by sum(end - start) desc
+        """
+    ).fetchall()
+    return [
+        (labels.get(int(kind), str(kind)), int(calls), f"{float(seconds):.6f} s")
+        for kind, calls, seconds in rows
+    ]
+
+
+def summarize(path: str, limit: int) -> None:
+    print(f"## {path}")
+    with sqlite3.connect(path) as conn:
+        print_rows(
+            "Top CUDA kernels",
+            top_stringid_rows(conn, "CUPTI_ACTIVITY_KIND_KERNEL", "shortName", limit),
+        )
+        print_rows(
+            "Top CUDA runtime calls",
+            top_stringid_rows(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId", limit),
+        )
+        print_rows("CUDA memcpy summary", summarize_memcpy(conn))
+        print_rows("CUDA synchronization summary", summarize_sync(conn))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Summarize CUDA activity from Nsight Systems SQLite files."
+    )
+    parser.add_argument("sqlite", nargs="+", help="Nsight Systems .sqlite file(s)")
+    parser.add_argument("--limit", type=int, default=12, help="Top rows to print")
+    args = parser.parse_args()
+
+    for index, path in enumerate(args.sqlite):
+        if index:
+            print()
+        summarize(os.path.abspath(path), args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -771,6 +771,14 @@ then shows the waiting time reappearing in `cuStreamSynchronize` and
 device-to-host runtime calls. The case is therefore useful for profiling
 attribution, but it is not a new recommended default on Spark.
 
+The Nsight harness also writes a compact SQL-derived CUDA activity summary when
+Nsight leaves a `.sqlite` export. Smoke run
+`runs/nsys-sql-summary-smoke512-20260531-160604` produced
+`nsys_sql_summary.txt` with top kernel, runtime, memcpy, and synchronization
+tables; for the `gpu_resident_orthox_nosync` smoke it highlighted
+`cuStreamSynchronize` as the leading runtime row and kept the energy unchanged
+at 302.280854 Ha.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:

--- a/tests/profile/si64/run_nsys.sh
+++ b/tests/profile/si64/run_nsys.sh
@@ -269,6 +269,7 @@ fi
 cp "${CNTL_FILE}" "${RUN_ROOT}/${TEST}.cntl"
 cp "${STRC_FILE}" "${RUN_ROOT}/${TEST}.strc"
 cp "${HERE}/profile_summary.py" "${RUN_ROOT}/"
+cp "${HERE}/nsys_sql_summary.py" "${RUN_ROOT}/"
 cp "${ROOT}/tests/fulltests/si2/stp.cntl" "${RUN_ROOT}/"
 perl -0pi -e "s/NSTEP\\s*=\\s*\\d+/NSTEP=${NSTEPS}/" "${RUN_ROOT}/${TEST}.cntl"
 if [[ -n "${EMPTY_BANDS:-}" ]]; then
@@ -310,5 +311,8 @@ echo "running Nsight Systems case ${CASE}: ${CMD}"
 /usr/bin/time -p ${TIMEOUT_PREFIX} ${CMD} > out.log 2> err.log
 
 python3 profile_summary.py nsys_profile*.csv > summary.txt
+if compgen -G "*.sqlite" >/dev/null; then
+  python3 nsys_sql_summary.py ./*.sqlite > nsys_sql_summary.txt || true
+fi
 grep -E "^real |^user |^sys " err.log > time.txt || true
 echo "Nsight data: ${RUN_ROOT}"


### PR DESCRIPTION
## Summary
- add `tests/profile/si64/nsys_sql_summary.py` for compact CUDA activity summaries from Nsight `.sqlite` exports
- have `run_nsys.sh` copy the helper and write `nsys_sql_summary.txt` whenever a SQLite export is present
- include the new helper in the profile harness syntax/compile check

## Spark validation
- existing 2048-band `gpu_resident_orthox_nosync` Nsight SQLite export summarized successfully; it reported top CUDA kernels, runtime calls, memcpy totals, and synchronization totals
- `CASE=gpu_resident_orthox_nosync TEST=si64_bands EMPTY_BANDS=512 NSTEPS=1 RANKS=1 ./run_nsys.sh` produced `nsys_sql_summary.txt`
- 512-band smoke energy remained 302.280854 Ha

## Checks
- `tests/profile/si64/check_harness.sh`
- `git diff --check`
