### PR TITLE
Check Si64 benchmark energy in profiling harness

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -97,6 +97,11 @@ High-level `PHASE_*` timers are reported separately as `phase_s` and
 because they are coarse envelopes around existing numerical kernel timers. Use
 the phase columns to localize unexplained wall time before adding lower-level
 kernel instrumentation.
+For the bundled `si64` and `si64_bands` cases, the harness also checks the
+final constant energy against the built-in reference (`EXPECTED_ENERGY`,
+default `302.280854`) with `ENERGY_TOL=1e-5`. A run with normal termination but
+an energy mismatch is reported as `ok=no` and carries `energy_delta` in the TSV
+and Markdown summaries.
 
 `WAVES$ETOT` is split further by `PAW_ETOT_*` rows, and the initial
 Gram-Schmidt setup is split by `PAW_GRAM_*` rows. These are nested PAW
@@ -464,9 +469,9 @@ NSTEPS=20 RANKS=4 REPEATS=3 CASES="nvhpc_cpu cublas cublas_off" ./run_benchmark.
 
 The harness creates timestamped directories under `tests/profile/si64/runs`,
 writes per-run logs and profile CSV files, and emits a `benchmark.tsv` summary
-with wall time, instrumented rank-seconds, category timings and final energy.
-It also writes a Markdown table (`benchmark.md` or `combined_benchmark.md`) that
-can be pasted directly into pull request comments.
+with wall time, instrumented rank-seconds, category timings, final energy and
+the optional energy delta. It also writes a Markdown table (`benchmark.md` or
+`combined_benchmark.md`) that can be pasted directly into pull request comments.
 
 For a short Nsight Systems trace of the recommended combined GPU profile binary:
 

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -5,11 +5,11 @@ import re
 import sys
 
 
-def number(value):
+def number(value, digits=2):
     if value is None or value == "":
         return ""
     try:
-        return f"{float(value):.2f}"
+        return f"{float(value):.{digits}f}"
     except ValueError:
         return str(value)
 
@@ -46,11 +46,11 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | phase_s | phase_gap_s | copy_gb | energy |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | phase_s | phase_gap_s | copy_gb | energy | energy_delta |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
@@ -68,7 +68,8 @@ def main(argv):
                 number(row.get("phase_s")),
                 number(row.get("phase_gap_s")),
                 number(row.get("copy_gb")),
-                number(row.get("energy")),
+                number(row.get("energy"), 6),
+                number(row.get("energy_delta"), 6),
             )
         )
     return 0

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -102,6 +102,21 @@ def run_ok(run_dir):
     return "NORMAL STOP" in text
 
 
+def energy_check(energy, env):
+    expected = env.get("expected_energy") or env.get("EXPECTED_ENERGY")
+    if not expected:
+        return None, None
+    if energy is None:
+        return None, False
+    try:
+        expected_value = float(expected)
+        tolerance = float(env.get("energy_tol") or env.get("ENERGY_TOL") or "1e-5")
+    except ValueError:
+        return None, False
+    delta = abs(energy - expected_value)
+    return delta, delta <= tolerance
+
+
 def wall_rank_time(wall, ranks):
     if wall is None:
         return None
@@ -121,6 +136,9 @@ def main(argv):
         env = run_env(run_dir)
         wall = wall_time(run_dir)
         wall_rank = wall_rank_time(wall, env.get("ranks"))
+        energy = final_energy(run_dir)
+        energy_delta, energy_is_ok = energy_check(energy, env)
+        ok = run_ok(run_dir) and (energy_is_ok is not False)
         gap = None
         coverage = None
         phase_gap = None
@@ -135,7 +153,7 @@ def main(argv):
                 "repeat": repeat,
                 "nsteps": env.get("nsteps") or env.get("nstps"),
                 "ranks": env.get("ranks"),
-                "ok": "yes" if run_ok(run_dir) else "no",
+                "ok": "yes" if ok else "no",
                 "wall_s": wall,
                 "wall_rank_s": wall_rank,
                 "rank_s": totals["instrumented"],
@@ -151,7 +169,11 @@ def main(argv):
                 "phase_gap_s": phase_gap,
                 "setup_s": totals["setup"],
                 "copy_gb": totals["copy_gb"],
-                "energy": final_energy(run_dir),
+                "energy": energy,
+                "energy_delta": energy_delta,
+                "energy_ok": (
+                    "" if energy_is_ok is None else ("yes" if energy_is_ok else "no")
+                ),
                 "env": env.get("env"),
             }
         )
@@ -182,6 +204,8 @@ def main(argv):
         "setup_s",
         "copy_gb",
         "energy",
+        "energy_delta",
+        "energy_ok",
         "env",
     ]
     print("\t".join(fields))

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -17,6 +17,8 @@ REQUIRE_CASES=${REQUIRE_CASES:-no}
 RUN_ROOT=${RUN_ROOT:-"${HERE}/runs/${TEST}-nstep${NSTEPS}-${RANKS}ranks-$(date +%Y%m%d-%H%M%S)"}
 MPI_ARGS=${MPI_ARGS:---mca coll ^hcoll}
 CASES=${CASES:-"cpu nvhpc_cpu gpu_resident gpu_off"}
+EXPECTED_ENERGY=${EXPECTED_ENERGY:-}
+ENERGY_TOL=${ENERGY_TOL:-1e-5}
 TIMEOUT_PREFIX=""
 if command -v timeout >/dev/null 2>&1; then
   TIMEOUT_PREFIX="timeout ${TIMEOUT}s"
@@ -34,6 +36,10 @@ if [[ -z "${TIME_CMD}" ]]; then
   echo "External time command not found; set TIME_CMD or install GNU time." >&2
   exit 1
 fi
+
+case "${TEST}" in
+  si64|si64_bands) EXPECTED_ENERGY=${EXPECTED_ENERGY:-302.280854} ;;
+esac
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
@@ -490,6 +496,10 @@ capture_metadata() {
     echo "nsteps=${NSTEPS}"
     echo "ranks=${RANKS}"
     echo "cases=${CASES}"
+    if [[ -n "${EXPECTED_ENERGY}" ]]; then
+      echo "expected_energy=${EXPECTED_ENERGY}"
+      echo "energy_tol=${ENERGY_TOL}"
+    fi
     echo "threads=OMP_NUM_THREADS=${OMP_NUM_THREADS} OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS} MKL_NUM_THREADS=${MKL_NUM_THREADS} BLIS_NUM_THREADS=${BLIS_NUM_THREADS} VECLIB_MAXIMUM_THREADS=${VECLIB_MAXIMUM_THREADS} NVPL_NUM_THREADS=${NVPL_NUM_THREADS}"
     echo
     uname -a
@@ -547,6 +557,10 @@ for case_name in ${CASES}; do
         echo "ranks=${RANKS}"
         echo "exe=${exe}"
         echo "env=${env_line}"
+        if [[ -n "${EXPECTED_ENERGY}" ]]; then
+          echo "expected_energy=${EXPECTED_ENERGY}"
+          echo "energy_tol=${ENERGY_TOL}"
+        fi
         echo "threads=OMP_NUM_THREADS=${OMP_NUM_THREADS} OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS} MKL_NUM_THREADS=${MKL_NUM_THREADS} BLIS_NUM_THREADS=${BLIS_NUM_THREADS} VECLIB_MAXIMUM_THREADS=${VECLIB_MAXIMUM_THREADS} NVPL_NUM_THREADS=${NVPL_NUM_THREADS}"
         echo "start=$(iso_now)"
       } > run.env


### PR DESCRIPTION
## Summary
- add an energy reference check to the profiling benchmark summary
- default `si64` and `si64_bands` runs to `EXPECTED_ENERGY=302.280854` with `ENERGY_TOL=1e-5`
- report `energy_delta` / `energy_ok` and mark runs as `ok=no` when the energy is wrong despite normal termination

## Validation
- `tests/profile/si64/check_harness.sh`
- synthetic bad-run check: normal stop at `296.7528007461491 Ha` is reported as `ok=no`, `energy_delta=5.52805325`, `energy_ok=no`

This catches the exact failure mode seen in the rejected OPSI-residency experiment: CP-PAW can terminate normally while the physics result is wrong.
