### PR TITLE
Reuse DENMAT LAGR setup across atoms

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -3338,6 +3338,10 @@ END IF
 !     ************P.E. BLOECHL, TU-CLAUSTHAL (2005)*****************************
       USE MPE_MODULE
       USE WAVES_MODULE
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &        CPPAW_CUBLAS_ACC_DENMAT_ENERGY_ENABLED
+#ENDIF
       IMPLICIT NONE
       INTEGER(4),INTENT(IN)  :: LMNXX
       INTEGER(4),INTENT(IN)  :: NDIMD_
@@ -3354,6 +3358,7 @@ END IF
       COMPLEX(8),ALLOCATABLE :: PROJ(:,:,:) !(NDIM,NBH,LMNX) <PRO|PSPSI>
       COMPLEX(8),ALLOCATABLE :: DENMAT1(:,:,:)
       COMPLEX(8),ALLOCATABLE :: EDENMAT1(:,:,:)
+      COMPLEX(8),ALLOCATABLE :: LAGR(:,:)
       REAL(8)   ,ALLOCATABLE :: OCC(:,:,:)
       COMPLEX(8)             :: CSVAR1,CSVAR2
       INTEGER(4)             :: NTASKS,THISTASK
@@ -3361,6 +3366,11 @@ END IF
       REAL(8)   ,ALLOCATABLE :: XK(:,:)
       LOGICAL(4)             :: TINV
       INTEGER(4)             :: IB
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      INTEGER(4)             :: LMNXMAX
+      LOGICAL(4)             :: TUSEACCLAGR
+      REAL(8)                :: ACCEL_DENMAT_FLOPS
+#ENDIF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                :: ACCEL_T0
       REAL(8)                :: ACCEL_T1
@@ -3410,8 +3420,45 @@ END IF
         DO ISPIN=1,NSPIN
           CALL WAVES_SELECTWV(IKPT,ISPIN)
           CALL PLANEWAVE$SELECT(GSET%ID)
+          CALL PLANEWAVE$GETL4('TINV',TINV)
           NBH=THIS%NBH
           NB=THIS%NB
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+          ALLOCATE(LAGR(NB,NB))
+          DO IB=1,NB
+            LAGR(:,IB)=THIS%RLAM0(:,IB)*OCC(IB,IKPT,ISPIN)
+          ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          CALL ACCELPROFILE$ADD('PAW_DENMAT_LAGR_SETUP' &
+     &      ,INT(NB,KIND=8),INT(NB,KIND=8),1_8,0_8 &
+     &      ,0.D0,16.D0*REAL(NB,KIND=8)*REAL(NB,KIND=8) &
+     &      ,ACCEL_T1-ACCEL_T0)
+#ENDIF
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+          LMNXMAX=0
+          DO IAT=1,NAT
+            ISP=MAP%ISP(IAT)
+            LMNXMAX=MAX(LMNXMAX,MAP%LMNX(ISP))
+          ENDDO
+          ACCEL_DENMAT_FLOPS=32.D0*REAL(NBH,KIND=8)*REAL(NBH,KIND=8) &
+     &       *REAL(LMNXMAX,KIND=8)*REAL(NDIM,KIND=8) &
+     &       +16.D0*REAL(NBH,KIND=8)*REAL(LMNXMAX,KIND=8) &
+     &       *REAL(LMNXMAX,KIND=8)*REAL(NDIM,KIND=8)*REAL(NDIM,KIND=8)
+          TUSEACCLAGR=TINV &
+     &       .AND.CPPAW_CUBLAS_ACC_DENMAT_ENERGY_ENABLED &
+     &            (ACCEL_DENMAT_FLOPS)
+          IF(TUSEACCLAGR) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$ADD('ACC_COPY_DENMAT_LAGR_IN' &
+     &        ,INT(NB,KIND=8),INT(NB,KIND=8),1_8,0_8 &
+     &        ,0.D0,16.D0*REAL(NB,KIND=8)*REAL(NB,KIND=8),0.D0)
+#ENDIF
+!$ACC ENTER DATA COPYIN(LAGR(1:NB,1:NB))
+          END IF
+#ENDIF
           IPRO=1
           DO IAT=1,NAT
             ISP=MAP%ISP(IAT)
@@ -3444,7 +3491,7 @@ END IF
 !!$  IF(OCC(IB,IKPT,ISPIN).LT.1.D-5) CYCLE
 !!$  WRITE(*,FMT='(I3,40("(",2F10.5,")"))')IB,THIS%PROJ(:,IB,IPRO:IPRO-1+LMNX)
 !!$ENDDO
-            CALL WAVES_DENMAT(NDIM,NBH,NB,LMNX,OCC(1,IKPT,ISPIN),THIS%RLAM0 &
+            CALL WAVES_DENMAT(NDIM,NBH,NB,LMNX,OCC(1,IKPT,ISPIN),LAGR &
      &                       ,PROJ,DENMAT1,EDENMAT1)
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
             CALL ACCELPROFILE$NOW(ACCEL_T1)
@@ -3478,6 +3525,12 @@ END IF
 #ENDIF
             IPRO=IPRO+LMNX
           ENDDO
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+          IF(TUSEACCLAGR) THEN
+!$ACC EXIT DATA DELETE(LAGR(1:NB,1:NB))
+          END IF
+#ENDIF
+          DEALLOCATE(LAGR)
         ENDDO
       ENDDO
 !     == THE PROJECTIONS ARE IDENTICAL AND COMPLETE FOR EACH K-GROUP
@@ -3772,7 +3825,7 @@ END IF
       END
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
-      SUBROUTINE WAVES_DENMAT(NDIM,NBH,NB,LMNX,OCC,LAMBDA,PROPSI &
+      SUBROUTINE WAVES_DENMAT(NDIM,NBH,NB,LMNX,OCC,LAGR,PROPSI &
      &                       ,DENMAT,EDENMAT)
 !     **************************************************************************
 !     **                                                                      **
@@ -3798,14 +3851,13 @@ END IF
       INTEGER(4),INTENT(IN) :: NB     ! #(STATES)
       INTEGER(4),INTENT(IN) :: LMNX   ! #(PROJECTORS ON THIS SITE)
       REAL(8)   ,INTENT(IN) :: OCC(NB)! OCCUPATIONS
-      COMPLEX(8),INTENT(IN) :: LAMBDA(NB,NB)   !LAGRANGE/F
+      COMPLEX(8),INTENT(IN) :: LAGR(NB,NB)     ! LAGRANGE/F TIMES OCCUPATION
       COMPLEX(8),INTENT(IN) :: PROPSI(NDIM,NBH,LMNX) !<PRO|PSI>
       COMPLEX(8),INTENT(OUT):: DENMAT(LMNX,LMNX,NDIM**2)
       COMPLEX(8),INTENT(OUT):: EDENMAT(LMNX,LMNX,NDIM**2)
       COMPLEX(8)            :: DENMAT1(LMNX,LMNX,NDIM,NDIM)
       COMPLEX(8)            :: EDENMAT1(LMNX,LMNX,NDIM,NDIM)
       COMPLEX(8)            :: FUNC(LMNX,NDIM)
-      COMPLEX(8)            :: LAGR(NB,NB)
       LOGICAL(4)            :: TINV
       INTEGER(4)            :: LMN1,LMN2,IDIM1,IDIM2,IB,IB1,IB2
       REAL(8)               :: SVAR1,SVAR2
@@ -3914,9 +3966,6 @@ END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
-      DO IB2=1,NB
-        LAGR(:,IB2)=LAMBDA(:,IB2)*OCC(IB2)
-      ENDDO
       EDENMAT1(:,:,:,:)=(0.D0,0.D0)
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       IF(TUSEACCENERGY) THEN
@@ -4083,6 +4132,7 @@ END IF
 !     **  site; the profiling rows show whether a broader resident rewrite is **
 !     **  worth the extra data-structure work.                                **
 !     **************************************************************************
+      USE OPENACC
       IMPLICIT NONE
       INTEGER(4),INTENT(IN) :: NDIM
       INTEGER(4),INTENT(IN) :: NBH
@@ -4104,6 +4154,8 @@ END IF
       REAL(8)               :: ACCEL_BYTES
       REAL(8)               :: ACCEL_FLOPS
       REAL(8)               :: ACCEL_COPY_TIME
+      LOGICAL(4)            :: TLAGRPRESENT
+      LOGICAL(4)            :: TPROPSIPRESENT
 #ENDIF
 !     **************************************************************************
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
@@ -4113,14 +4165,26 @@ END IF
      &            +16.D0*REAL(NBH,KIND=8) &
      &            *REAL(LMNX,KIND=8)*REAL(LMNX,KIND=8) &
      &            *REAL(NDIM,KIND=8)*REAL(NDIM,KIND=8)
-      ACCEL_BYTES=16.D0*(REAL(NB,KIND=8)*REAL(NB,KIND=8) &
-     &            +REAL(NDIM,KIND=8)*REAL(NBH,KIND=8) &
-     &            *REAL(LMNX,KIND=8) &
-     &            +REAL(LMNX,KIND=8)*REAL(LMNX,KIND=8) &
-     &            *REAL(NDIM,KIND=8)*REAL(NDIM,KIND=8))
+      TLAGRPRESENT=ACC_IS_PRESENT(LAGR)
+      TPROPSIPRESENT=ACC_IS_PRESENT(PROPSI)
+      ACCEL_BYTES=16.D0*REAL(LMNX,KIND=8)*REAL(LMNX,KIND=8) &
+     &            *REAL(NDIM,KIND=8)*REAL(NDIM,KIND=8)
+      IF(.NOT.TLAGRPRESENT) THEN
+        ACCEL_BYTES=ACCEL_BYTES &
+     &      +16.D0*REAL(NB,KIND=8)*REAL(NB,KIND=8)
+      ELSE
+        CALL ACCELPROFILE$ADD('ACC_PRESENT_DENMAT_LAGR' &
+     &      ,INT(NB,KIND=8),INT(NB,KIND=8),1_8,0_8,0.D0,0.D0,0.D0)
+      END IF
+      IF(.NOT.TPROPSIPRESENT) THEN
+        ACCEL_BYTES=ACCEL_BYTES &
+     &      +16.D0*REAL(NDIM,KIND=8)*REAL(NBH,KIND=8) &
+     &      *REAL(LMNX,KIND=8)
+      END IF
 #ENDIF
       ALLOCATE(FUNCACC(LMNX,NDIM,NBH))
-!$ACC DATA COPYIN(LAGR(1:NB,1:NB),PROPSI(1:NDIM,1:NBH,1:LMNX)) &
+!$ACC DATA PRESENT_OR_COPYIN(LAGR(1:NB,1:NB) &
+!$ACC& ,PROPSI(1:NDIM,1:NBH,1:LMNX)) &
 !$ACC& CREATE(FUNCACC(1:LMNX,1:NDIM,1:NBH)) &
 !$ACC& COPYOUT(EDENMAT1(1:LMNX,1:LMNX,1:NDIM,1:NDIM))
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -269,9 +269,14 @@ An opt-in diagnostic, `CPPAW_GPU_DENMAT_ENERGY=1`, offloads the
 time-inversion `WAVES_DENMAT` energy/Lambda contraction with OpenACC and records
 `ACC_KERNEL_DENMAT_ENERGY_TINV` plus `ACC_COPY_DENMAT_ENERGY_TINV`; the harness
 cases are `gpu_resident_denmat_energy` and
-`gpu_resident_hpsi_denmat_energy`. It is disabled by default because the
-prototype copies the Lambda block per site and is meant to measure the value of
-a broader resident rewrite.
+`gpu_resident_hpsi_denmat_energy`. The outer `WAVES$DENMAT` setup records
+`PAW_DENMAT_LAGR_SETUP`, builds `LAGR=LAMBDA*OCC` once per k-point/spin, and,
+when the diagnostic is active, keeps that block resident across the atom loop.
+The LAGR device lifetime is visible through `ACC_COPY_DENMAT_LAGR_IN` and
+`ACC_PRESENT_DENMAT_LAGR`; the remaining per-site output copy is reported as
+`ACC_COPY_DENMAT_ENERGY_TINV`. It is disabled by default because the current
+Si64 wall time is still neutral even though the DENMAT envelope and transfer
+estimate shrink.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated
@@ -506,7 +511,9 @@ be overridden by kernel category:
   time-inversion one-center DENMAT energy/Lambda contraction with OpenACC. The
   compatibility alias is `CPPAW_CUBLAS_ACC_DENMAT_ENERGY`; use
   `CPPAW_GPU_DENMAT_MINFLOP` or `CPPAW_CUBLAS_ACC_DENMAT_MINFLOP` to adjust the
-  offload threshold.
+  offload threshold. Residency-profile builds precompute the corresponding
+  `LAGR=LAMBDA*OCC` block once per k-point/spin and keep it on the GPU while
+  the DENMAT diagnostic is active.
 
 The benchmark harness exposes conservative diagnostic cases such as
 `gpu_resident_projection_conservative`, `gpu_resident_overlap_conservative`,

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -30,6 +30,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `1cov-split-20260531-*` | One-center overlap copy accounting | `gpu_resident_hpsi` 40.48 s at 2048/1 | - | `gpu_resident_hpsi` 9.78 s at 512/4 | Splits the 1COV copy estimate into packed projector input and overlap-matrix output rows. |
 | `wave-io-split-20260531-*` | Wavefunction IO copy accounting | `gpu_resident_hpsi` 39.22 s at 2048/1 | - | `gpu_resident_hpsi` 9.72 s at 512/4 | Splits Gram, ORTHO, ADDPRO, and ADDOPSI wavefunction IO estimates into input and output rows. |
 | `denmat-energy-acc-v2-20260531-*` | DENMAT energy OpenACC diagnostic | `gpu_resident_hpsi` 39.00 s, `gpu_resident_hpsi_denmat_energy` 39.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.75 s at 512/4 | Adds an opt-in two-stage OpenACC diagnostic for the time-inversion DENMAT energy/Lambda contraction; DENMAT shrinks, but Lambda copies keep it diagnostic-only. |
+| `denmat-lagr-residency-20260531-*` | DENMAT LAGR setup/residency | `gpu_resident_hpsi` 37.19 s, `gpu_resident_hpsi_denmat_energy` 37.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.56 s at 512/4 | Precomputes `LAGR=LAMBDA*OCC` once per k-point/spin and keeps it resident for the DENMAT diagnostic; copy volume drops sharply, wall time remains neutral at 2048/1. |
 
 The latest full-matrix run lives at:
 
@@ -1560,6 +1561,55 @@ Spark because the prototype transfers Lambda once per site. The next useful
 step is therefore not to enable this by default, but to make Lambda/LAGR or the
 whole DENMAT working set resident across the atom loop, or to reformulate the
 contraction into a small batched BLAS path.
+
+## DENMAT LAGR Residency
+
+The next DENMAT follow-up precomputes `LAGR=LAMBDA*OCC` once per k-point/spin in
+the outer `WAVES$DENMAT` loop instead of rebuilding it inside every atom-site
+`WAVES_DENMAT` call. When `CPPAW_GPU_DENMAT_ENERGY=1` is active, the same LAGR
+block is copied to the GPU once and kept resident across the atom loop. New
+profile rows are `PAW_DENMAT_LAGR_SETUP`, `ACC_COPY_DENMAT_LAGR_IN`, and
+`ACC_PRESENT_DENMAT_LAGR`.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/denmat-lagr-residency-20260531-512-1r
+runs/denmat-lagr-residency-20260531-2048-1r
+runs/denmat-lagr-residency-20260531-512-4r
+```
+
+| Case | Empty bands | Ranks | Wall time | Total copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi` | 512 | 1 | 7.10 s | 1.3676 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 512 | 1 | 6.43 s | 1.3786 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi` | 2048 | 1 | 37.19 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 37.40 s | 4.9892 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi` | 512 | 4 | 9.81 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.56 s | 1.7591 GB | 0.000000401 Ha |
+
+| Profile row | 2048/1 baseline | 2048/1 DENMAT GPU | 512/4 baseline, rank 1 | 512/4 DENMAT GPU, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_DENMAT_LAGR_SETUP` | 0.0217 s | 0.0249 s | 0.0024 s | 0.0022 s |
+| `ACC_COPY_DENMAT_LAGR_IN` | - | 0.0758 GB | - | 0.0066 GB |
+| `ACC_PRESENT_DENMAT_LAGR` | - | 64 calls | - | 16 calls |
+| `PAW_ETOT_DENMAT` | 2.0660 s | 0.8893 s | 0.2280 s | 0.1910 s |
+| `PAW_DENMAT_SITE_KERNEL` | 1.3356 s | 0.1399 s | 0.0705 s | 0.0325 s |
+| `PAW_DENMAT_ENERGY_LOOP` | 1.3226 s | 0.1268 s | 0.0681 s | 0.0302 s |
+| `ACC_KERNEL_DENMAT_ENERGY_TINV` | - | 0.1252 s | - | 0.0214 s |
+| `ACC_COPY_DENMAT_ENERGY_TINV` | - | 0.0147 GB | - | 0.0011 GB |
+| `PAW_OFFDEN_SUM` | 0.6993 s | 0.7135 s | 0.1524 s | 0.1527 s |
+
+Compared with the previous DENMAT GPU diagnostic, the total copy estimate for
+`gpu_resident_hpsi_denmat_energy` drops from 9.7620 GB to 4.9892 GB at 2048/1
+and from 2.1523 GB to 1.7591 GB at 512/4. The DENMAT envelope itself also
+shrinks strongly, but the full Si64 wall time remains dominated by other phases
+at 2048/1. Keep the DENMAT energy path opt-in and use these rows to decide
+whether the next step should be a batched BLAS formulation or broader
+projector/wavefunction residency around the one-center work.
 
 ## Recommended Next Benchmark
 


### PR DESCRIPTION
## Summary
- precompute `LAGR=LAMBDA*OCC` once per k-point/spin in `WAVES$DENMAT` instead of rebuilding it for every atom-site `WAVES_DENMAT` call
- keep the precomputed LAGR block resident on the GPU while the opt-in `CPPAW_GPU_DENMAT_ENERGY=1` diagnostic walks the atom loop
- add/document profiling rows `PAW_DENMAT_LAGR_SETUP`, `ACC_COPY_DENMAT_LAGR_IN`, and `ACC_PRESENT_DENMAT_LAGR`

## Spark C86C validation
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile -j16`
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile_parallel -j16`
- `NSTEPS=1 EMPTY_BANDS=512 RANKS=1 CASES="gpu_resident_hpsi gpu_resident_hpsi_denmat_energy"`
- `NSTEPS=1 EMPTY_BANDS=2048 RANKS=1 CASES="gpu_resident_hpsi gpu_resident_hpsi_denmat_energy"`
- `NSTEPS=1 EMPTY_BANDS=512 RANKS=4 CASES="gpu_resident_hpsi gpu_resident_hpsi_denmat_energy"`

## Results
| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi` | 512 | 1 | 7.10 s | 1.3676 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy` | 512 | 1 | 6.43 s | 1.3786 GB | 0.000000401 Ha |
| `gpu_resident_hpsi` | 2048 | 1 | 37.19 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 37.40 s | 4.9892 GB | 0.000000407 Ha |
| `gpu_resident_hpsi` | 512 | 4 | 9.81 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.56 s | 1.7591 GB | 0.000000401 Ha |

The 2048/1 DENMAT diagnostic copy estimate drops from the previous 9.7620 GB to 4.9892 GB while keeping the energy-valid result. The full Si64 wall time is still neutral at 2048/1, so the DENMAT GPU path remains opt-in.