### PR TITLE
Split projection residency copy profiling by context

### DIFF
--- a/src/paw_cg.f90
+++ b/src/paw_cg.f90
@@ -100,7 +100,7 @@ WRITE(*,"('CG-MIXER: POT   :',3F10.7)") V(1:3,1)
             ALLOCATE(R0(3,NAT))
             CALL ATOMLIST$GETR8A('R(0)',0,3*NAT,R0)
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R0,NGL,NDIM,NBH,MAP%NPRO &
-                ,THIS%PSI0,THIS%PROJ) 
+                ,THIS%PSI0,THIS%PROJ,'CG_STATE')
             DEALLOCATE(R0)
             !DEALLOCATE(PROJ)
             CALL TIMING$CLOCKOFF('CG-PRO2')
@@ -146,7 +146,7 @@ WRITE(*,"('CG-MIXER: POT   :',3F10.7)") V(1:3,1)
          IF(TNEWPRO) THEN
             CALL TIMING$CLOCKON('CG-PROJ')
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R0,NGL,1,1,NPRO &
-                 ,PSI,PROJ)
+                 ,PSI,PROJ,'CG_HPSI')
             CALL TIMING$CLOCKOFF('CG-PROJ')
          END IF
 !WRITE(*,"('HPSI PROJ 2',3F10.5)") REAL(PROJ(1,1:3))
@@ -168,7 +168,7 @@ WRITE(*,"('CG-MIXER: POT   :',3F10.7)") V(1:3,1)
          IF(TNEWPRO) THEN
             CALL TIMING$CLOCKON('CG-PROJ')
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R0,NGL,1,1,NPRO &
-                 ,PSI,PROJ)
+                 ,PSI,PROJ,'CG_OPSI')
             CALL TIMING$CLOCKOFF('CG-PROJ')
          END IF
 !WRITE(*,"('OPSI PROJ  ',3F10.5)") REAL(PROJ(1,1:3))
@@ -710,7 +710,5 @@ WRITE(*,*)
 !WRITE(*,"('NORM PROJ 2',3F10.5)") REAL(PROJ(1,1:3))
       RETURN
       END SUBROUTINE CG_INTERNAL_NORMALIZE
-
-
 
 

--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -3013,7 +3013,7 @@ END IF
           NBH=THIS%NBH
           IF(ID.EQ.'PSI0') THEN
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,MAP%NPRO &
-     &                            ,THIS%PSI0,THIS%PROJ)
+     &                            ,THIS%PSI0,THIS%PROJ,'SETUP0')
             CALL MPE$COMBINE('K','+',THIS%PROJ)
           ELSE
             CALL ERROR$MSG('ID NOT RECOGNIZED')
@@ -6416,7 +6416,8 @@ RETURN
       END
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
-      SUBROUTINE WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NB,NPRO,PSI,PROPSI)
+      SUBROUTINE WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NB,NPRO,PSI &
+     &                             ,PROPSI,PROFILE_ID)
 !     **************************************************************************
 !     **                                                                      **
 !     **  CALCULATE PROJECTIONS                                               **
@@ -6446,6 +6447,7 @@ RETURN
       INTEGER(4)     ,INTENT(IN) :: NPRO       ! #(PROJECTIONS)
       COMPLEX(8)     ,INTENT(IN) :: PSI(NGL,NDIM,NB) !WAVEFUNCTIONS
       COMPLEX(8)     ,INTENT(OUT):: PROPSI(NDIM,NB,NPRO) !
+      CHARACTER(*)   ,INTENT(IN) :: PROFILE_ID
       REAL(8)        ,ALLOCATABLE:: GVEC(:,:)  !(3,NGL)
       COMPLEX(8)     ,ALLOCATABLE:: PRO(:,:)   !(NGL,LMNXX)
       COMPLEX(8)     ,ALLOCATABLE:: PROPSI1(:) !(LMNX,NDIM,NB)
@@ -6467,6 +6469,10 @@ RETURN
       LOGICAL(4)                 :: TSUPER
       REAL(8)                    :: PROJFLOPS
       REAL(8)                    :: GWEIGHT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CHARACTER(32)               :: ACC_PRESENT_PSI
+      CHARACTER(32)               :: ACC_COPY_PSI
+#ENDIF
 !     **************************************************************************
                                 CALL TIMING$CLOCKON('WAVES_PROJECTIONS')
 !
@@ -6526,9 +6532,10 @@ RETURN
         IPRO=1
         TUSEGPUEXPANDPRO=CPPAW_CUBLAS_ACC_PRO_EXPANSION_ENABLED()
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        ACC_PRESENT_PSI='ACC_PRESENT_PROJ_'//TRIM(PROFILE_ID)//'_PSI'
+        ACC_COPY_PSI='ACC_COPY_PROJ_'//TRIM(PROFILE_ID)//'_PSI_IN'
         CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D &
-     &      ('ACC_PRESENT_PROJ_PSI','ACC_COPY_PROJ_PSI_IN' &
-     &      ,NGL,NDIM,NB,PSI)
+     &      (ACC_PRESENT_PSI,ACC_COPY_PSI,NGL,NDIM,NB,PSI)
         CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D &
      &      ('ACC_PRESENT_PROJ_PROPSI','ACC_COPY_PROJ_PROPSI_OUT' &
      &      ,NDIM,NB,NPRO,PROPSI)
@@ -6584,9 +6591,10 @@ RETURN
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
         IF(TUSECUBLASPROJ) THEN
+          ACC_PRESENT_PSI='ACC_PRESENT_PROJ_'//TRIM(PROFILE_ID)//'_PSI'
+          ACC_COPY_PSI='ACC_COPY_PROJ_'//TRIM(PROFILE_ID)//'_PSI_IN'
           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D &
-     &        ('ACC_PRESENT_PROJ_PSI','ACC_COPY_PROJ_PSI_IN' &
-     &        ,NGL,NDIM,NB,PSI)
+     &        (ACC_PRESENT_PSI,ACC_COPY_PSI,NGL,NDIM,NB,PSI)
         END IF
 #ENDIF
 #ENDIF

--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -336,11 +336,13 @@ END IF
 !$ACC DATA COPY(THIS%PSIM(1:NGL,1:NDIM,1:NBH)) &
 !$ACC& COPYIN(THIS%OPSI(1:NGL,1:NDIM,1:NBH)) IF(TRESIDENTOVERLAP)
           CALL WAVES_PROJECTIONS(MAP,GSET,NAT,RP,NGL,NDIM,NBH,NPRO &
-     &                                                     ,THIS%PSIM,THIS%PROJ)
+     &                                               ,THIS%PSIM,THIS%PROJ &
+     &                                               ,'ORTHO_PSIM')
           CALL MPE$COMBINE('K','+',THIS%PROJ)
           ALLOCATE(OPROJ(NDIM,NBH,NPRO))
           CALL WAVES_PROJECTIONS(MAP,GSET,NAT,RP,NGL,NDIM,NBH,NPRO &
-     &                                                         ,THIS%OPSI,OPROJ)
+     &                                                    ,THIS%OPSI,OPROJ &
+     &                                                    ,'ORTHO_OPSI')
           CALL MPE$COMBINE('K','+',OPROJ)
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           CALL ACCELPROFILE$NOW(ACCEL_T1)
@@ -588,7 +590,8 @@ END IF
 !         ======================================================================
           IF(TTEST) THEN
             ALLOCATE(OPROJ(NDIM,NBH,NPRO))
-            CALL WAVES_PROJECTIONS(MAP,GSET,NAT,RP,NGL,NDIM,NBH,NPRO,THIS%PSIM,OPROJ)
+            CALL WAVES_PROJECTIONS(MAP,GSET,NAT,RP,NGL,NDIM,NBH,NPRO &
+     &                             ,THIS%PSIM,OPROJ,'ORTHO_TEST')
             CALL MPE$COMBINE('K','+',OPROJ)
             ALLOCATE(AUXMAT(NB,NB))
             CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,OPROJ,OPROJ,AUXMAT)
@@ -3156,7 +3159,8 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
       CALL ACCELPROFILE$NOW(ACCEL_GRAM_T0)
 #ENDIF
 !$ACC DATA COPY(PSI(1:NGL,1:NDIM,1:NBH)) IF(TRESIDENTGRAM)
-      CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,NPRO,PSI,PROJ)
+      CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,NPRO,PSI &
+     &                       ,PROJ,'GRAM_'//TRIM(PROFILE_ID))
       CALL MPE$COMBINE('K','+',PROJ)
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_GRAM_T1)
@@ -3361,7 +3365,8 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !     =================================================================
       IF(TTEST) THEN
         ALLOCATE(PROJ(NDIM,NBH,NPRO))
-        CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,NPRO,PSI,PROJ)
+        CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,NPRO,PSI &
+     &                         ,PROJ,'GRAM_TEST')
         CALL MPE$COMBINE('K','+',PROJ)
         ALLOCATE(AUXMAT(NB,NB))
         CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,PROJ,PROJ,AUXMAT)
@@ -3998,7 +4003,7 @@ PRINT*,'CELLSCALE ',CELLSCALE
 !           =============================================================
             ALLOCATE(PROJ(NDIM,NBH,NPRO))
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R,NGL,NDIM,NBH,NPRO &
-       &                          ,THIS%PSI0,PROJ)
+       &                          ,THIS%PSI0,PROJ,'WRITEPDOS')
             CALL MPE$COMBINE('K','+',PROJ)
           END IF
           IF(KMAP(IKPTG).EQ.THISTASK) THEN
@@ -6798,10 +6803,12 @@ DEALLOCATE(TEST)
           ALLOCATE(THISPROJ(NDIM,NBH,NPRO))
           IF(ID.EQ.'0') THEN
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R0,NGL,NDIM,NBH,NPRO &
-     &                                                     ,THIS%PSI0,THISPROJ)
+     &                                               ,THIS%PSI0,THISPROJ &
+     &                                               ,'TEST0')
           ELSE IF(ID.EQ.'-') THEN
             CALL WAVES_PROJECTIONS(MAP,GSET,NAT,R0,NGL,NDIM,NBH,NPRO &
-     &                                                     ,THIS%PSIM,THISPROJ)
+     &                                               ,THIS%PSIM,THISPROJ &
+     &                                               ,'TESTM')
           ELSE
             CALL ERROR$CHVAL('ID',ID)
             CALL ERROR$STOP('WAVES$TESTORTHO')

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -201,8 +201,10 @@ places where an array was already resident, while matching `ACC_COPY_*` rows add
 the estimated bytes for a required host/device transfer. The tracked arrays are
 `PSIM`/`OPSI` in the orthogonalization region and `WAVES_ADDOPSI`,
 with `OPSI`/`LAMBDA` tracked for the non-inversion data region, `PSI` and
-`PROPSI` in `WAVES_PROJECTIONS`, and context-specific `PSI`/`PROPSI` rows in
-`WAVES_ADDPRO` (`HPSI` and `OPSI`). The ADDPRO `PSI` rows are input/output
+`PROPSI` in `WAVES_PROJECTIONS`, and context-specific projection `PSI` rows
+such as `ACC_COPY_PROJ_SETUP0_PSI_IN`, `ACC_COPY_PROJ_GRAM_PSI0_PSI_IN`, and
+`ACC_COPY_PROJ_ORTHO_PSIM_PSI_IN`. `WAVES_ADDPRO` has context-specific
+`PSI`/`PROPSI` rows (`HPSI` and `OPSI`). The ADDPRO `PSI` rows are input/output
 copy estimates because the projector addition updates the wavefunction. The
 Gram-Schmidt setup keeps `PSI` resident through the final wavefunction transform
 and records that outer input/output region with context-specific rows such as

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -1108,6 +1108,34 @@ orthogonalization calls. A later optimization should therefore either cover both
 initial Gram calls with a broader, verified wavefunction lifetime or leave this
 path alone and focus first on the non-Gram projection/Addpro edges.
 
+## Projection Context Copy Accounting
+
+`WAVES_PROJECTIONS` now tags the profiled `PSI` input copy by caller context.
+The old aggregate `ACC_COPY_PROJ_PSI_IN` row is split into rows such as
+`ACC_COPY_PROJ_SETUP0_PSI_IN`, `ACC_COPY_PROJ_WRITEPDOS_PSI_IN`, and present
+checks for resident callers such as `ACC_PRESENT_PROJ_GRAM_PSI0_PSI`.
+`PROPSI_OUT` stays aggregate because the profiler label length is intentionally
+kept short.
+
+Spark C86C validation:
+
+```
+runs/projection-profile-contexts-20260531-181555
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | Projection `PSI` rows | Energy delta |
+| --- | ---: | ---: | ---: | ---: | --- | ---: |
+| `gpu_resident` | 512 | 1 | 7.04 s | 1.5119 GB | `SETUP0` 0.0672 GB, `WRITEPDOS` 0.0672 GB; Gram/Ortho present | 0.000000401 Ha |
+| `gpu_resident` | 512 | 4 | 9.36 s | 1.9022 GB | `SETUP0` and `WRITEPDOS` about 0.0168 GB per rank; Gram/Ortho present | 0.000000401 Ha |
+| `gpu_resident` | 2048 | 1 | 39.94 s | 5.4696 GB | `SETUP0` 0.2286 GB, `WRITEPDOS` 0.2286 GB; Gram/Ortho present | 0.000000407 Ha |
+
+This is instrumentation, not a speedup. The split moves an important design
+decision out of the dark: the remaining projection wavefunction copies in the
+current Si64 smoke are setup and PDOS/reporting edges, while the Gram and
+orthogonalization projection calls already see resident `PSI`. The next
+optimization should therefore prioritize the measured `ADDPRO_HPSI` and
+`ADDPRO_OPSI` edges before widening projection residency.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Summary
- Split `WAVES_PROJECTIONS` residency profiling for the `PSI` input by caller context.
- Preserve the aggregate `PROPSI_OUT` copy row to keep profiler labels short.
- Document the Spark C86C validation and the new interpretation of the remaining projection copies.

## Spark C86C Validation
Branch was built on Spark with both residency-profile targets:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Run root:
`tests/profile/si64/runs/projection-profile-contexts-20260531-181555`

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident` | 512 | 1 | 7.04 s | 1.5119 GB | 0.000000401 Ha |
| `gpu_resident` | 512 | 4 | 9.36 s | 1.9022 GB | 0.000000401 Ha |
| `gpu_resident` | 2048 | 1 | 39.94 s | 5.4696 GB | 0.000000407 Ha |

Projection context rows show that the remaining Si64 projection `PSI` copies are setup/reporting edges:
- `ACC_COPY_PROJ_SETUP0_PSI_IN`: 0.0672 GB at 512 bands, 0.2286 GB at 2048 bands
- `ACC_COPY_PROJ_WRITEPDOS_PSI_IN`: 0.0672 GB at 512 bands, 0.2286 GB at 2048 bands
- Gram and orthogonalization projection calls report present checks instead of copies.

## Local Checks
- `tests/profile/si64/check_harness.sh`
- `git diff --check`
