### PR TITLE
Invert ADDOPSI input on device

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -771,6 +771,14 @@ END IF
 !      **   FOR A ROUTINE THAT PRESERVES OPSI                                 **
 !      **                                                                     **
 !      *************************************************************************
+       USE PLANEWAVE_MODULE
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+       USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &        CPPAW_CUBLAS_ACC_RESIDENCY_ENABLED &
+     &       ,CPPAW_CUBLAS_ACC_INVERSION_BATCH_ENABLED &
+     &       ,CPPAW_CUBLAS_ACC_SHOULD_USE_ADDPRODUCT &
+     &       ,CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D
+#ENDIF
        IMPLICIT NONE
        INTEGER(4),INTENT(IN)   :: NGL
        INTEGER(4),INTENT(IN)   :: NDIM
@@ -785,6 +793,13 @@ END IF
        COMPLEX(8),ALLOCATABLE  :: LAMBDA1(:,:)
        COMPLEX(8),ALLOCATABLE  :: LAMBDA2(:,:)
        COMPLEX(8),ALLOCATABLE  :: TPSI(:)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+       COMPLEX(8),ALLOCATABLE  :: OPSIINV(:,:)
+       INTEGER(4),POINTER      :: MINUSGACC(:)
+       LOGICAL(4)              :: TUSEACCINVERT
+       REAL(8)                 :: ACCINVFLOPS
+       INTEGER(4)              :: IG
+#ENDIF
        COMPLEX(8),PARAMETER    :: CI=(0.D0,1.D0)
        COMPLEX(8)              :: CSVAR1,CSVAR2
        INTEGER(4)              :: NGLNDIM
@@ -799,6 +814,9 @@ END IF
 #ENDIF
        TINV=NBH.NE.NB
        NGLNDIM=NGL*NDIM
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+       TUSEACCINVERT=.FALSE.
+#ENDIF
        IF(.NOT.TINV) THEN
 !        == PSIBAR=PSIBAR+OPSI*LAMBDA ==========================================
          CALL LIB$ADDPRODUCTC8(.FALSE.,NGLNDIM,NBH,NBH,OPSI,LAMBDA,PSIBAR)
@@ -817,6 +835,58 @@ END IF
              LAMBDA2(IBH1,IBH2)=0.5D0*(CSVAR1+CSVAR2)
            ENDDO
          ENDDO
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+         ACCINVFLOPS=8.D0*REAL(NGLNDIM,KIND=8) &
+     &                    *REAL(NBH,KIND=8)*REAL(NBH,KIND=8)
+         TUSEACCINVERT=CPPAW_CUBLAS_ACC_RESIDENCY_ENABLED() &
+     &     .AND.CPPAW_CUBLAS_ACC_INVERSION_BATCH_ENABLED() &
+     &     .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_ADDPRODUCT(ACCINVFLOPS)
+         IF(TUSEACCINVERT) THEN
+           ALLOCATE(OPSIINV(NGLNDIM,NBH))
+           MINUSGACC=>THIS%MINUSG
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
+     &         ('ACC_PRESENT_ADDOPSI_OPSI_TINV' &
+     &         ,'ACC_COPY_ADDOPSI_OPSI_TINV_IN',NGLNDIM,NBH,OPSI)
+           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
+     &         ('ACC_PRESENT_ADDOPSI_LAM1_TINV' &
+     &         ,'ACC_COPY_ADDOPSI_LAM1_TINV_IN',NBH,NBH,LAMBDA1)
+           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
+     &         ('ACC_PRESENT_ADDOPSI_LAM2_TINV' &
+     &         ,'ACC_COPY_ADDOPSI_LAM2_TINV_IN',NBH,NBH,LAMBDA2)
+#ENDIF
+!$ACC DATA COPYIN(OPSI(1:NGLNDIM,1:NBH),LAMBDA1(1:NBH,1:NBH) &
+!$ACC&          ,LAMBDA2(1:NBH,1:NBH),MINUSGACC(1:NGL)) &
+!$ACC& CREATE(OPSIINV(1:NGLNDIM,1:NBH))
+!          == ADD O|PSI_+>LAMBDA1 ==============================================
+           CALL LIB$ADDPRODUCTC8(.FALSE.,NGLNDIM,NBH,NBH,OPSI &
+     &                          ,LAMBDA1,PSIBAR)
+!          == BUILD INVERTED OPSI ON DEVICE ====================================
+!$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(I) PRESENT(OPSI,OPSIINV,MINUSGACC)
+           DO IBH1=1,NBH
+             DO IDIM=1,NDIM
+               DO IG=1,NGL
+                 I=(IDIM-1)*NGL+IG
+                 OPSIINV(I,IBH1)=CONJG(OPSI((IDIM-1)*NGL &
+     &                                      +MINUSGACC(IG),IBH1))
+               ENDDO
+             ENDDO
+           ENDDO
+!$ACC END PARALLEL LOOP
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
+     &         ('ACC_PRESENT_ADDOPSI_OPSIINV_TINV' &
+     &         ,'ACC_COPY_ADDOPSI_OPSIINV_TINV_IN',NGLNDIM,NBH,OPSIINV)
+#ENDIF
+!          == ADD O|PSI_->LAMBDA2 ==============================================
+           CALL LIB$ADDPRODUCTC8(.FALSE.,NGLNDIM,NBH,NBH,OPSIINV &
+     &                          ,LAMBDA2,PSIBAR)
+!$ACC END DATA
+           DEALLOCATE(OPSIINV)
+           DEALLOCATE(LAMBDA1)
+           DEALLOCATE(LAMBDA2)
+         ELSE
+#ENDIF
 !        == ADD O|PSI_+>LAMBDA1 ================================================
          CALL LIB$ADDPRODUCTC8(.FALSE.,NGLNDIM,NBH,NBH,OPSI,LAMBDA1,PSIBAR)
          DEALLOCATE(LAMBDA1)
@@ -835,6 +905,9 @@ END IF
 !        == ADD O|PSI_+>LAMBDA1 ================================================
          CALL LIB$ADDPRODUCTC8(.FALSE.,NGLNDIM,NBH,NBH,OPSI,LAMBDA2,PSIBAR)
          DEALLOCATE(LAMBDA2)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+         END IF
+#ENDIF
        END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
        CALL ACCELPROFILE$NOW(ACCEL_T1)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -187,6 +187,9 @@ region, recorded as `ACC_PRESENT_ADDOPSI_PSIM` /
 are copied into the same region. For inversion-symmetric wave sets, `OPSI` and
 the temporary lambda blocks still use the per-call cuBLAS wrapper copies
 because `OPSI` is inverted on the host between the two addproduct calls.
+With the inversion-batch GPU path enabled, the inversion-symmetric path copies
+`OPSI` once as `ACC_COPY_ADDOPSI_OPSI_TINV_IN`, creates the inverted
+`OPSIINV` on the device, and reports it as `ACC_PRESENT_ADDOPSI_OPSIINV_TINV`.
 
 The residency profile also records semantic OpenACC present checks for the PAW
 wavefunction arrays that dominate this follow-up. `ACC_PRESENT_*` rows count

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -935,6 +935,37 @@ estimate drops from 6.1555 GB to 5.6982 GB. The remaining
 `ACC_COPY_CUBLAS_ZGEMM_NN_A_IN` rows now correspond to the `WAVES_ADDOPSI`
 `OPSI` inputs, not the Gram transform scratch copy.
 
+### ADDOPSI Device Inversion
+
+The inversion-symmetric `WAVES_ADDOPSI` path now uses the same inversion-batch
+idea as the plane-wave addproduct helper. The residency-profile GPU path copies
+`OPSI` once, builds an inverted `OPSIINV` scratch array on the device using
+`MINUSG`, and runs both addproducts with present inputs. The original host
+inversion branch remains the fallback when residency or inversion batching is
+disabled.
+
+Spark C86C validation:
+
+```
+runs/addopsi-device-inversion512-20260531-170700
+runs/addopsi-device-inversion2048-20260531-170715
+runs/addopsi-device-inversion-parallel512-20260531-170835
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | `OPSI_TINV_IN` | `OPSIINV_TINV` | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident` | 512 | 1 | 7.27 s | 2.2230 GB | 1 call, 0.0672 GB | present, 1 call | 302.280854 Ha |
+| `gpu_resident_orthox` | 512 | 1 | 7.41 s | 1.5119 GB | 1 call, 0.0672 GB | present, 1 call | 302.280854 Ha |
+| `gpu_resident` | 512 | 4 | 9.32 s | 4.7465 GB | 1 call, 0.0168 GB per rank | present, 1 call per rank | 302.280854 Ha |
+| `gpu_resident` | 2048 | 1 | 40.98 s | 21.1897 GB | 1 call, 0.2286 GB | present, 1 call | 302.280854 Ha |
+| `gpu_resident_orthox` | 2048 | 1 | 39.37 s | 5.4696 GB | 1 call, 0.2286 GB | present, 1 call | 302.280854 Ha |
+
+Compared with the Gram-transform device-input run, the 2048-band orthox copy
+estimate drops from 5.6982 GB to 5.4696 GB. The remaining large wavefunction
+copy rows are now outside this local addproduct path: the outer Gram
+`PSI` input/output region, projection wavefunction inputs, and force/setup
+wavefunction copies.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Summary
- add a residency-profile GPU path for inversion-symmetric `WAVES_ADDOPSI`
- copy `OPSI` once, build inverted `OPSIINV` on the device via `MINUSG`, and run both addproducts with present inputs
- keep the existing host inversion branch as the fallback when residency/inversion batching is disabled

## Spark C86C validation
- `nvhpc_gpu_acc_residency_profile` build
- `nvhpc_gpu_acc_residency_profile_parallel` build
- `runs/addopsi-device-inversion512-20260531-170700`
- `runs/addopsi-device-inversion2048-20260531-170715`
- `runs/addopsi-device-inversion-parallel512-20260531-170835`

## Key results
| Case | Empty bands | Ranks | Wall time | Copy estimate | Final energy |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident` | 512 | 1 | 7.27 s | 2.2230 GB | 302.280854 Ha |
| `gpu_resident_orthox` | 512 | 1 | 7.41 s | 1.5119 GB | 302.280854 Ha |
| `gpu_resident` | 512 | 4 | 9.32 s | 4.7465 GB | 302.280854 Ha |
| `gpu_resident` | 2048 | 1 | 40.98 s | 21.1897 GB | 302.280854 Ha |
| `gpu_resident_orthox` | 2048 | 1 | 39.37 s | 5.4696 GB | 302.280854 Ha |

In the 2048-band `gpu_resident_orthox` profile, the ADDOPSI TINV path reports `ACC_COPY_ADDOPSI_OPSI_TINV_IN` once at 0.2286 GB and `ACC_PRESENT_ADDOPSI_OPSIINV_TINV` for the device-built inverted scratch. The generic `ACC_COPY_CUBLAS_ZGEMM_NN_A_IN/B_IN` rows disappear for this local addproduct path.
