### PR TITLE
Split overlap scalarproduct profiling by context

### DIFF
--- a/src/paw_accel_cublas.f90
+++ b/src/paw_accel_cublas.f90
@@ -49,7 +49,25 @@
       REAL(8)            :: MINFLOP_OVERLAP=1.D7
       REAL(8)            :: MINFLOP_ADDPRODUCT=1.D7
       REAL(8)            :: MINFLOP_MATMUL=1.D7
+      CHARACTER(16)      :: OVERLAP_PROFILE_ID=''
       CONTAINS
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_SET_OVERLAP_PROFILE(PROFILE_ID)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN) :: PROFILE_ID
+!     **************************************************************************
+      OVERLAP_PROFILE_ID=ADJUSTL(PROFILE_ID)
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_SET_OVERLAP_PROFILE
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE()
+      IMPLICIT NONE
+!     **************************************************************************
+      OVERLAP_PROFILE_ID=''
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE
 !
 !     ..........................................................................
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
@@ -67,6 +85,51 @@
      &                     ,0.D0,BYTES,0.D0)
       RETURN
       END SUBROUTINE CPPAW_CUBLAS_ACC_PROFILE_BYTES
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_ZSPROD_NAMES(SUFFIX,PRESENT_NAME &
+     &                                        ,COPY_NAME)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN)  :: SUFFIX
+      CHARACTER(32),INTENT(OUT):: PRESENT_NAME
+      CHARACTER(32),INTENT(OUT):: COPY_NAME
+!     **************************************************************************
+      IF(LEN_TRIM(OVERLAP_PROFILE_ID).GT.0) THEN
+        PRESENT_NAME='ACC_PRESENT_ZSP_'//TRIM(OVERLAP_PROFILE_ID)//'_' &
+     &       //TRIM(SUFFIX)
+        COPY_NAME='ACC_COPY_ZSP_'//TRIM(OVERLAP_PROFILE_ID)//'_' &
+     &       //TRIM(SUFFIX)
+        IF(TRIM(SUFFIX).EQ.'P1') COPY_NAME=TRIM(COPY_NAME)//'_IN'
+        IF(TRIM(SUFFIX).EQ.'P2') COPY_NAME=TRIM(COPY_NAME)//'_IN'
+      ELSE IF(TRIM(SUFFIX).EQ.'P1') THEN
+        PRESENT_NAME='ACC_PRESENT_CUBLAS_ZSPROD_PSI1'
+        COPY_NAME='ACC_COPY_CUBLAS_ZSPROD_PSI1_IN'
+      ELSE IF(TRIM(SUFFIX).EQ.'P2') THEN
+        PRESENT_NAME='ACC_PRESENT_CUBLAS_ZSPROD_PSI2'
+        COPY_NAME='ACC_COPY_CUBLAS_ZSPROD_PSI2_IN'
+      ELSE
+        PRESENT_NAME='ACC_PRESENT_CUBLAS_ZSPROD_OUT'
+        COPY_NAME='ACC_COPY_CUBLAS_ZSPROD_OUT'
+      END IF
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_ZSPROD_NAMES
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_ZSPROD_COPY_NAME(SUFFIX,COPY_NAME)
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(IN)   :: SUFFIX
+      CHARACTER(32),INTENT(OUT) :: COPY_NAME
+!     **************************************************************************
+      IF(LEN_TRIM(OVERLAP_PROFILE_ID).GT.0) THEN
+        COPY_NAME='ACC_COPY_ZSP_'//TRIM(OVERLAP_PROFILE_ID)//'_' &
+     &       //TRIM(SUFFIX)
+      ELSE IF(TRIM(SUFFIX).EQ.'OVL') THEN
+        COPY_NAME='ACC_COPY_CUBLAS_ZSPROD_OVL_RES'
+      ELSE
+        COPY_NAME='ACC_COPY_CUBLAS_ZSPROD'
+      END IF
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_ZSPROD_COPY_NAME
 #ENDIF
 !
 !     ..........................................................................
@@ -1059,6 +1122,15 @@
       COMPLEX(8),INTENT(OUT) :: OVERLAP(N1,N2)
       LOGICAL(4),INTENT(OUT) :: USED
       REAL(8)                :: FLOPS
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CHARACTER(32)          :: ACC_PRESENT_PSI1
+      CHARACTER(32)          :: ACC_COPY_PSI1
+      CHARACTER(32)          :: ACC_PRESENT_PSI2
+      CHARACTER(32)          :: ACC_COPY_PSI2
+      CHARACTER(32)          :: ACC_PRESENT_OUT
+      CHARACTER(32)          :: ACC_COPY_OUT
+      CHARACTER(32)          :: ACC_COPY_AGG
+#ENDIF
 !     **************************************************************************
       IF(TID) THEN
         FLOPS=4.D0*REAL(N1,KIND=8)*REAL(N1,KIND=8)*REAL(LEN,KIND=8)
@@ -1069,17 +1141,20 @@
       IF(.NOT.USED) RETURN
       IF(RESIDENCY_ENABLED) THEN
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL CPPAW_CUBLAS_ACC_ZSPROD_NAMES('P1',ACC_PRESENT_PSI1 &
+     &      ,ACC_COPY_PSI1)
+        CALL CPPAW_CUBLAS_ACC_ZSPROD_NAMES('P2',ACC_PRESENT_PSI2 &
+     &      ,ACC_COPY_PSI2)
+        CALL CPPAW_CUBLAS_ACC_ZSPROD_NAMES('OUT',ACC_PRESENT_OUT &
+     &      ,ACC_COPY_OUT)
         CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
-     &      ('ACC_PRESENT_CUBLAS_ZSPROD_PSI1' &
-     &      ,'ACC_COPY_CUBLAS_ZSPROD_PSI1_IN',LEN,N1,PSI1)
+     &      (ACC_PRESENT_PSI1,ACC_COPY_PSI1,LEN,N1,PSI1)
         IF(.NOT.TID) THEN
           CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
-     &        ('ACC_PRESENT_CUBLAS_ZSPROD_PSI2' &
-     &        ,'ACC_COPY_CUBLAS_ZSPROD_PSI2_IN',LEN,N2,PSI2)
+     &        (ACC_PRESENT_PSI2,ACC_COPY_PSI2,LEN,N2,PSI2)
         END IF
         CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_2D &
-     &      ('ACC_PRESENT_CUBLAS_ZSPROD_OUT' &
-     &      ,'ACC_COPY_CUBLAS_ZSPROD_OUT',N1,N2,OVERLAP)
+     &      (ACC_PRESENT_OUT,ACC_COPY_OUT,N1,N2,OVERLAP)
 #ENDIF
         IF(TID) THEN
 !$ACC DATA PRESENT_OR_COPYIN(PSI1(1:LEN,1:N1)) &
@@ -1102,7 +1177,8 @@
      &                                             ,N2,PSI2,OVERLAP)
 !$ACC END DATA
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-        CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES('ACC_COPY_CUBLAS_ZSPROD' &
+        CALL CPPAW_CUBLAS_ACC_ZSPROD_COPY_NAME('GEN',ACC_COPY_AGG)
+        CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES(ACC_COPY_AGG &
      &       ,LEN,N1,N2,0,16.D0*(REAL(LEN,KIND=8)*REAL(N1,KIND=8) &
      &       +REAL(N1,KIND=8)*REAL(N2,KIND=8)))
 #ENDIF
@@ -1114,7 +1190,8 @@
      &                                           ,N2,PSI2,OVERLAP)
 !$ACC END DATA
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-      CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES('ACC_COPY_CUBLAS_ZSPROD' &
+      CALL CPPAW_CUBLAS_ACC_ZSPROD_COPY_NAME('GEN',ACC_COPY_AGG)
+      CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES(ACC_COPY_AGG &
      &     ,LEN,N1,N2,0,16.D0*(REAL(LEN,KIND=8)*REAL(N1,KIND=8) &
      &     +REAL(LEN,KIND=8)*REAL(N2,KIND=8) &
      &     +REAL(N1,KIND=8)*REAL(N2,KIND=8)))
@@ -1140,6 +1217,7 @@
       REAL(8)                :: ACCEL_T0
       REAL(8)                :: ACCEL_T1
       REAL(8)                :: ACCEL_BYTES
+      CHARACTER(32)          :: ACC_COPY_OVL_RES
 #ENDIF
 !     **************************************************************************
       IF(TID) THEN
@@ -1174,7 +1252,8 @@
      &       ,INT(LEN,KIND=8),INT(N1,KIND=8),INT(N2,KIND=8),0_8 &
      &       ,FLOPS,ACCEL_BYTES,ACCEL_T1-ACCEL_T0)
       END IF
-      CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES('ACC_COPY_CUBLAS_ZSPROD_OVL_RES' &
+      CALL CPPAW_CUBLAS_ACC_ZSPROD_COPY_NAME('OVL',ACC_COPY_OVL_RES)
+      CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES(ACC_COPY_OVL_RES &
      &     ,LEN,N1,N2,0,16.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8))
 #ENDIF
       RETURN

--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -2385,12 +2385,14 @@ CALL TIMING$CLOCKON('W:EXPECT')
           DO IB=1,NBH
             IF(GSET%TINV) THEN
               CALL WAVES_OVERLAP(.FALSE.,NGL,NDIM,1,2 &
-     &              ,THIS%PSI0(:,:,IB),THIS%HPSI(:,:,IB),HAMILTON)
+     &              ,THIS%PSI0(:,:,IB),THIS%HPSI(:,:,IB),HAMILTON &
+     &              ,'EXPECT_INV')
               EIG(2*IB-1,IKPT,ISPIN)=REAL(HAMILTON(1,1),KIND=8)
               EIG(2*IB  ,IKPT,ISPIN)=REAL(HAMILTON(2,2),KIND=8)
             ELSE 
               CALL WAVES_OVERLAP(.FALSE.,NGL,NDIM,1,1 &
-     &            ,THIS%PSI0(:,:,IB),THIS%HPSI(:,:,IB),HAMILTON)
+     &            ,THIS%PSI0(:,:,IB),THIS%HPSI(:,:,IB),HAMILTON &
+     &            ,'EXPECT')
               EIG(IB,IKPT,ISPIN)=REAL(HAMILTON(1,1),KIND=8)
             END IF
           ENDDO
@@ -2448,7 +2450,7 @@ CALL TIMESTEP$GETI4('ISTEP',ISVAR)
             NGL=GSET%NGL
             ALLOCATE(HAMILTON(NB,NB))
             CALL WAVES_OVERLAP(.FALSE.,NGL,NDIM,NBH,NB,THIS%PSI0,THIS%HPSI &
-     &                        ,HAMILTON)
+     &                        ,HAMILTON,'HAMILTON')
             IF(.NOT.ASSOCIATED(THIS%EIGVAL))ALLOCATE(THIS%EIGVAL(NB))
             IF(.NOT.ASSOCIATED(THIS%EIGVEC))ALLOCATE(THIS%EIGVEC(NB,NB))
             CALL LIB$DIAGC8(NB,HAMILTON,THIS%EIGVAL,THIS%EIGVEC)

--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -371,19 +371,22 @@ END IF
 !         ==  NOW ADD OVERLAP OF PSEUDO WAVE FUNCTIONS                        ==
 !         ======================================================================
           ALLOCATE(AUXMAT(NB,NB))
-          CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM,THIS%PSIM,AUXMAT)
+          CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM &
+     &                       ,THIS%PSIM,AUXMAT,'ORTH_PSIM')
           DO I=1,NB
             DO J=1,NB
               MAT(I,J)=MAT(I,J)+AUXMAT(I,J)
             ENDDO
           ENDDO
-          CALL WAVES_OVERLAP(.FALSE.,NGL,NDIM,NBH,NB,THIS%OPSI,THIS%PSIM,AUXMAT)
+          CALL WAVES_OVERLAP(.FALSE.,NGL,NDIM,NBH,NB,THIS%OPSI &
+     &                       ,THIS%PSIM,AUXMAT,'ORTH_OPM')
           DO I=1,NB
             DO J=1,NB
               OMAT(I,J)=OMAT(I,J)+AUXMAT(I,J)
             ENDDO
           ENDDO
-          CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%OPSI,THIS%OPSI,AUXMAT)
+          CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%OPSI &
+     &                       ,THIS%OPSI,AUXMAT,'ORTH_OPSI')
           DO I=1,NB
             DO J=1,NB
               OOMAT(I,J)=OOMAT(I,J)+AUXMAT(I,J)
@@ -602,7 +605,8 @@ END IF
             ENDDO
 !PRINT*,'1C-CHARGE AFTER ORTHOGONALIZATION ',CSUM
             ALLOCATE(MAT(NB,NB))
-            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM,THIS%PSIM,MAT)
+            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM &
+     &                         ,THIS%PSIM,MAT,'ORTH_TEST')
             CSUM=(0.D0,0.D0)
             DO I=1,NB
               CSUM=CSUM+MAT(I,I)*OCC(I,IKPT,ISPIN)
@@ -1067,7 +1071,8 @@ END IF
        END
 !
 !      ..............................................................
-      SUBROUTINE WAVES_OVERLAP(TID,NGL,NDIM,NBH,NB,PSI1,PSI2,MAT)
+      SUBROUTINE WAVES_OVERLAP(TID,NGL,NDIM,NBH,NB,PSI1,PSI2,MAT &
+     &                        ,PROFILE_ID)
 !      **                                                          **
 !      **  CALCULATES <PSI1|PSI2>                                  **
 !      **                                                          **
@@ -1075,7 +1080,9 @@ END IF
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
      &        CPPAW_CUBLAS_ACC_SCALARPRODUCT_RESIDENT_COPY &
-     &       ,CPPAW_CUBLAS_ACC_WAVE_OVERLAP_RESIDENT_ACTIVE
+     &       ,CPPAW_CUBLAS_ACC_WAVE_OVERLAP_RESIDENT_ACTIVE &
+     &       ,CPPAW_CUBLAS_ACC_SET_OVERLAP_PROFILE &
+     &       ,CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE
 #ENDIF
       IMPLICIT NONE
        LOGICAL(4),INTENT(IN) :: TID !INDICATES THAT PSI1=PSI2
@@ -1086,6 +1093,7 @@ END IF
        COMPLEX(8),INTENT(IN) :: PSI1(NGL,NDIM,NBH)
        COMPLEX(8),INTENT(IN) :: PSI2(NGL,NDIM,NBH)
        COMPLEX(8),INTENT(OUT):: MAT(NB,NB)
+       CHARACTER(*),INTENT(IN):: PROFILE_ID
        INTEGER(4)            :: IBH1,IBH2,IDIM
        INTEGER(4)            :: IB1A,IB1B,IB2A,IB2B,I,J
        COMPLEX(8),ALLOCATABLE:: TMAT(:,:)
@@ -1101,6 +1109,9 @@ END IF
 #ENDIF
 !      **************************************************************
                              CALL TIMING$CLOCKON('WAVES_OVERLAP')
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      CALL CPPAW_CUBLAS_ACC_SET_OVERLAP_PROFILE(PROFILE_ID)
+#ENDIF
       TINV=(NB.NE.NBH)
       IF(.NOT.TINV) THEN
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
@@ -1112,6 +1123,9 @@ END IF
             CALL PLANEWAVE$GETR8('GWEIGHT',GWEIGHT)
             MAT=MAT*GWEIGHT
             CALL MPE$COMBINE('K','+',MAT)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+            CALL CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE()
+#ENDIF
                              CALL TIMING$CLOCKOFF('WAVES_OVERLAP')
             RETURN
           END IF
@@ -1123,6 +1137,9 @@ END IF
            CALL PLANEWAVE$SCALARPRODUCT(' ',NGL,NDIM,NB,PSI1,NB,PSI2,MAT)
          END IF
          CALL MPE$COMBINE('K','+',MAT)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+         CALL CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE()
+#ENDIF
                              CALL TIMING$CLOCKOFF('WAVES_OVERLAP')
          RETURN
        ENDIF
@@ -1214,9 +1231,12 @@ END IF
        ENDDO
        DEALLOCATE(TMAT)
        CALL MPE$COMBINE('K','+',MAT)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      CALL CPPAW_CUBLAS_ACC_CLEAR_OVERLAP_PROFILE()
+#ENDIF
                              CALL TIMING$CLOCKOFF('WAVES_OVERLAP')
-       RETURN
-       END
+      RETURN
+      END
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,PROJ1,PROJ2,MAT)
@@ -3175,7 +3195,8 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
 !     ==================================================================
       ALLOCATE(OVERLAP(NB,NB))
       ALLOCATE(AUXMAT(NB,NB))
-      CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,PSI,PSI,OVERLAP)
+      CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,PSI,PSI,OVERLAP &
+     &                   ,'GRAM_'//TRIM(PROFILE_ID))
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_GRAM_T1)
       CALL ACCELPROFILE$ADD('PAW_GRAM_PW_OVERLAP' &
@@ -3372,7 +3393,8 @@ PRINT*,'A     ',(A(I,I),I=1,NB)
         CALL WAVES_1COVERLAP(MAP,NDIM,NBH,NB,NPRO,PROJ,PROJ,AUXMAT)
         DEALLOCATE(PROJ)
         ALLOCATE(OVERLAP(NB,NB))
-        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,PSI,PSI,OVERLAP)
+        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,PSI,PSI,OVERLAP &
+     &                     ,'GRAM_TEST')
         DO J=1,NB
           DO I=1,NB
             OVERLAP(I,J)=OVERLAP(I,J)+AUXMAT(I,J)
@@ -6061,7 +6083,8 @@ PRINT*,'XK ',XK
         NDIMHALF=1
         ALLOCATE(AUXMAT(NBD,NBD))
         CALL WAVES_1COVERLAP(MAP,NDIMHALF,NBD,NBD,MAP%NPRO,THIS%PROJ,THIS%PROJ,AUXMAT)
-        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIMHALF,NBD,NBD,THIS%PSI0,THIS%PSI0,QMAT)
+        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIMHALF,NBD,NBD,THIS%PSI0 &
+     &                     ,THIS%PSI0,QMAT,'S2_NC')
         DO J=1,NBD
           DO I=1,NBD
             QMAT(I,J)=(QMAT(I,J)+AUXMAT(I,J))*0.5D0
@@ -6100,7 +6123,8 @@ PRINT*,'XK ',XK
               PSI0(:,:,NBH+1:2*NBH)=THIS%PSI0
            END IF
         END DO
-        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH*2,NB*2,PSI0,PSI0,AUXMAT2)
+        CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH*2,NB*2,PSI0,PSI0 &
+     &                     ,AUXMAT2,'S2_COL')
         DEALLOCATE(PSI0)
 
         QMAT=(0.D0,0.D0)
@@ -6826,9 +6850,11 @@ DEALLOCATE(TEST)
 !         ======================================================================
           ALLOCATE(AUXMAT(NB,NB))
           IF(ID.EQ.'0') THEN
-            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSI0,THIS%PSI0,AUXMAT)
+            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSI0 &
+     &                         ,THIS%PSI0,AUXMAT,'TEST0')
           ELSE IF(ID.EQ.'-') THEN
-            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM,THIS%PSIM,AUXMAT)
+            CALL WAVES_OVERLAP(.TRUE.,NGL,NDIM,NBH,NB,THIS%PSIM &
+     &                         ,THIS%PSIM,AUXMAT,'TESTM')
           ELSE
             CALL ERROR$CHVAL('ID',ID)
             CALL ERROR$STOP('WAVES$TESTORTHO')

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -206,6 +206,11 @@ such as `ACC_COPY_PROJ_SETUP0_PSI_IN`, `ACC_COPY_PROJ_GRAM_PSI0_PSI_IN`, and
 `ACC_COPY_PROJ_ORTHO_PSIM_PSI_IN`. `WAVES_ADDPRO` has context-specific
 `PSI`/`PROPSI` rows (`HPSI` and `OPSI`). The ADDPRO `PSI` rows are input/output
 copy estimates because the projector addition updates the wavefunction. The
+wavefunction overlap `ZSPROD` rows are also tagged by `WAVES_OVERLAP` caller
+context, for example `ACC_COPY_ZSP_ORTH_PSIM_P1_IN`,
+`ACC_PRESENT_ZSP_GRAM_PSI0_P1`, and `ACC_COPY_ZSP_HAMILTON_P2_IN`.
+The suffixes `P1`, `P2`, `OUT`, and `OVL` identify the first input, second
+input, generic scalarproduct output, and resident-overlap output rows. The
 Gram-Schmidt setup keeps `PSI` resident through the final wavefunction transform
 and records that outer input/output region with context-specific rows such as
 `ACC_COPY_GRAM_PSI0_PSI_IO` and `ACC_COPY_GRAM_PSIM_PSI_IO`. The

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -1136,6 +1136,46 @@ orthogonalization projection calls already see resident `PSI`. The next
 optimization should therefore prioritize the measured `ADDPRO_HPSI` and
 `ADDPRO_OPSI` edges before widening projection residency.
 
+## Overlap Context Copy Accounting
+
+`WAVES_OVERLAP` now tags the generic cuBLAS `ZSPROD` copy/present rows by
+caller context. The old aggregate rows such as
+`ACC_COPY_CUBLAS_ZSPROD_PSI1_IN`, `ACC_COPY_CUBLAS_ZSPROD_PSI2_IN`,
+`ACC_COPY_CUBLAS_ZSPROD_OUT`, and `ACC_COPY_CUBLAS_ZSPROD_OVL_RES` are split
+into short rows such as `ACC_COPY_ZSP_HAMILTON_P1_IN`,
+`ACC_PRESENT_ZSP_GRAM_PSI0_P1`, and `ACC_COPY_ZSP_ORTH_PSIM_OVL`.
+
+Spark C86C validation:
+
+```
+runs/overlap-profile-contexts-20260531-162835
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident` | 512 | 1 | 7.03 s | 1.5119 GB | 0.000000401 Ha |
+| `gpu_resident` | 512 | 4 | 9.35 s | 1.9022 GB | 0.000000401 Ha |
+| `gpu_resident` | 2048 | 1 | 39.04 s | 5.4696 GB | 0.000000407 Ha |
+
+The 2048-band context split shows that the large remaining non-resident overlap
+copies are Hamiltonian/reporting edges:
+
+| Row | Calls | Copy estimate | Meaning |
+| --- | ---: | ---: | --- |
+| `ACC_COPY_ZSP_HAMILTON_P1_IN` | 2 | 0.4572 GB | First Hamiltonian overlap input is copied. |
+| `ACC_COPY_ZSP_HAMILTON_P2_IN` | 1 | 0.2286 GB | Second Hamiltonian overlap input is copied once; the other call sees it present. |
+| `ACC_COPY_ZSP_HAMILTON_OUT` | 2 | 0.0379 GB | Hamiltonian overlap output copy. |
+| `ACC_PRESENT_ZSP_GRAM_PSI0_P1/P2` | 1 each | 0 GB | Gram overlap inputs are resident. |
+| `ACC_PRESENT_ZSP_GRAM_PSIM_P1/P2` | 1 each | 0 GB | Gram overlap inputs are resident. |
+| `ACC_PRESENT_ZSP_ORTH_*_P1/P2` | 1 each | 0 GB | Orthogonalization overlap inputs are resident. |
+
+This is instrumentation, not a speedup. It shows that widening overlap
+residency inside Gram/Ortho would not attack the dominant remaining `ZSPROD`
+copies in this smoke. The next optimization target remains the measured
+wavefunction updates in `ACC_COPY_ADDPRO_HPSI_PSI_IO` and
+`ACC_COPY_ADDPRO_OPSI_PSI_IO`; Hamiltonian/reporting residency can be considered
+later if the band-output path matters for production runs.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Summary
- Add short caller-context labels for `WAVES_OVERLAP` so generic cuBLAS `ZSPROD` copy/present rows are no longer aggregate.
- Split rows such as `ACC_COPY_CUBLAS_ZSPROD_PSI1_IN`, `ACC_COPY_CUBLAS_ZSPROD_PSI2_IN`, `ACC_COPY_CUBLAS_ZSPROD_OUT`, and `ACC_COPY_CUBLAS_ZSPROD_OVL_RES` into `ACC_COPY_ZSP_<context>_*` / `ACC_PRESENT_ZSP_<context>_*` rows.
- Document the Spark result: the dominant remaining non-resident `ZSPROD` copies are Hamiltonian/reporting edges, not Gram/orthogonalization overlap inputs.

## Spark C86C Validation
Built on Spark with both residency-profile targets:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Run root:
`tests/profile/si64/runs/overlap-profile-contexts-20260531-162835`

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident` | 512 | 1 | 7.03 s | 1.5119 GB | 0.000000401 Ha |
| `gpu_resident` | 512 | 4 | 9.35 s | 1.9022 GB | 0.000000401 Ha |
| `gpu_resident` | 2048 | 1 | 39.04 s | 5.4696 GB | 0.000000407 Ha |

2048-band context rows:
- `ACC_COPY_ZSP_HAMILTON_P1_IN`: 2 calls, 0.4572 GB
- `ACC_COPY_ZSP_HAMILTON_P2_IN`: 1 call, 0.2286 GB
- `ACC_COPY_ZSP_HAMILTON_OUT`: 2 calls, 0.0379 GB
- Gram and orthogonalization overlap inputs report `ACC_PRESENT_ZSP_*_P1/P2` rows.

## Local Checks
- `tests/profile/si64/check_harness.sh`
- `git diff --check`
