### PR TITLE
Add off-site DENMAT cuBLAS diagnostic

### DIFF
--- a/src/paw_accel_cublas.f90
+++ b/src/paw_accel_cublas.f90
@@ -63,6 +63,7 @@
       REAL(8)            :: MINFLOP_ADDPRODUCT=1.D7
       REAL(8)            :: MINFLOP_MATMUL=1.D7
       REAL(8)            :: MINFLOP_DENMAT=1.D8
+      REAL(8)            :: MINFLOP_OFFDEN=1.D8
       CHARACTER(16)      :: OVERLAP_PROFILE_ID=''
       CONTAINS
 !
@@ -425,6 +426,10 @@
      &    ('CPPAW_GPU_DENMAT_MINFLOP',MINFLOP_DENMAT)
       CALL CPPAW_CUBLAS_ACC_READ_REAL_ENV &
      &    ('CPPAW_CUBLAS_ACC_DENMAT_MINFLOP',MINFLOP_DENMAT)
+      CALL CPPAW_CUBLAS_ACC_READ_REAL_ENV &
+     &    ('CPPAW_GPU_OFFDEN_MINFLOP',MINFLOP_OFFDEN)
+      CALL CPPAW_CUBLAS_ACC_READ_REAL_ENV &
+     &    ('CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP',MINFLOP_OFFDEN)
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_SYNC',VALUE &
      &                             ,STATUS=STATUS)
       IF(STATUS.EQ.0) THEN
@@ -698,6 +703,17 @@
      &                                  .AND.(FLOPS.GE.MINFLOP_MATMUL)
       RETURN
       END FUNCTION CPPAW_CUBLAS_ACC_SHOULD_USE_MATMUL
+!
+!     ..........................................................................
+      LOGICAL(4) FUNCTION CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN(FLOPS)
+      IMPLICIT NONE
+      REAL(8),INTENT(IN) :: FLOPS
+!     **************************************************************************
+      CALL CPPAW_CUBLAS_ACC_INITCONFIG
+      CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN=ENABLED &
+     &                                  .AND.(FLOPS.GE.MINFLOP_OFFDEN)
+      RETURN
+      END FUNCTION CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN
 !
 !     ..........................................................................
       LOGICAL(4) FUNCTION CPPAW_CUBLAS_ACC_RESIDENCY_ENABLED()
@@ -1190,6 +1206,66 @@
       CALL CPPAW_CUBLAS_ACC_FINISH(ISTAT)
       RETURN
       END SUBROUTINE CPPAW_CUBLAS_ACC_DGEMM_NT_PRESENT
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY(LEN1,LEN2,N,PSI1 &
+     &                                         ,PSI2,OPERATOR,USED)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN)  :: LEN1
+      INTEGER(4),INTENT(IN)  :: LEN2
+      INTEGER(4),INTENT(IN)  :: N
+      COMPLEX(8),INTENT(IN)  :: PSI1(LEN1,N)
+      COMPLEX(8),INTENT(IN)  :: PSI2(LEN2,N)
+      COMPLEX(8),INTENT(OUT) :: OPERATOR(LEN1,LEN2)
+      LOGICAL(4),INTENT(OUT) :: USED
+      REAL(8)                :: FLOPS
+!     **************************************************************************
+      FLOPS=8.D0*REAL(LEN1,KIND=8)*REAL(LEN2,KIND=8)*REAL(N,KIND=8)
+      USED=CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN(FLOPS)
+      IF(.NOT.USED) RETURN
+!$ACC DATA COPYIN(PSI1(1:LEN1,1:N),PSI2(1:LEN2,1:N)) &
+!$ACC& COPYOUT(OPERATOR(1:LEN1,1:LEN2))
+      CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT(LEN1,LEN2,N,PSI1 &
+     &                                      ,PSI2,OPERATOR)
+!$ACC END DATA
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      CALL CPPAW_CUBLAS_ACC_PROFILE_BYTES('ACC_COPY_CUBLAS_ZGEMM_NT' &
+     &     ,LEN1,LEN2,N,0,16.D0*(REAL(LEN1,KIND=8)*REAL(N,KIND=8) &
+     &     +REAL(LEN2,KIND=8)*REAL(N,KIND=8) &
+     &     +REAL(LEN1,KIND=8)*REAL(LEN2,KIND=8)))
+#ENDIF
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY
+!
+!     ..........................................................................
+      SUBROUTINE CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT(LEN1,LEN2,N,PSI1 &
+     &                                            ,PSI2,OPERATOR)
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN)  :: LEN1
+      INTEGER(4),INTENT(IN)  :: LEN2
+      INTEGER(4),INTENT(IN)  :: N
+      COMPLEX(8),INTENT(IN)  :: PSI1(LEN1,N)
+      COMPLEX(8),INTENT(IN)  :: PSI2(LEN2,N)
+      COMPLEX(8),INTENT(OUT) :: OPERATOR(LEN1,LEN2)
+      COMPLEX(8)             :: ONE
+      COMPLEX(8)             :: ZERO
+      INTEGER(4)             :: ISTAT
+!     **************************************************************************
+      ONE=(1.D0,0.D0)
+      ZERO=(0.D0,0.D0)
+      CALL CPPAW_CUBLAS_ACC_ENSURE
+!$ACC HOST_DATA USE_DEVICE(PSI1,PSI2,OPERATOR)
+      ISTAT=CUBLASZGEMM(HANDLE,CUBLAS_OP_N,CUBLAS_OP_T,LEN1,LEN2,N &
+     &                 ,ONE,PSI1,LEN1,PSI2,LEN2,ZERO,OPERATOR,LEN1)
+!$ACC END HOST_DATA
+      IF(ISTAT.NE.0) THEN
+        CALL ERROR$MSG('CUBLASZGEMM FAILED')
+        CALL ERROR$I4VAL('STATUS',ISTAT)
+        CALL ERROR$STOP('CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT')
+      END IF
+      CALL CPPAW_CUBLAS_ACC_FINISH(ISTAT)
+      RETURN
+      END SUBROUTINE CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT
 !
 !     ..........................................................................
       SUBROUTINE CPPAW_CUBLAS_ACC_ZGEMM_NC_COPY(LEN1,LEN2,N,PSI1 &

--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4462,6 +4462,7 @@ END IF
       REAL(8)                :: F1,F2
       LOGICAL(4)             :: TINV
       LOGICAL(4)             :: TOFFDENBLAS
+      LOGICAL(4)             :: TOFFDENCUBLAS
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
       INTEGER(4)             :: NTASKS,THISTASK,ICOUNT
@@ -4486,6 +4487,7 @@ END IF
       ALLOCATE(OCC(NBX,NKPTL,NSPIN))
       CALL WAVES_DYNOCCGETR8A('OCC',NBX*NKPTL*NSPIN,OCC)
       TOFFDENBLAS=.FALSE.
+      TOFFDENCUBLAS=.FALSE.
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_LOCAL',ENVVAL &
      &                             ,STATUS=ENVSTAT)
       IF(ENVSTAT.NE.0) THEN
@@ -4498,6 +4500,21 @@ END IF
           TOFFDENBLAS=.TRUE.
         CASE DEFAULT
           TOFFDENBLAS=.FALSE.
+        END SELECT
+      END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_CUBLAS',ENVVAL &
+     &                             ,STATUS=ENVSTAT)
+      IF(ENVSTAT.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_OFFDEN',ENVVAL &
+     &                               ,STATUS=ENVSTAT)
+      END IF
+      IF(ENVSTAT.EQ.0) THEN
+        SELECT CASE(TRIM(ADJUSTL(ENVVAL)))
+        CASE('1','T','t','TRUE','true','True','YES','yes','ON','on')
+          TOFFDENBLAS=.TRUE.
+          TOFFDENCUBLAS=.TRUE.
+        CASE DEFAULT
+          TOFFDENCUBLAS=.FALSE.
         END SELECT
       END IF
 !
@@ -4567,7 +4584,8 @@ END IF
               CALL WAVES_OFFDEN_TINV_NDIM1_BLAS(NPROAT(IAT1) &
      &             ,NPROAT(IAT2),NBH,NB,NDIMD,NSPIN,ISPIN &
      &             ,OCC(1,IKPT,ISPIN),EIKR,THIS%PROJ(1,1,I0+1) &
-     &             ,THIS%PROJ(1,1,J0+1),OSDENMAT(NN)%MAT)
+     &             ,THIS%PROJ(1,1,J0+1),OSDENMAT(NN)%MAT &
+     &             ,TOFFDENCUBLAS)
               CYCLE
             END IF
             DO I=1,NPROAT(IAT1)
@@ -4697,7 +4715,12 @@ END IF
 !     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE WAVES_OFFDEN_TINV_NDIM1_BLAS(N1,N2,NBH,NB,NDIMD &
      &                                       ,NSPIN,ISPIN,OCC,EIKR &
-     &                                       ,PROJ1,PROJ2,MAT)
+     &                                       ,PROJ1,PROJ2,MAT &
+     &                                       ,TCUBLAS)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &        CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY
+#ENDIF
 !     **************************************************************************
 !     **  BLAS diagnostic for the inversion-symmetric, scalar off-site        **
 !     **  density-matrix contraction. It is opt-in and intentionally limited  **
@@ -4716,6 +4739,7 @@ END IF
       COMPLEX(8),INTENT(IN) :: PROJ1(NBH,N1)
       COMPLEX(8),INTENT(IN) :: PROJ2(NBH,N2)
       REAL(8)   ,INTENT(INOUT) :: MAT(N1,N2,NDIMD)
+      LOGICAL(4),INTENT(IN) :: TCUBLAS
       COMPLEX(8),ALLOCATABLE :: A(:,:)
       COMPLEX(8),ALLOCATABLE :: B(:,:)
       COMPLEX(8),ALLOCATABLE :: WORK(:,:)
@@ -4724,14 +4748,17 @@ END IF
       REAL(8)               :: FPLUS
       REAL(8)               :: FMINUS
       INTEGER(4)            :: I,J,IBH
+      LOGICAL(4)            :: TCUBLAS_USED
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)               :: ACCEL_T0
       REAL(8)               :: ACCEL_T1
       REAL(8)               :: ACCEL_FLOPS
+      CHARACTER(32)         :: ACCEL_GEMM_NAME
 #ENDIF
 !     **************************************************************************
       ONE=(1.D0,0.D0)
       ZERO=(0.D0,0.D0)
+      TCUBLAS_USED=.FALSE.
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
@@ -4757,12 +4784,25 @@ END IF
      &    ,ACCEL_T1-ACCEL_T0)
       CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
-      CALL ZGEMM('N','T',N1,N2,NBH,ONE,A,N1,B,N2,ZERO,WORK,N1)
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      IF(TCUBLAS) THEN
+        CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY(N1,N2,NBH,A,B,WORK &
+     &                                     ,TCUBLAS_USED)
+      END IF
+#ENDIF
+      IF(.NOT.TCUBLAS_USED) THEN
+        CALL ZGEMM('N','T',N1,N2,NBH,ONE,A,N1,B,N2,ZERO,WORK,N1)
+      END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       CALL ACCELPROFILE$NOW(ACCEL_T1)
       ACCEL_FLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
      &           *REAL(NBH,KIND=8)
-      CALL ACCELPROFILE$ADD('ZGEMM_OFFDEN_TINV_NDIM1' &
+      IF(TCUBLAS_USED) THEN
+        ACCEL_GEMM_NAME='CUBLAS_ZGEMM_OFFDEN_TINV_NDIM1'
+      ELSE
+        ACCEL_GEMM_NAME='ZGEMM_OFFDEN_TINV_NDIM1'
+      END IF
+      CALL ACCELPROFILE$ADD(ACCEL_GEMM_NAME &
      &    ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8),0_8 &
      &    ,ACCEL_FLOPS,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
      &    +REAL(N1,KIND=8)*REAL(N2,KIND=8)),ACCEL_T1-ACCEL_T0)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -288,6 +288,13 @@ It rewrites the `TINV`/`NDIM=1` off-site local contraction as packed
 host-data BLAS prototype rather than a full resident GPU path, so it is
 disabled by default and should be used to quantify whether keeping projector
 buffers resident on the GPU would be worthwhile.
+`CPPAW_GPU_OFFDEN_CUBLAS=1` or `CPPAW_CUBLAS_ACC_OFFDEN=1` additionally
+tries cuBLAS for that packed `ZGEMM(N,T)` through
+`CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP`; the forced harness cases set this threshold
+to 1. Spark Si64 shows that the per-neighbor cuBLAS prototype is slower inside
+`PAW_OFFDEN_SUM_LOCAL` than host BLAS because the matrices are tiny and copied
+for every neighbor. Keep it as a diagnostic only; a useful GPU version should
+batch neighbors and/or keep packed projector buffers resident.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated
@@ -361,6 +368,9 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_hpsi_offden_blas` | Combined HPSI residency plus scalar `TINV` off-site DENMAT BLAS diagnostic. |
 | `gpu_resident_denmat_energy_offden_blas` | Combined DENMAT energy/Lambda diagnostic plus scalar `TINV` off-site DENMAT BLAS diagnostic. |
 | `gpu_resident_hpsi_denmat_energy_offden_blas` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar `TINV` off-site DENMAT BLAS diagnostic. |
+| `gpu_resident_offden_cublas` | Diagnostic that forces `CPPAW_GPU_OFFDEN_CUBLAS=1` and `CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=1` for the scalar off-site DENMAT BLAS prototype. |
+| `gpu_resident_hpsi_offden_cublas` | Combined HPSI residency plus scalar off-site DENMAT cuBLAS diagnostic. |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_psim_propagate` | Opt-in diagnostic that propagates `PSIM` on the GPU and copies it back before orthogonalization via `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_hpsi_psim_propagate` | Combined diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -33,6 +33,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `denmat-lagr-residency-20260531-*` | DENMAT LAGR setup/residency | `gpu_resident_hpsi` 37.19 s, `gpu_resident_hpsi_denmat_energy` 37.40 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy` 9.56 s at 512/4 | Precomputes `LAGR=LAMBDA*OCC` once per k-point/spin and keeps it resident for the DENMAT diagnostic; copy volume drops sharply, wall time remains neutral at 2048/1. |
 | `offden-profile-split-20260531-*` | Off-site DENMAT profiling split | `gpu_resident_hpsi_denmat_energy` 36.39 s at 2048/1 | - | `gpu_resident_hpsi` 9.75 s at 512/4 | Splits `PAW_OFFDEN_SUM` into setup/zero/local/combine; off-site time is mostly local contraction, not MPI combine. |
 | `offden-blas-diagnostic-20260531-*` / `offden-blas-combined-20260531-*` | Off-site DENMAT BLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` 36.91 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` 9.76 s at 512/4 | Rewrites scalar `TINV` off-site local work as packed `ZGEMM`; energy-valid, much faster inside `PAW_OFFDEN_SUM_LOCAL`, still opt-in host-data diagnostic. |
+| `offden-cublas-diagnostic-20260531-*` / `offden-cublas-combined-20260531-*` | Naive off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 36.79 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 9.75 s at 512/4 | Adds a forced per-neighbor cuBLAS diagnostic; energy-valid, but kernel timings are worse than host BLAS, so the next GPU attempt must batch or keep buffers resident. |
 
 The latest full-matrix run lives at:
 
@@ -1720,6 +1721,61 @@ Si64 step is dominated by other phases and the prototype still packs host
 buffers every neighbor. The next useful GPU step is therefore not another
 off-site timing split, but keeping projector/packed off-site buffers resident
 and moving this matrix formulation behind an OpenACC/cuBLAS-aware backend.
+
+## Off-Site DENMAT cuBLAS Diagnostic
+
+The follow-up cuBLAS diagnostic adds `CPPAW_GPU_OFFDEN_CUBLAS=1` with
+`CPPAW_CUBLAS_ACC_OFFDEN=1` as an alias and a separate
+`CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP` threshold. The harness forces that threshold
+to 1 for `gpu_resident_*_offden_cublas` cases. This path still packs host
+buffers per neighbor, then sends one small `ZGEMM(N,T)` to cuBLAS per neighbor.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-cublas-diagnostic-20260531-512-4r
+runs/offden-cublas-diagnostic-20260531-2048-1r
+runs/offden-cublas-repro-20260531-2048-1r
+runs/offden-cublas-combined-repro-20260531-2048-1r
+runs/offden-cublas-combined-20260531-512-4r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.23 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas` | 512 | 4 | 10.00 s | 1.8762 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 40.52 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas` | 2048 | 1 | 39.04 s | 5.3941 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.75 s | 1.7591 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas` | 512 | 4 | 9.80 s | 1.9069 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.79 s | 4.9892 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas` | 2048 | 1 | 37.52 s | 5.4846 GB | 0.000000407 Ha |
+
+| Profile row | 2048/1 HPSI+BLAS | 2048/1 HPSI+cuBLAS | 512/4 HPSI+BLAS, rank 1 | 512/4 HPSI+cuBLAS, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BLAS_PACK` | 0.0227 s | 0.0285 s | 0.0059 s | 0.0083 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0492 s | - | 0.0118 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.1593 s | - | 0.3990 s |
+| `ACC_COPY_CUBLAS_ZGEMM_NT` | - | 0.4954 GB | - | 0.0369 GB |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0733 s | 0.1905 s | 0.0183 s | 0.4084 s |
+
+| Profile row | 2048/1 DENMAT GPU+BLAS | 2048/1 DENMAT GPU+cuBLAS | 512/4 DENMAT GPU+BLAS, rank 1 | 512/4 DENMAT GPU+cuBLAS, rank 1 |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BLAS_PACK` | 0.0222 s | 0.0260 s | 0.0057 s | 0.0080 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0490 s | - | 0.0118 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.1595 s | - | 0.3998 s |
+| `ACC_COPY_CUBLAS_ZGEMM_NT` | - | 0.4954 GB | - | 0.0369 GB |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0727 s | 0.1875 s | 0.0181 s | 0.4090 s |
+
+The naive cuBLAS implementation is therefore a negative control: it is
+correct, but the per-neighbor launch/copy pattern loses to host BLAS inside the
+off-site local contraction. The useful GPU direction is a batched/strided
+formulation grouped by projector shape, ideally with packed `A`/`B` buffers
+resident across neighbors. A simple one-cuBLAS-call-per-neighbor rewrite should
+not become the default.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -266,6 +266,15 @@ case_note() {
     gpu_resident_hpsi_denmat_energy_offden_blas)
       echo "Combined HPSI residency, DENMAT energy/Lambda OpenACC diagnostic, and scalar TINV off-site DENMAT BLAS prototype."
       ;;
+    gpu_resident_offden_cublas)
+      echo "Residency diagnostic that tries cuBLAS for the scalar TINV off-site DENMAT BLAS prototype."
+      ;;
+    gpu_resident_hpsi_offden_cublas)
+      echo "Combined HPSI residency plus scalar TINV off-site DENMAT cuBLAS diagnostic."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas)
+      echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar TINV off-site DENMAT cuBLAS diagnostic."
+      ;;
     gpu_resident_offden_blas)
       echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
       ;;
@@ -489,6 +498,9 @@ case_env() {
     gpu_resident_hpsi_denmat_energy) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_denmat_energy_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
+    gpu_resident_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
+    gpu_resident_hpsi_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary
- Adds a forced, opt-in cuBLAS diagnostic for the scalar `TINV`/`NDIM=1` off-site DENMAT BLAS prototype.
- Provides a `ZGEMM(N,T)` cuBLAS helper and the switches `CPPAW_GPU_OFFDEN_CUBLAS=1` / `CPPAW_CUBLAS_ACC_OFFDEN=1` with `CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP`.
- Extends the Si64 harness with `*_offden_cublas` cases and documents the Spark benchmark result.

## Interpretation
This is a negative-control diagnostic, not a new recommended default. The path is energy-correct, but a per-neighbor cuBLAS launch/copy pattern is slower inside `PAW_OFFDEN_SUM_LOCAL` than the host-BLAS rewrite from #124. The next useful GPU implementation should batch neighbors by projector shape and/or keep packed projector buffers resident.

## Spark C86C validation
Builds:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Runs:
- `runs/offden-cublas-diagnostic-20260531-512-4r`
- `runs/offden-cublas-diagnostic-20260531-2048-1r`
- `runs/offden-cublas-repro-20260531-2048-1r`
- `runs/offden-cublas-combined-repro-20260531-2048-1r`
- `runs/offden-cublas-combined-20260531-512-4r`

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.23 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_cublas` | 512 | 4 | 10.00 s | 1.8762 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 40.52 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_offden_cublas` | 2048 | 1 | 39.04 s | 5.3941 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.75 s | 1.7591 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas` | 512 | 4 | 9.80 s | 1.9069 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.79 s | 4.9892 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas` | 2048 | 1 | 37.52 s | 5.4846 GB | 0.000000407 Ha |

| Profile row | 2048/1 DENMAT GPU+BLAS | 2048/1 DENMAT GPU+cuBLAS | 512/4 DENMAT GPU+BLAS rank 1 | 512/4 DENMAT GPU+cuBLAS rank 1 |
| --- | ---: | ---: | ---: | ---: |
| `PAW_OFFDEN_BLAS_PACK` | 0.0222 s | 0.0260 s | 0.0057 s | 0.0080 s |
| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0490 s | - | 0.0118 s | - |
| `CUBLAS_ZGEMM_OFFDEN_TINV_NDIM1` | - | 0.1595 s | - | 0.3998 s |
| `ACC_COPY_CUBLAS_ZGEMM_NT` | - | 0.4954 GB | - | 0.0369 GB |
| `PAW_OFFDEN_SUM_LOCAL` | 0.0727 s | 0.1875 s | 0.0181 s | 0.4090 s |

## Conclusion
The naive cuBLAS path should remain opt-in and diagnostic-only. It confirms that the matrix formulation is viable, but not with one small cuBLAS call per neighbor. The next implementation should be batched/strided and resident-aware.
