### PR TITLE
Add off-site DENMAT BLAS diagnostic

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4461,9 +4461,12 @@ END IF
       REAL(8)                :: SVAR
       REAL(8)                :: F1,F2
       LOGICAL(4)             :: TINV
+      LOGICAL(4)             :: TOFFDENBLAS
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
       INTEGER(4)             :: NTASKS,THISTASK,ICOUNT
+      CHARACTER(16)          :: ENVVAL
+      INTEGER(4)             :: ENVSTAT
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)                :: ACCEL_T0
       REAL(8)                :: ACCEL_T1
@@ -4482,6 +4485,21 @@ END IF
       CALL DYNOCC$GETI4('NB',NBX)
       ALLOCATE(OCC(NBX,NKPTL,NSPIN))
       CALL WAVES_DYNOCCGETR8A('OCC',NBX*NKPTL*NSPIN,OCC)
+      TOFFDENBLAS=.FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_LOCAL',ENVVAL &
+     &                             ,STATUS=ENVSTAT)
+      IF(ENVSTAT.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_OFFDEN_BLAS',ENVVAL &
+     &                               ,STATUS=ENVSTAT)
+      END IF
+      IF(ENVSTAT.EQ.0) THEN
+        SELECT CASE(TRIM(ADJUSTL(ENVVAL)))
+        CASE('1','T','t','TRUE','true','True','YES','yes','ON','on')
+          TOFFDENBLAS=.TRUE.
+        CASE DEFAULT
+          TOFFDENBLAS=.FALSE.
+        END SELECT
+      END IF
 !
 !     ==========================================================================
 !     ==  CONSTRUCT INDEX ARRAYS                                              ==
@@ -4545,6 +4563,13 @@ END IF
             EIKR=EXP(CI*SVAR)  !<P_{R+T}|PSI>=<P_R|PSI>*EIKR
             I0=IPRO1(IAT1)-1
             J0=IPRO1(IAT2)-1
+            IF(TOFFDENBLAS.AND.TINV.AND.NDIM.EQ.1) THEN
+              CALL WAVES_OFFDEN_TINV_NDIM1_BLAS(NPROAT(IAT1) &
+     &             ,NPROAT(IAT2),NBH,NB,NDIMD,NSPIN,ISPIN &
+     &             ,OCC(1,IKPT,ISPIN),EIKR,THIS%PROJ(1,1,I0+1) &
+     &             ,THIS%PROJ(1,1,J0+1),OSDENMAT(NN)%MAT)
+              CYCLE
+            END IF
             DO I=1,NPROAT(IAT1)
               DO J=1,NPROAT(IAT2)
 !
@@ -4666,6 +4691,115 @@ END IF
         CALL ERROR$STOP('WAVES_SUMMUPOFFSITEDENMAT')
       END IF
                                                                 CALL TRACE$POP()
+      RETURN
+      END
+!
+!     ...1.........2.........3.........4.........5.........6.........7.........8
+      SUBROUTINE WAVES_OFFDEN_TINV_NDIM1_BLAS(N1,N2,NBH,NB,NDIMD &
+     &                                       ,NSPIN,ISPIN,OCC,EIKR &
+     &                                       ,PROJ1,PROJ2,MAT)
+!     **************************************************************************
+!     **  BLAS diagnostic for the inversion-symmetric, scalar off-site        **
+!     **  density-matrix contraction. It is opt-in and intentionally limited  **
+!     **  to NDIM=1, where the original tensor-to-spin mapping is scalar.     **
+!     **************************************************************************
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN) :: N1
+      INTEGER(4),INTENT(IN) :: N2
+      INTEGER(4),INTENT(IN) :: NBH
+      INTEGER(4),INTENT(IN) :: NB
+      INTEGER(4),INTENT(IN) :: NDIMD
+      INTEGER(4),INTENT(IN) :: NSPIN
+      INTEGER(4),INTENT(IN) :: ISPIN
+      REAL(8)   ,INTENT(IN) :: OCC(NB)
+      COMPLEX(8),INTENT(IN) :: EIKR
+      COMPLEX(8),INTENT(IN) :: PROJ1(NBH,N1)
+      COMPLEX(8),INTENT(IN) :: PROJ2(NBH,N2)
+      REAL(8)   ,INTENT(INOUT) :: MAT(N1,N2,NDIMD)
+      COMPLEX(8),ALLOCATABLE :: A(:,:)
+      COMPLEX(8),ALLOCATABLE :: B(:,:)
+      COMPLEX(8),ALLOCATABLE :: WORK(:,:)
+      COMPLEX(8)            :: ONE
+      COMPLEX(8)            :: ZERO
+      REAL(8)               :: FPLUS
+      REAL(8)               :: FMINUS
+      INTEGER(4)            :: I,J,IBH
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)               :: ACCEL_T0
+      REAL(8)               :: ACCEL_T1
+      REAL(8)               :: ACCEL_FLOPS
+#ENDIF
+!     **************************************************************************
+      ONE=(1.D0,0.D0)
+      ZERO=(0.D0,0.D0)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+      ALLOCATE(A(N1,NBH))
+      ALLOCATE(B(N2,NBH))
+      ALLOCATE(WORK(N1,N2))
+      DO IBH=1,NBH
+        FPLUS=0.5D0*(OCC(2*IBH-1)+OCC(2*IBH))
+        FMINUS=0.5D0*(OCC(2*IBH-1)-OCC(2*IBH))
+        DO I=1,N1
+          A(I,IBH)=PROJ1(IBH,I)
+        ENDDO
+        DO J=1,N2
+          B(J,IBH)=FPLUS*CONJG(PROJ2(IBH,J))*CONJG(EIKR) &
+     &            +FMINUS*PROJ2(IBH,J)*EIKR
+        ENDDO
+      ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_BLAS_PACK' &
+     &    ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8),0_8 &
+     &    ,0.D0,16.D0*REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
+     &    ,ACCEL_T1-ACCEL_T0)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+      CALL ZGEMM('N','T',N1,N2,NBH,ONE,A,N1,B,N2,ZERO,WORK,N1)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      ACCEL_FLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &           *REAL(NBH,KIND=8)
+      CALL ACCELPROFILE$ADD('ZGEMM_OFFDEN_TINV_NDIM1' &
+     &    ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8),0_8 &
+     &    ,ACCEL_FLOPS,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
+     &    +REAL(N1,KIND=8)*REAL(N2,KIND=8)),ACCEL_T1-ACCEL_T0)
+      CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+      IF(NSPIN.EQ.1) THEN
+        DO J=1,N2
+          DO I=1,N1
+            MAT(I,J,1)=MAT(I,J,1)+REAL(WORK(I,J),KIND=8)
+          ENDDO
+        ENDDO
+      ELSE IF(NSPIN.EQ.2) THEN
+        IF(ISPIN.EQ.1) THEN
+          DO J=1,N2
+            DO I=1,N1
+              MAT(I,J,1)=MAT(I,J,1)+REAL(WORK(I,J),KIND=8)
+              MAT(I,J,2)=MAT(I,J,2)+REAL(WORK(I,J),KIND=8)
+            ENDDO
+          ENDDO
+        ELSE
+          DO J=1,N2
+            DO I=1,N1
+              MAT(I,J,1)=MAT(I,J,1)+REAL(WORK(I,J),KIND=8)
+              MAT(I,J,2)=MAT(I,J,2)-REAL(WORK(I,J),KIND=8)
+            ENDDO
+          ENDDO
+        END IF
+      END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL ACCELPROFILE$NOW(ACCEL_T1)
+      CALL ACCELPROFILE$ADD('PAW_OFFDEN_BLAS_ACCUM' &
+     &    ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8),0_8 &
+     &    ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
+      DEALLOCATE(WORK)
+      DEALLOCATE(B)
+      DEALLOCATE(A)
       RETURN
       END
 !

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -280,6 +280,14 @@ The LAGR device lifetime is visible through `ACC_COPY_DENMAT_LAGR_IN` and
 `ACC_COPY_DENMAT_ENERGY_TINV`. It is disabled by default because the current
 Si64 wall time is still neutral even though the DENMAT envelope and transfer
 estimate shrink.
+The scalar time-inversion off-site DENMAT diagnostic is enabled with
+`CPPAW_GPU_OFFDEN_LOCAL=1`; `CPPAW_OFFDEN_BLAS=1` is kept as a shorter alias.
+It rewrites the `TINV`/`NDIM=1` off-site local contraction as packed
+`ZGEMM` calls and records `PAW_OFFDEN_BLAS_PACK`,
+`ZGEMM_OFFDEN_TINV_NDIM1`, and `PAW_OFFDEN_BLAS_ACCUM`. This is still a
+host-data BLAS prototype rather than a full resident GPU path, so it is
+disabled by default and should be used to quantify whether keeping projector
+buffers resident on the GPU would be worthwhile.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated
@@ -349,6 +357,10 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_hpsi` | Opt-in residency diagnostic that keeps `HPSI` on the GPU from Hamiltonian-side `WAVES_ADDPRO` through the immediate expectation/Hamiltonian overlaps via `CPPAW_GPU_HPSI_RESIDENCY=1`. |
 | `gpu_resident_denmat_energy` | Opt-in diagnostic that sets `CPPAW_GPU_DENMAT_ENERGY=1` and forces the time-inversion one-center DENMAT energy/Lambda OpenACC prototype for comparison. |
 | `gpu_resident_hpsi_denmat_energy` | Combined diagnostic with HPSI residency and the DENMAT energy/Lambda OpenACC prototype enabled together. |
+| `gpu_resident_offden_blas` | Opt-in diagnostic that sets `CPPAW_GPU_OFFDEN_LOCAL=1` and rewrites scalar `TINV` off-site DENMAT local work as packed BLAS. |
+| `gpu_resident_hpsi_offden_blas` | Combined HPSI residency plus scalar `TINV` off-site DENMAT BLAS diagnostic. |
+| `gpu_resident_denmat_energy_offden_blas` | Combined DENMAT energy/Lambda diagnostic plus scalar `TINV` off-site DENMAT BLAS diagnostic. |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar `TINV` off-site DENMAT BLAS diagnostic. |
 | `gpu_psim_propagate` | Opt-in diagnostic that propagates `PSIM` on the GPU and copies it back before orthogonalization via `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_hpsi_psim_propagate` | Combined diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -32,6 +32,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `denmat-energy-acc-v2-20260531-*` | DENMAT energy OpenACC diagnostic | `gpu_resident_hpsi` 39.00 s, `gpu_resident_hpsi_denmat_energy` 39.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.75 s at 512/4 | Adds an opt-in two-stage OpenACC diagnostic for the time-inversion DENMAT energy/Lambda contraction; DENMAT shrinks, but Lambda copies keep it diagnostic-only. |
 | `denmat-lagr-residency-20260531-*` | DENMAT LAGR setup/residency | `gpu_resident_hpsi` 37.19 s, `gpu_resident_hpsi_denmat_energy` 37.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.56 s at 512/4 | Precomputes `LAGR=LAMBDA*OCC` once per k-point/spin and keeps it resident for the DENMAT diagnostic; copy volume drops sharply, wall time remains neutral at 2048/1. |
 | `offden-profile-split-20260531-*` | Off-site DENMAT profiling split | `gpu_resident_hpsi_denmat_energy` 36.39 s at 2048/1 | - | `gpu_resident_hpsi` 9.75 s at 512/4 | Splits `PAW_OFFDEN_SUM` into setup/zero/local/combine; off-site time is mostly local contraction, not MPI combine. |
+| `offden-blas-diagnostic-20260531-*` / `offden-blas-combined-20260531-*` | Off-site DENMAT BLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` 36.91 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` 9.76 s at 512/4 | Rewrites scalar `TINV` off-site local work as packed `ZGEMM`; energy-valid, much faster inside `PAW_OFFDEN_SUM_LOCAL`, still opt-in host-data diagnostic. |
 
 The latest full-matrix run lives at:
 
@@ -1654,6 +1655,71 @@ the MPI combine row is negligible; at 512/4 it is visible but still smaller
 than the local loop on rank 1. This points the next off-site acceleration pass
 toward a local matrix-kernel rewrite or GPU residency around `THIS%PROJ`, not
 first toward MPI reduction tuning.
+
+## Off-Site DENMAT BLAS Diagnostic
+
+The follow-up diagnostic adds `CPPAW_GPU_OFFDEN_LOCAL=1` with
+`CPPAW_OFFDEN_BLAS=1` as an alias. For scalar `TINV`/`NDIM=1` off-site DENMAT
+neighbors it packs the projector factors and evaluates the local contraction
+with `ZGEMM`, recording:
+
+```
+PAW_OFFDEN_BLAS_PACK
+ZGEMM_OFFDEN_TINV_NDIM1
+PAW_OFFDEN_BLAS_ACCUM
+```
+
+This is still a host-data BLAS prototype, not a fully resident cuBLAS path.
+It is intentionally disabled by default. Its role is to measure whether the
+local loop has enough matrix-kernel structure to justify a later resident
+projector/GPU implementation.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-blas-diagnostic-20260531-512-4r
+runs/offden-blas-diagnostic-20260531-2048-1r
+runs/offden-blas-combined-20260531-512-4r
+runs/offden-blas-combined-20260531-2048-1r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi` | 512 | 4 | 9.86 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.16 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi` | 2048 | 1 | 38.79 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 37.91 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.83 s | 1.7591 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.76 s | 1.7591 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 37.75 s | 4.9892 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.91 s | 4.9892 GB | 0.000000407 Ha |
+
+| Profile row | 2048/1 HPSI | 2048/1 HPSI+BLAS | 512/4 HPSI, rank 1 | 512/4 HPSI+BLAS, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.7183 s | 0.0723 s | 0.1396 s | 0.0194 s |
+| `PAW_OFFDEN_SUM_COMBINE` | 0.0000 s | 0.0000 s | 0.0166 s | 0.0209 s |
+| `PAW_OFFDEN_BLAS_PACK` | - | 0.0219 s | - | 0.0058 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.0490 s | - | 0.0126 s |
+| `PAW_OFFDEN_BLAS_ACCUM` | - | 0.0002 s | - | 0.0001 s |
+
+| Profile row | 2048/1 DENMAT GPU | 2048/1 DENMAT GPU+BLAS | 512/4 DENMAT GPU, rank 1 | 512/4 DENMAT GPU+BLAS, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.7151 s | 0.0734 s | 0.1403 s | 0.0181 s |
+| `PAW_OFFDEN_SUM_COMBINE` | 0.0000 s | 0.0000 s | 0.0152 s | 0.0158 s |
+| `PAW_OFFDEN_BLAS_PACK` | - | 0.0220 s | - | 0.0056 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.0498 s | - | 0.0119 s |
+| `PAW_OFFDEN_BLAS_ACCUM` | - | 0.0002 s | - | 0.0001 s |
+
+The local contraction shrinks by roughly one order of magnitude in both the
+plain HPSI and combined DENMAT-GPU cases, while all energy checks remain within
+the existing Si64 tolerance. The total wall-time change is modest because the
+Si64 step is dominated by other phases and the prototype still packs host
+buffers every neighbor. The next useful GPU step is therefore not another
+off-site timing split, but keeping projector/packed off-site buffers resident
+and moving this matrix formulation behind an OpenACC/cuBLAS-aware backend.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -260,6 +260,12 @@ case_note() {
     gpu_resident_hpsi_denmat_energy)
       echo "Combined HPSI residency plus DENMAT energy/Lambda OpenACC diagnostic."
       ;;
+    gpu_resident_offden_blas)
+      echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
+      ;;
+    gpu_resident_hpsi_offden_blas)
+      echo "Combined HPSI residency plus scalar TINV off-site DENMAT BLAS prototype."
+      ;;
     gpu_psim_propagate|gpu_resident_psim)
       echo "Diagnostic that propagates PSIM on the GPU and copies it back before orthogonalization."
       ;;
@@ -475,6 +481,8 @@ case_env() {
     gpu_resident_hpsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_denmat_energy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} $(cublas_env)" ;;
+    gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
+    gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;
     gpu_hpsi_psim_propagate|gpu_resident_hpsi_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;
     gpu_resident_hpsi_opsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 $(cublas_env)" ;;

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -260,6 +260,12 @@ case_note() {
     gpu_resident_hpsi_denmat_energy)
       echo "Combined HPSI residency plus DENMAT energy/Lambda OpenACC diagnostic."
       ;;
+    gpu_resident_denmat_energy_offden_blas)
+      echo "Combined DENMAT energy/Lambda OpenACC diagnostic plus scalar TINV off-site DENMAT BLAS prototype."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_blas)
+      echo "Combined HPSI residency, DENMAT energy/Lambda OpenACC diagnostic, and scalar TINV off-site DENMAT BLAS prototype."
+      ;;
     gpu_resident_offden_blas)
       echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
       ;;
@@ -481,6 +487,8 @@ case_env() {
     gpu_resident_hpsi) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_denmat_energy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} $(cublas_env)" ;;
+    gpu_resident_denmat_energy_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary
- Adds an opt-in scalar `TINV`/`NDIM=1` off-site DENMAT diagnostic guarded by `CPPAW_GPU_OFFDEN_LOCAL=1` (`CPPAW_OFFDEN_BLAS=1` alias).
- Rewrites the off-site local contraction as packed `ZGEMM` work and records `PAW_OFFDEN_BLAS_PACK`, `ZGEMM_OFFDEN_TINV_NDIM1`, and `PAW_OFFDEN_BLAS_ACCUM` profile rows.
- Extends the Si64 harness with standalone and combined DENMAT-energy cases, then documents the Spark results.

## Notes
This is a host-data BLAS prototype, not a finished resident cuBLAS path. It stays disabled by default and is meant to quantify whether a later projector-resident GPU path is worthwhile.

## Spark C86C validation
Builds:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Runs:
- `runs/offden-blas-diagnostic-20260531-512-4r`
- `runs/offden-blas-diagnostic-20260531-2048-1r`
- `runs/offden-blas-combined-20260531-512-4r`
- `runs/offden-blas-combined-20260531-2048-1r`

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi` | 512 | 4 | 9.86 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.16 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi` | 2048 | 1 | 38.79 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 37.91 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy` | 512 | 4 | 9.83 s | 1.7591 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.76 s | 1.7591 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy` | 2048 | 1 | 37.75 s | 4.9892 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.91 s | 4.9892 GB | 0.000000407 Ha |

| Profile row | 2048/1 HPSI | 2048/1 HPSI+BLAS | 512/4 HPSI rank 1 | 512/4 HPSI+BLAS rank 1 |
| --- | ---: | ---: | ---: | ---: |
| `PAW_OFFDEN_SUM_LOCAL` | 0.7183 s | 0.0723 s | 0.1396 s | 0.0194 s |
| `PAW_OFFDEN_SUM_COMBINE` | 0.0000 s | 0.0000 s | 0.0166 s | 0.0209 s |
| `PAW_OFFDEN_BLAS_PACK` | - | 0.0219 s | - | 0.0058 s |
| `ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.0490 s | - | 0.0126 s |

| Profile row | 2048/1 DENMAT GPU | 2048/1 DENMAT GPU+BLAS | 512/4 DENMAT GPU rank 1 | 512/4 DENMAT GPU+BLAS rank 1 |
| --- | ---: | ---: | ---: | ---: |
| `PAW_OFFDEN_SUM_LOCAL` | 0.7151 s | 0.0734 s | 0.1403 s | 0.0181 s |
| `PAW_OFFDEN_SUM_COMBINE` | 0.0000 s | 0.0000 s | 0.0152 s | 0.0158 s |
| `PAW_OFFDEN_BLAS_PACK` | - | 0.0220 s | - | 0.0056 s |
| `ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.0498 s | - | 0.0119 s |

## Conclusion
The local off-site contraction shrinks by roughly one order of magnitude, while all energy checks stay within the existing Si64 tolerance. Overall Si64 wall time changes only modestly, so the next useful GPU step is projector/packed-buffer residency plus an OpenACC/cuBLAS-aware backend for this matrix formulation.
