### PR TITLE
Capture benchmark accelerator env combos

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -102,6 +102,11 @@ final constant energy against the built-in reference (`EXPECTED_ENERGY`,
 default `302.280854`) with `ENERGY_TOL=1e-5`. A run with normal termination but
 an energy mismatch is reported as `ok=no` and carries `energy_delta` in the TSV
 and Markdown summaries.
+The harness also records inherited `CPPAW_GPU_*`, `CPPAW_CUBLAS_ACC_*`,
+`CPPAW_CUSOLVER_ACC_*`, `CPPAW_CUFFT_ACC*`, and `CPPAW_GRAM_CHOLESKY`
+environment switches in `run.env` and the benchmark `env` column. Case-specific
+settings are appended after inherited settings, so explicit `CASES` keywords
+remain reproducible and override broader shell defaults.
 
 `WAVES$ETOT` is split further by `PAW_ETOT_*` rows, and the initial
 Gram-Schmidt setup is split by `PAW_GRAM_*` rows. These are nested PAW
@@ -307,6 +312,7 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_orthox_nosync` | Diagnostic that combines `gpu_resident_orthox` with `CPPAW_CUBLAS_ACC_SYNC=0`; use for profiling synchronization overhead, not as the default. |
 | `gpu_resident_opsi` | Opt-in residency diagnostic that keeps orthogonalization `OPSI` on the GPU through projection/overlap/`WAVES_ADDOPSI` via `CPPAW_GPU_OPSI_RESIDENCY=1`; superwave cases use conservative host build/scale staging before device residency. |
 | `gpu_resident_hpsi` | Opt-in residency diagnostic that keeps `HPSI` on the GPU from Hamiltonian-side `WAVES_ADDPRO` through the immediate expectation/Hamiltonian overlaps via `CPPAW_GPU_HPSI_RESIDENCY=1`. |
+| `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |
 | `gpu_resident_projection_conservative` / `gpu_resident_overlap_conservative` / `gpu_resident_addproduct_conservative` / `gpu_resident_matmul_conservative` | Residency diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident_force_all` | Residency diagnostic that also forces cuFFT and small cuSOLVER offload. |
 | `gpu_resident_off` | Residency binary with native cuFFT/cuBLAS/cuSOLVER disabled for same-executable fallback comparison. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -1366,6 +1366,31 @@ for the reused wavefunction. Wall time improves for the small 1-rank smoke, but
 is neutral to slightly slower for the larger and 4-rank checks, so the switch
 remains opt-in rather than a new default.
 
+## HPSI + OPSI Benchmark Keyword
+
+The harness follow-up adds the explicit combined keyword
+`gpu_resident_hpsi_opsi` and records inherited `CPPAW_*` accelerator switches in
+the benchmark `env` column. This avoids ambiguous runs where an extra shell
+environment switch affects the executable but is not visible in the TSV.
+
+Spark C86C validation:
+
+```
+runs/hpsi-opsi-keyword-20260531-512-1r
+runs/hpsi-opsi-keyword-20260531-2048-1r
+runs/hpsi-opsi-keyword-20260531-512-4r
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi_opsi` | 512 | 1 | 7.21 s | 1.3676 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_opsi` | 2048 | 1 | 39.75 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_opsi` | 512 | 4 | 9.65 s | 1.7284 GB | 0.000000401 Ha |
+
+The combined keyword is energy-valid and reproduces the HPSI copy reduction,
+but OPSI residency does not add another copy reduction for these Si64 smoke
+cases. Keep it as a reproducible diagnostic combination, not a new default.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -254,6 +254,9 @@ case_note() {
     gpu_resident_hpsi)
       echo "Residency diagnostic that keeps HPSI on the GPU from WAVES_ADDPRO through the immediate expectation/Hamiltonian overlaps."
       ;;
+    gpu_resident_hpsi_opsi)
+      echo "Residency diagnostic that combines HPSI and OPSI wavefunction residency switches."
+      ;;
     gpu_resident_1coverlap_host)
       echo "Residency diagnostic that disables only the one-center overlap cuBLAS path."
       ;;
@@ -392,6 +395,20 @@ cublas_matmul_conservative_env() {
   echo "$(cublas_env) CPPAW_CUBLAS_ACC_MATMUL_MINFLOP=${CPPAW_CUBLAS_MATMUL_CONSERVATIVE_MINFLOP:-${CPPAW_CUBLAS_CONSERVATIVE_MINFLOP:-1e8}}"
 }
 
+inherited_accel_env() {
+  local name value env_line=""
+  while IFS='=' read -r name value; do
+    case "${name}" in
+      CPPAW_GPU_*|CPPAW_CUBLAS_ACC_*|CPPAW_CUSOLVER_ACC_*|CPPAW_CUFFT_ACC*|CPPAW_GRAM_CHOLESKY)
+        if [[ "${value}" =~ ^[A-Za-z0-9_./:+-]+$ ]]; then
+          env_line="${env_line:+${env_line} }${name}=${value}"
+        fi
+        ;;
+    esac
+  done < <(env)
+  echo "${env_line}"
+}
+
 case_env() {
   case "$1" in
     cublas) cublas_env ;;
@@ -444,6 +461,7 @@ case_env() {
     gpu_resident_orthox_nosync) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_ORTHO_X_RESIDENCY=1 $(cublas_env) CPPAW_CUBLAS_ACC_SYNC=0" ;;
     gpu_resident_opsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_hpsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 $(cublas_env)" ;;
+    gpu_resident_hpsi_opsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_1coverlap_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=0 $(cublas_env)" ;;
     gpu_resident_gram_cholesky) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=1 $(cublas_env)" ;;
     gpu_resident_gram_legacy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=0 $(cublas_env)" ;;
@@ -537,6 +555,8 @@ capture_metadata() {
       fi
       note=$(case_note "${case_name}")
       [[ -n "${note}" ]] && echo "note=${note}"
+      extra_env=$(inherited_accel_env)
+      [[ -n "${extra_env}" ]] && echo "inherited_accel_env=${extra_env}"
       if [[ -x "${exe}" ]]; then
         runtime_env=$(case_runtime_env "${case_name}" "${exe}")
         if [[ -n "${runtime_env}" ]]; then
@@ -573,7 +593,8 @@ for case_name in ${CASES}; do
     prepare_case "${run_dir}"
     (
       cd "${run_dir}"
-      env_line=$(combined_env "$(case_runtime_env "${case_name}" "${exe}")" "$(case_env "${case_name}")")
+      env_line=$(combined_env "$(inherited_accel_env)" \
+        "$(case_runtime_env "${case_name}" "${exe}")" "$(case_env "${case_name}")")
       {
         echo "case=${case_name}"
         echo "repeat=${repeat}"


### PR DESCRIPTION
## Summary
- record inherited accelerator `CPPAW_*` switches in `run.env`, `metadata.txt`, and the benchmark `env` column
- add explicit `gpu_resident_hpsi_opsi` case for combined HPSI/OPSI residency diagnostics
- document the keyword and Spark smoke results

## Validation
Local checks:

```bash
git diff --check
bash -n tests/profile/si64/run_benchmark.sh tests/profile/si64/run_nvhpc_standard.sh
```

Spark C86C runs using the existing `nvhpc_gpu_acc_residency_profile` binaries:

```text
runs/hpsi-opsi-keyword-20260531-512-1r
runs/hpsi-opsi-keyword-20260531-2048-1r
runs/hpsi-opsi-keyword-20260531-512-4r
```

| Case | Empty bands | Ranks | Wall time | Total copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_opsi` | 512 | 1 | 7.21 s | 1.3676 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_opsi` | 2048 | 1 | 39.75 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_opsi` | 512 | 4 | 9.65 s | 1.7284 GB | 0.000000401 Ha |

All runs are energy-valid. The combined keyword reproduces the HPSI copy reduction; OPSI residency does not add another reduction in these Si64 smoke cases, so the combination remains a diagnostic keyword rather than a recommended default.
