### PR TITLE
Split off-site DENMAT profiling

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4464,12 +4464,19 @@ END IF
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
       INTEGER(4)             :: NTASKS,THISTASK,ICOUNT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)                :: ACCEL_T0
+      REAL(8)                :: ACCEL_T1
+#ENDIF
 !     **************************************************************************
                                     CALL TRACE$PUSH('WAVES_SUMMUPOFFSITEDENMAT')
 !
 !     ==========================================================================
 !     ==  GET K-POINTS IN RELATIVE COORDINATES                                ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       ALLOCATE(XK(3,NKPTL))
       CALL WAVES_DYNOCCGETR8A('XK',3*NKPTL,XK)
       CALL DYNOCC$GETI4('NB',NBX)
@@ -4489,17 +4496,36 @@ END IF
         NPROAT(IAT)=MAP%LMNX(ISP)
         IPRO=IPRO+NPROAT(IAT)
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_SUM_SETUP' &
+     &    ,INT(NKPTL,KIND=8),INT(NSPIN,KIND=8),INT(NAT,KIND=8),0_8 &
+     &    ,0.D0,8.D0*REAL(NBX,KIND=8)*REAL(NKPTL,KIND=8) &
+     &    *REAL(NSPIN,KIND=8),ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==  ADD UP DENSITY MATRIX                                               ==
 !     ==========================================================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       NND=SIZE(OSDENMAT)
       DO NN=1,NND
         OSDENMAT(NN)%MAT=0.D0
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_SUM_ZERO' &
+     &    ,INT(NND,KIND=8),INT(NDIMD,KIND=8),0_8,0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
       NPRO=MAP%NPRO
       CALL MPE$QUERY('K',NTASKS,THISTASK)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       DO IKPT=1,NKPTL
         DO ISPIN=1,NSPIN
           CALL WAVES_SELECTWV(IKPT,ISPIN)
@@ -4585,6 +4611,12 @@ END IF
           ENDDO   !NN
         ENDDO   !ISPIN
       ENDDO  !IKPT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_SUM_LOCAL' &
+     &    ,INT(NND,KIND=8),INT(NPRO,KIND=8),INT(NB,KIND=8) &
+     &    ,INT(NTASKS,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==  SUM OVER MONOMER INCLUDES ALSO THE KPOINT SUM                       ==
@@ -4594,11 +4626,20 @@ END IF
 !     == THIS WAS DUE TO DIFFERING NEIGHBORLISTS ON DIFFERENT TASKS ============
 !     == THE PROBLEM IS FIXED BY BROADCASTING THE NEIGHBORLIST =================
 !     == IN WAVES$OFFSITEDENMAT(). =============================================
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
       DO NN=1,NND
 !       -- ONCE, THE CODE FAILED WITHIN MPI IN THE FOLLOWING CALL. THE FAILURE -
 !       -- WAS NOT DETERMINISTIC -----------------------------------------------
         CALL MPE$COMBINE('MONOMER','+',OSDENMAT(NN)%MAT)
       ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_SUM_COMBINE' &
+     &    ,INT(NND,KIND=8),INT(NDIMD,KIND=8),INT(NTASKS,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
 !
 !     ==========================================================================
 !     ==                                                                      ==

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -262,7 +262,10 @@ should target packed projector inputs or overlap-matrix outputs.
 One-center density-matrix profiling uses `PAW_DENMAT_*` rows to split the
 previous `PAW_ETOT_DENMAT` envelope into occupation setup, site setup, inner
 density/energy loops, accumulation, MPI combine, and spin conversion. Off-site
-density-matrix setup is split into `PAW_OFFDEN_*` rows. These rows are CPU-side
+density-matrix setup is split into `PAW_OFFDEN_*` rows, and the off-site
+accumulation envelope is split further into `PAW_OFFDEN_SUM_SETUP`,
+`PAW_OFFDEN_SUM_ZERO`, `PAW_OFFDEN_SUM_LOCAL`, and
+`PAW_OFFDEN_SUM_COMBINE`. These rows are CPU-side
 instrumentation for deciding whether a later GPU kernel should target
 `WAVES_DENMAT` itself, the projection copy/setup edges, or off-site bookkeeping.
 An opt-in diagnostic, `CPPAW_GPU_DENMAT_ENERGY=1`, offloads the

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -31,6 +31,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `wave-io-split-20260531-*` | Wavefunction IO copy accounting | `gpu_resident_hpsi` 39.22 s at 2048/1 | - | `gpu_resident_hpsi` 9.72 s at 512/4 | Splits Gram, ORTHO, ADDPRO, and ADDOPSI wavefunction IO estimates into input and output rows. |
 | `denmat-energy-acc-v2-20260531-*` | DENMAT energy OpenACC diagnostic | `gpu_resident_hpsi` 39.00 s, `gpu_resident_hpsi_denmat_energy` 39.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.75 s at 512/4 | Adds an opt-in two-stage OpenACC diagnostic for the time-inversion DENMAT energy/Lambda contraction; DENMAT shrinks, but Lambda copies keep it diagnostic-only. |
 | `denmat-lagr-residency-20260531-*` | DENMAT LAGR setup/residency | `gpu_resident_hpsi` 37.19 s, `gpu_resident_hpsi_denmat_energy` 37.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.56 s at 512/4 | Precomputes `LAGR=LAMBDA*OCC` once per k-point/spin and keeps it resident for the DENMAT diagnostic; copy volume drops sharply, wall time remains neutral at 2048/1. |
+| `offden-profile-split-20260531-*` | Off-site DENMAT profiling split | `gpu_resident_hpsi_denmat_energy` 36.39 s at 2048/1 | - | `gpu_resident_hpsi` 9.75 s at 512/4 | Splits `PAW_OFFDEN_SUM` into setup/zero/local/combine; off-site time is mostly local contraction, not MPI combine. |
 
 The latest full-matrix run lives at:
 
@@ -1610,6 +1611,49 @@ shrinks strongly, but the full Si64 wall time remains dominated by other phases
 at 2048/1. Keep the DENMAT energy path opt-in and use these rows to decide
 whether the next step should be a batched BLAS formulation or broader
 projector/wavefunction residency around the one-center work.
+
+## Off-Site DENMAT Split
+
+The next instrumentation pass splits the previous `PAW_OFFDEN_SUM` envelope
+inside `WAVES_SUMMUPOFFSITEDENMAT` into setup, zeroing, local contraction, and
+MPI combine rows:
+
+```
+PAW_OFFDEN_SUM_SETUP
+PAW_OFFDEN_SUM_ZERO
+PAW_OFFDEN_SUM_LOCAL
+PAW_OFFDEN_SUM_COMBINE
+```
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-profile-split-20260531-512-4r
+runs/offden-profile-split-20260531-2048-1r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi` | 512 | 4 | 9.75 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.77 s | 1.7591 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi` | 2048 | 1 | 38.70 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 36.39 s | 4.9892 GB | 0.000000407 Ha |
+
+| Profile row | 2048/1 baseline | 2048/1 DENMAT GPU | 512/4 baseline, rank 1 | 512/4 DENMAT GPU, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_SUM_SETUP` | 0.0000 s | 0.0000 s | 0.0001 s | 0.0000 s |
+| `PAW_OFFDEN_SUM_ZERO` | 0.0000 s | 0.0000 s | 0.0001 s | 0.0001 s |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.7136 s | 0.6979 s | 0.1386 s | 0.1374 s |
+| `PAW_OFFDEN_SUM_COMBINE` | 0.0000 s | 0.0000 s | 0.0152 s | 0.0394 s |
+
+The off-site remainder is therefore mostly local contraction work. At 2048/1
+the MPI combine row is negligible; at 512/4 it is visible but still smaller
+than the local loop on rank 1. This points the next off-site acceleration pass
+toward a local matrix-kernel rewrite or GPU residency around `THIS%PROJ`, not
+first toward MPI reduction tuning.
 
 ## Recommended Next Benchmark
 


### PR DESCRIPTION
## Summary
- split `WAVES_SUMMUPOFFSITEDENMAT` profiling below the existing `PAW_OFFDEN_SUM` envelope
- add `PAW_OFFDEN_SUM_SETUP`, `PAW_OFFDEN_SUM_ZERO`, `PAW_OFFDEN_SUM_LOCAL`, and `PAW_OFFDEN_SUM_COMBINE` rows
- document the Spark result: the off-site remainder is mostly local contraction work, not MPI combine

## Spark C86C validation
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile -j16`
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile_parallel -j16`
- `NSTEPS=1 EMPTY_BANDS=512 RANKS=4 CASES="gpu_resident_hpsi gpu_resident_hpsi_denmat_energy"`
- `NSTEPS=1 EMPTY_BANDS=2048 RANKS=1 CASES="gpu_resident_hpsi gpu_resident_hpsi_denmat_energy"`

## Results
| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi` | 512 | 4 | 9.75 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.77 s | 1.7591 GB | 0.000000401 Ha |
| `gpu_resident_hpsi` | 2048 | 1 | 38.70 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 36.39 s | 4.9892 GB | 0.000000407 Ha |

## Profile split
| Profile row | 2048/1 baseline | 2048/1 DENMAT GPU | 512/4 baseline, rank 1 | 512/4 DENMAT GPU, rank 1 |
| --- | ---: | ---: | ---: | ---: |
| `PAW_OFFDEN_SUM_LOCAL` | 0.7136 s | 0.6979 s | 0.1386 s | 0.1374 s |
| `PAW_OFFDEN_SUM_COMBINE` | ~0.0000 s | ~0.0000 s | 0.0152 s | 0.0394 s |

This keeps the change instrumentation-only and points the next off-site acceleration pass toward a local matrix-kernel rewrite or GPU residency around `THIS%PROJ`.