### PR TITLE
Profile one-center density matrix phases

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -3361,6 +3361,10 @@ END IF
       REAL(8)   ,ALLOCATABLE :: XK(:,:)
       LOGICAL(4)             :: TINV
       INTEGER(4)             :: IB
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                :: ACCEL_T0
+      REAL(8)                :: ACCEL_T1
+#ENDIF
 !     **************************************************************************
                               CALL TRACE$PUSH('WAVES$DENMAT')
                               CALL TIMING$CLOCKON('W:DENMAT')
@@ -3372,16 +3376,36 @@ END IF
 !     ==========================================================================
 !     ==  GET OCCUPATIONS FROM DYNOCC OBJECT                                  ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL DYNOCC$GETI4('NB',NBX)
       ALLOCATE(OCC(NBX,NKPTL,NSPIN))
       CALL WAVES_DYNOCCGETR8A('OCC',NBX*NKPTL*NSPIN,OCC)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_OCC_SETUP' &
+     &    ,INT(NBX,KIND=8),INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==                                                                      ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL MPE$QUERY('K',NTASKS,THISTASK)
       DENMAT(:,:,:,:)=(0.D0,0.D0)
       EDENMAT(:,:,:,:)=(0.D0,0.D0)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_INIT' &
+     &    ,INT(LMNXX,KIND=8),INT(NDIMD,KIND=8),INT(NAT,KIND=8),0_8 &
+     &    ,0.D0,16.D0*REAL(LMNXX,KIND=8)*REAL(LMNXX,KIND=8) &
+     &    *REAL(NDIMD,KIND=8)*REAL(NAT,KIND=8)*2.D0 &
+     &    ,ACCEL_T1-ACCEL_T0)
+#ENDIF
       DO IKPT=1,NKPTL
         DO ISPIN=1,NSPIN
           CALL WAVES_SELECTWV(IKPT,ISPIN)
@@ -3398,10 +3422,23 @@ END IF
               IPRO=IPRO+LMNX
               CYCLE
             END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
             ALLOCATE(PROJ(NDIM,NBH,LMNX))
             PROJ(:,:,:)=THIS%PROJ(:,:,IPRO:IPRO-1+LMNX)
             ALLOCATE(DENMAT1(LMNX,LMNX,NDIMD))
             ALLOCATE(EDENMAT1(LMNX,LMNX,NDIMD))
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('PAW_DENMAT_SITE_SETUP' &
+     &        ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NDIM,KIND=8) &
+     &        ,INT(NDIMD,KIND=8),0.D0 &
+     &        ,16.D0*REAL(LMNX,KIND=8)*REAL(NBH,KIND=8) &
+     &        *REAL(NDIM,KIND=8) &
+     &        ,ACCEL_T1-ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
 !!$PRINT*,"========  WAVES$DENMAT  ======IKPT=",IKPT,' IAT=',IAT,' IPRO=',IPRO
 !!$DO IB=1,NB
 !!$  IF(OCC(IB,IKPT,ISPIN).LT.1.D-5) CYCLE
@@ -3409,6 +3446,13 @@ END IF
 !!$ENDDO
             CALL WAVES_DENMAT(NDIM,NBH,NB,LMNX,OCC(1,IKPT,ISPIN),THIS%RLAM0 &
      &                       ,PROJ,DENMAT1,EDENMAT1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('PAW_DENMAT_SITE_KERNEL' &
+     &        ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NB,KIND=8) &
+     &        ,INT(NDIM,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
             IF(NDIM.EQ.1) THEN
               DENMAT(1:LMNX,1:LMNX,ISPIN,IAT) &
      &                   =DENMAT(1:LMNX,1:LMNX,ISPIN,IAT)+DENMAT1(:,:,1)
@@ -3423,6 +3467,15 @@ END IF
             DEALLOCATE(DENMAT1)
             DEALLOCATE(EDENMAT1)
             DEALLOCATE(PROJ)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('PAW_DENMAT_SITE_ACCUM' &
+     &        ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NDIMD,KIND=8) &
+     &        ,0_8,0.D0 &
+     &        ,16.D0*REAL(LMNX,KIND=8)*REAL(LMNX,KIND=8) &
+     &        *REAL(NDIMD,KIND=8)*4.D0 &
+     &        ,ACCEL_T1-ACCEL_T0)
+#ENDIF
             IPRO=IPRO+LMNX
           ENDDO
         ENDDO
@@ -3431,13 +3484,28 @@ END IF
 !     == EACH K-GROUP HOLDS ONLY THE WAVE FUNCTIONS BELONGING TO IT.
 !     == EACH PROCESSOR OF EACH K-GROUP ONLY ADDS UP A FRACTION OF THE PROJECTIONS
 !     == THEREFORE THERE IS NO DOUBLE COUNTING BY SUMMING OVER THE MONOMER
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL MPE$COMBINE('MONOMER','+',DENMAT)
       CALL MPE$COMBINE('MONOMER','+',EDENMAT)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_COMBINE' &
+     &    ,INT(LMNXX,KIND=8),INT(NDIMD,KIND=8),INT(NAT,KIND=8) &
+     &    ,INT(NTASKS,KIND=8),0.D0 &
+     &    ,16.D0*REAL(LMNXX,KIND=8)*REAL(LMNXX,KIND=8) &
+     &    *REAL(NDIMD,KIND=8)*REAL(NAT,KIND=8)*2.D0 &
+     &    ,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==  CONVERT SPIN-UP AND SPIN-DOWN DENSITY MATRIX INTO                   ==
 !     ==  TOTAL AND SPIN DENSITY MATRICES                                     ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       IF(NSPIN.EQ.2) THEN
         DO IAT=1,NAT
           ISP=MAP%ISP(IAT)
@@ -3457,6 +3525,12 @@ END IF
           ENDDO
         ENDDO
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_SPIN_CONVERT' &
+     &    ,INT(LMNXX,KIND=8),INT(NDIMD,KIND=8),INT(NAT,KIND=8) &
+     &    ,INT(NSPIN,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==  PRINT FOR TEST                                                      ==
@@ -3736,6 +3810,10 @@ END IF
       INTEGER(4)            :: NFILO
       LOGICAL(4),PARAMETER  :: TPR=.FALSE.
       COMPLEX(8),PARAMETER   :: CI=(0.D0,1.D0)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                :: ACCEL_T0
+      REAL(8)                :: ACCEL_T1
+#ENDIF
 !     **************************************************************************
       NDIMD=NDIM**2
       DENMAT(:,:,:)=(0.D0,0.D0)
@@ -3766,6 +3844,9 @@ END IF
 !     == = <P|PSI1>F1<PSI1|P>+<P|PSI2>F2<PSI2|P>
 !     == + I[<P|PSI2>F1<PSI1|P>-<P|PSI1>F2<PSI2|P>]
 !     == IMAGINARY PART IS DROPPED
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       DENMAT1(:,:,:,:)=(0.D0,0.D0)
       DO IB=1,NBH
 !       == FIND OCCUPATION OF THE STATE ========================================
@@ -3802,10 +3883,19 @@ END IF
       IF(TINV) THEN
         DENMAT1(:,:,:,:)=REAL(DENMAT1(:,:,:,:),KIND=8)
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_DENSITY_LOOP' &
+     &    ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NDIM,KIND=8) &
+     &    ,INT(NB,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     == NOW SUM UP EDENMAT  <P|PSITILDE>*LAMBDA*<PSITILDE|P>                 ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       DO IB2=1,NB
         LAGR(:,IB2)=LAMBDA(:,IB2)*OCC(IB2)
       ENDDO
@@ -3856,10 +3946,19 @@ END IF
           ENDDO
         ENDDO
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_ENERGY_LOOP' &
+     &    ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NDIM,KIND=8) &
+     &    ,INT(NB,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     == MAP DENSITY MATRIX ONTO TOTAL AND SPIN DENSITY                       ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       IF(NDIM.EQ.1) THEN  !== TOTAL DENSITY ====================================
         DO LMN1=1,LMNX
           DO LMN2=1,LMNX
@@ -3922,6 +4021,12 @@ END IF
         DENMAT(:,:,1)=REAL(DENMAT(:,:,1),KIND=8)
         EDENMAT(:,:,1)=REAL(EDENMAT(:,:,1),KIND=8)
       END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_DENMAT_MAP_SYM' &
+     &    ,INT(LMNX,KIND=8),INT(NBH,KIND=8),INT(NDIMD,KIND=8) &
+     &    ,INT(NB,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     == PRINTOUT FOR TEST                                                    ==
@@ -3971,6 +4076,10 @@ END IF
       INTEGER(4)             :: IAT1,IAT2,N1,N2
       INTEGER(4)             :: IAT,ISP,NN
       INTEGER(4)             :: NTASKS,THISTASK
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                :: ACCEL_T0
+      REAL(8)                :: ACCEL_T1
+#ENDIF
 !     **************************************************************************
                                           CALL TRACE$PUSH('WAVES_OFFSITEDENMAT')
       NAT=MAP%NAT
@@ -4004,6 +4113,9 @@ END IF
 !     ==========================================================================
 !     == SET UP NEIGHBORLIST (ENCODED IN NNLIST)                              ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL MPE$QUERY('MONOMER',NTASKS,THISTASK)
       ALLOCATE(RC(NAT))
       DO IAT=1,NAT
@@ -4023,6 +4135,12 @@ END IF
       CALL MPE$BROADCAST('MONOMER',1,NNLIST(:,:NND))
       DEALLOCATE(RC)
       DEALLOCATE(R0)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_NEIGHBOR' &
+     &    ,INT(NAT,KIND=8),INT(NND,KIND=8),INT(NTASKS,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==  REPORT NEIGHBORLIST                                                 ==
@@ -4039,6 +4157,9 @@ END IF
 !     ==========================================================================
 !     == ALLOCATE DENSITY MATRIX
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       ALLOCATE(OSDENMAT(NND))
       DO NN=1,NND
         IAT1=NNLIST(1,NN)
@@ -4054,11 +4175,26 @@ END IF
         ALLOCATE(OSDENMAT(NN)%MAT(N1,N2,NDIMD))
         OSDENMAT(NN)%MAT(:,:,:)=0.D0
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_ALLOC' &
+     &    ,INT(NAT,KIND=8),INT(NND,KIND=8),INT(NDIMD,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     == EVALUATE DENSITY MATRIX
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       CALL WAVES_SUMMUPOFFSITEDENMAT()
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_SUM' &
+     &    ,INT(NAT,KIND=8),INT(NND,KIND=8),INT(NDIMD,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
                                                                 CALL TRACE$POP()
       RETURN
       END

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -259,6 +259,12 @@ path splits its estimated transfers into `ACC_COPY_1COV_PROJ_IN`,
 `ACC_COPY_1COV_MAT_OUT`, and, for inversion-symmetric superwave cases,
 `ACC_COPY_1COV_CMAT_OUT`; use those rows to decide whether a future optimization
 should target packed projector inputs or overlap-matrix outputs.
+One-center density-matrix profiling uses `PAW_DENMAT_*` rows to split the
+previous `PAW_ETOT_DENMAT` envelope into occupation setup, site setup, inner
+density/energy loops, accumulation, MPI combine, and spin conversion. Off-site
+density-matrix setup is split into `PAW_OFFDEN_*` rows. These rows are CPU-side
+instrumentation for deciding whether a later GPU kernel should target
+`WAVES_DENMAT` itself, the projection copy/setup edges, or off-site bookkeeping.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -1482,6 +1482,44 @@ copies and a `PSIM` copy-out. The performance-positive path is still broader
 projector, PRO, and wavefunction residency that lets later phases consume the
 GPU-resident data instead of copying it back immediately.
 
+## DENMAT Profiling Split
+
+The one-center density-matrix follow-up splits the previous coarse
+`PAW_ETOT_DENMAT` envelope into `PAW_DENMAT_*` rows for occupation setup, site
+setup, inner density/energy loops, accumulation, MPI combine, and spin
+conversion. It also adds coarse `PAW_OFFDEN_*` rows for off-site density-matrix
+bookkeeping. This is instrumentation only; it does not change the accelerator
+data path.
+
+Spark C86C validation:
+
+```
+runs/denmat-profiling-final-20260531-2048-1r
+runs/denmat-profiling-final-20260531-512-4r
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi` | 2048 | 1 | 41.70 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi` | 512 | 4 | 9.85 s | 1.7284 GB | 0.000000401 Ha |
+
+| Profile row | 2048 bands, 1 rank | 512 bands, 4 ranks, rank 1 |
+| --- | ---: | ---: |
+| `PAW_ETOT_DENMAT` | 4.1846 s | 0.2378 s |
+| `PAW_DENMAT_SITE_KERNEL` | 3.4608 s | 0.0827 s |
+| `PAW_DENMAT_ENERGY_LOOP` | 3.0668 s | 0.0798 s |
+| `PAW_DENMAT_DENSITY_LOOP` | 0.0131 s | 0.0023 s |
+| `PAW_OFFDEN_SUM` | 0.7213 s | 0.1534 s |
+
+All runs are energy-valid. The split shows that the large one-rank Si64 case is
+not dominated by projector setup or accumulation inside `WAVES$DENMAT`; it is
+dominated by the inner `WAVES_DENMAT` energy/Lambda loop. That makes a future
+GPU or BLAS-style rewrite of the one-center energy-density contraction a better
+candidate than further micro-optimizing DENMAT host setup. In the 4-rank smoke,
+the local DENMAT kernel is much smaller and off-site summation is the larger
+remaining subpiece, so a parallel follow-up should keep MPI/off-site behavior in
+view.
+
 ## Recommended Next Benchmark
 
 Use the focused default comparison for routine checks:


### PR DESCRIPTION
## Summary
- split the coarse `PAW_ETOT_DENMAT` profile envelope into `PAW_DENMAT_*` rows for occupation setup, site setup, inner density/energy loops, accumulation, MPI combine, and spin conversion
- add `PAW_OFFDEN_*` rows for off-site density-matrix neighbor/setup/sum work
- document the new rows in the profiling README and Spark benchmark summary

## Validation
Spark C86C / NVHPC 26.3:
- `nvhpc_gpu_acc_residency_profile` build: pass
- `nvhpc_gpu_acc_residency_profile_parallel` build: pass
- `git diff --check`: pass
- Si64 `NSTEPS=1`, `gpu_resident_hpsi`, 2048 empty bands, 1 rank: 41.70 s, 4.8988 GB, energy OK
- Si64 `NSTEPS=1`, `gpu_resident_hpsi`, 512 empty bands, 4 ranks: 9.85 s, 1.7284 GB, energy OK

## Notes
The split shows the 2048-band one-rank case is dominated by `WAVES_DENMAT` itself, especially `PAW_DENMAT_ENERGY_LOOP` at 3.0668 s inside a 4.1846 s `PAW_ETOT_DENMAT` envelope. The 4-rank smoke shrinks the local DENMAT kernel to 0.0827 s on rank 1 while `PAW_OFFDEN_SUM` is 0.1534 s, so a follow-up GPU kernel should target the one-center energy/Lambda contraction first and keep parallel/off-site behavior in view.
