### PR TITLE
Add stacked off-site DENMAT cuBLAS diagnostic

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4463,6 +4463,8 @@ END IF
       LOGICAL(4)             :: TINV
       LOGICAL(4)             :: TOFFDENBLAS
       LOGICAL(4)             :: TOFFDENCUBLAS
+      LOGICAL(4)             :: TOFFDENBATCH
+      INTEGER(4)             :: OFFDENBATCHSIZE
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
       INTEGER(4)             :: NTASKS,THISTASK,ICOUNT
@@ -4488,6 +4490,8 @@ END IF
       CALL WAVES_DYNOCCGETR8A('OCC',NBX*NKPTL*NSPIN,OCC)
       TOFFDENBLAS=.FALSE.
       TOFFDENCUBLAS=.FALSE.
+      TOFFDENBATCH=.FALSE.
+      OFFDENBATCHSIZE=64
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_LOCAL',ENVVAL &
      &                             ,STATUS=ENVSTAT)
       IF(ENVSTAT.NE.0) THEN
@@ -4517,6 +4521,27 @@ END IF
           TOFFDENCUBLAS=.FALSE.
         END SELECT
       END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_CUBLAS_BATCH' &
+     &                             ,ENVVAL,STATUS=ENVSTAT)
+      IF(ENVSTAT.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_OFFDEN_BATCH' &
+     &                               ,ENVVAL,STATUS=ENVSTAT)
+      END IF
+      IF(ENVSTAT.EQ.0) THEN
+        SELECT CASE(TRIM(ADJUSTL(ENVVAL)))
+        CASE('1','T','t','TRUE','true','True','YES','yes','ON','on')
+          TOFFDENBLAS=.TRUE.
+          TOFFDENCUBLAS=.TRUE.
+          TOFFDENBATCH=.TRUE.
+        CASE DEFAULT
+          TOFFDENBATCH=.FALSE.
+        END SELECT
+      END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_BATCH_SIZE' &
+     &                             ,ENVVAL,STATUS=ENVSTAT)
+      IF(ENVSTAT.EQ.0) READ(ENVVAL,*,ERR=101,END=101) OFFDENBATCHSIZE
+  101 CONTINUE
+      IF(OFFDENBATCHSIZE.LT.1) OFFDENBATCHSIZE=64
 !
 !     ==========================================================================
 !     ==  CONSTRUCT INDEX ARRAYS                                              ==
@@ -4568,6 +4593,13 @@ END IF
           CALL PLANEWAVE$GETL4('TINV',TINV)
           NBH=THIS%NBH
           NB=THIS%NB
+          IF(TOFFDENBATCH.AND.TINV.AND.NDIM.EQ.1) THEN
+            CALL WAVES_OFFDEN_TINV_NDIM1_CUBLAS_BATCH(NND,NPRO &
+     &           ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD &
+     &           ,NSPIN,ISPIN,OFFDENBATCHSIZE,OCC(1,IKPT,ISPIN) &
+     &           ,XK(1,IKPT),THIS%PROJ(1,1,1),OSDENMAT)
+            CYCLE
+          END IF
           ICOUNT=0
           DO NN=1,NND
             ICOUNT=ICOUNT+1
@@ -4840,6 +4872,215 @@ END IF
       DEALLOCATE(WORK)
       DEALLOCATE(B)
       DEALLOCATE(A)
+      RETURN
+      END
+!
+!     ...1.........2.........3.........4.........5.........6.........7.........8
+      SUBROUTINE WAVES_OFFDEN_TINV_NDIM1_CUBLAS_BATCH(NND,NPRO &
+     &          ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD,NSPIN &
+     &          ,ISPIN,BATCHSIZE,OCC,XK,PROJ,OSDENMAT)
+      USE RSPACEOP_MODULE, ONLY: RSPACEMAT_TYPE
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
+     &        CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY
+#ENDIF
+!     **************************************************************************
+!     **  Chunked cuBLAS diagnostic for scalar, inversion-symmetric off-site  **
+!     **  density-matrix contractions. Neighbors sharing the same first atom  **
+!     **  and second-projector size are stacked into one wide ZGEMM.          **
+!     **************************************************************************
+      IMPLICIT NONE
+      COMPLEX(8),PARAMETER   :: CI=(0.D0,1.D0)
+      REAL(8)   ,PARAMETER   :: PI=4.D0*ATAN(1.D0)
+      INTEGER(4),INTENT(IN)  :: NND
+      INTEGER(4),INTENT(IN)  :: NPRO
+      INTEGER(4),INTENT(IN)  :: NPROAT(*)
+      INTEGER(4),INTENT(IN)  :: IPRO1(*)
+      INTEGER(4),INTENT(IN)  :: NTASKS
+      INTEGER(4),INTENT(IN)  :: THISTASK
+      INTEGER(4),INTENT(IN)  :: NBH
+      INTEGER(4),INTENT(IN)  :: NB
+      INTEGER(4),INTENT(IN)  :: NDIMD
+      INTEGER(4),INTENT(IN)  :: NSPIN
+      INTEGER(4),INTENT(IN)  :: ISPIN
+      INTEGER(4),INTENT(IN)  :: BATCHSIZE
+      REAL(8)   ,INTENT(IN)  :: OCC(NB)
+      REAL(8)   ,INTENT(IN)  :: XK(3)
+      COMPLEX(8),INTENT(IN)  :: PROJ(NBH,NPRO)
+      TYPE(RSPACEMAT_TYPE),INTENT(INOUT) :: OSDENMAT(NND)
+      LOGICAL(4),ALLOCATABLE :: DONE(:)
+      INTEGER(4),ALLOCATABLE :: IDX(:)
+      COMPLEX(8),ALLOCATABLE :: A(:,:)
+      COMPLEX(8),ALLOCATABLE :: B(:,:)
+      COMPLEX(8),ALLOCATABLE :: WORK(:,:)
+      COMPLEX(8)            :: ONE
+      COMPLEX(8)            :: ZERO
+      COMPLEX(8)            :: EIKR
+      REAL(8)               :: SVAR
+      REAL(8)               :: FPLUS
+      REAL(8)               :: FMINUS
+      INTEGER(4)            :: NN0
+      INTEGER(4)            :: NN
+      INTEGER(4)            :: K
+      INTEGER(4)            :: I
+      INTEGER(4)            :: J
+      INTEGER(4)            :: IBH
+      INTEGER(4)            :: IAT1
+      INTEGER(4)            :: IAT2
+      INTEGER(4)            :: I0
+      INTEGER(4)            :: J0
+      INTEGER(4)            :: N1
+      INTEGER(4)            :: N2
+      INTEGER(4)            :: COUNT
+      INTEGER(4)            :: MAXBATCH
+      INTEGER(4)            :: IOFF
+      LOGICAL(4)            :: TCUBLAS_USED
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      REAL(8)               :: ACCEL_T0
+      REAL(8)               :: ACCEL_T1
+      REAL(8)               :: ACCEL_FLOPS
+      CHARACTER(32)         :: ACCEL_GEMM_NAME
+#ENDIF
+!     **************************************************************************
+      ONE=(1.D0,0.D0)
+      ZERO=(0.D0,0.D0)
+      MAXBATCH=MAX(1,BATCHSIZE)
+      ALLOCATE(DONE(NND))
+      ALLOCATE(IDX(MAXBATCH))
+      DONE=.FALSE.
+      DO NN0=1,NND
+        IF(DONE(NN0)) CYCLE
+        IF(MOD(NN0-1,NTASKS).NE.THISTASK-1) THEN
+          DONE(NN0)=.TRUE.
+          CYCLE
+        END IF
+        IAT1=OSDENMAT(NN0)%IAT1
+        IAT2=OSDENMAT(NN0)%IAT2
+        N1=NPROAT(IAT1)
+        N2=NPROAT(IAT2)
+        COUNT=0
+        DO NN=NN0,NND
+          IF(DONE(NN)) CYCLE
+          IF(MOD(NN-1,NTASKS).NE.THISTASK-1) THEN
+            DONE(NN)=.TRUE.
+            CYCLE
+          END IF
+          IF(OSDENMAT(NN)%IAT1.NE.IAT1) CYCLE
+          IF(NPROAT(OSDENMAT(NN)%IAT2).NE.N2) CYCLE
+          COUNT=COUNT+1
+          IDX(COUNT)=NN
+          DONE(NN)=.TRUE.
+          IF(COUNT.EQ.MAXBATCH) EXIT
+        ENDDO
+        IF(COUNT.EQ.0) CYCLE
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+        ALLOCATE(A(N1,NBH))
+        ALLOCATE(B(N2*COUNT,NBH))
+        ALLOCATE(WORK(N1,N2*COUNT))
+        I0=IPRO1(IAT1)-1
+        DO IBH=1,NBH
+          DO I=1,N1
+            A(I,IBH)=PROJ(IBH,I0+I)
+          ENDDO
+        ENDDO
+        DO K=1,COUNT
+          NN=IDX(K)
+          IAT2=OSDENMAT(NN)%IAT2
+          J0=IPRO1(IAT2)-1
+          IOFF=(K-1)*N2
+          SVAR=2.D0*PI*SUM(XK(:)*REAL(OSDENMAT(NN)%IT,KIND=8))
+          EIKR=EXP(CI*SVAR)
+          DO IBH=1,NBH
+            FPLUS=0.5D0*(OCC(2*IBH-1)+OCC(2*IBH))
+            FMINUS=0.5D0*(OCC(2*IBH-1)-OCC(2*IBH))
+            DO J=1,N2
+              B(IOFF+J,IBH)=FPLUS*CONJG(PROJ(IBH,J0+J))*CONJG(EIKR) &
+     &                  +FMINUS*PROJ(IBH,J0+J)*EIKR
+            ENDDO
+          ENDDO
+        ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        CALL ACCELPROFILE$ADD('PAW_OFFDEN_BATCH_PACK' &
+     &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &      ,INT(COUNT,KIND=8),0.D0 &
+     &      ,16.D0*REAL(NBH,KIND=8) &
+     &      *(REAL(N1,KIND=8)+REAL(N2,KIND=8)*REAL(COUNT,KIND=8)) &
+     &      ,ACCEL_T1-ACCEL_T0)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+        TCUBLAS_USED=.FALSE.
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+        CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY(N1,N2*COUNT,NBH &
+     &       ,A,B,WORK,TCUBLAS_USED)
+#ENDIF
+        IF(.NOT.TCUBLAS_USED) THEN
+          CALL ZGEMM('N','T',N1,N2*COUNT,NBH,ONE,A,N1 &
+     &              ,B,N2*COUNT,ZERO,WORK,N1)
+        END IF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        ACCEL_FLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &             *REAL(NBH,KIND=8)*REAL(COUNT,KIND=8)
+        IF(TCUBLAS_USED) THEN
+          ACCEL_GEMM_NAME='CUBLAS_ZGEMM_OFFDEN_TINV_STACK'
+        ELSE
+          ACCEL_GEMM_NAME='ZGEMM_OFFDEN_TINV_STACK'
+        END IF
+        CALL ACCELPROFILE$ADD(ACCEL_GEMM_NAME &
+     &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &      ,INT(COUNT,KIND=8),ACCEL_FLOPS &
+     &      ,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
+     &      +REAL(N1,KIND=8)*REAL(N2,KIND=8))*REAL(COUNT,KIND=8) &
+     &      ,ACCEL_T1-ACCEL_T0)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+        DO K=1,COUNT
+          NN=IDX(K)
+          IOFF=(K-1)*N2
+          IF(NSPIN.EQ.1) THEN
+            DO J=1,N2
+              DO I=1,N1
+                OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
+     &              +REAL(WORK(I,IOFF+J),KIND=8)
+              ENDDO
+            ENDDO
+          ELSE IF(NSPIN.EQ.2) THEN
+            IF(ISPIN.EQ.1) THEN
+              DO J=1,N2
+                DO I=1,N1
+                  OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
+     &                +REAL(WORK(I,IOFF+J),KIND=8)
+                  OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
+     &                +REAL(WORK(I,IOFF+J),KIND=8)
+                ENDDO
+              ENDDO
+            ELSE
+              DO J=1,N2
+                DO I=1,N1
+                  OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
+     &                +REAL(WORK(I,IOFF+J),KIND=8)
+                  OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
+     &                -REAL(WORK(I,IOFF+J),KIND=8)
+                ENDDO
+              ENDDO
+            END IF
+          END IF
+        ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        CALL ACCELPROFILE$ADD('PAW_OFFDEN_BATCH_ACCUM' &
+     &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
+     &      ,INT(COUNT,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
+        DEALLOCATE(WORK)
+        DEALLOCATE(B)
+        DEALLOCATE(A)
+      ENDDO
+      DEALLOCATE(IDX)
+      DEALLOCATE(DONE)
       RETURN
       END
 !

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -295,6 +295,15 @@ to 1. Spark Si64 shows that the per-neighbor cuBLAS prototype is slower inside
 `PAW_OFFDEN_SUM_LOCAL` than host BLAS because the matrices are tiny and copied
 for every neighbor. Keep it as a diagnostic only; a useful GPU version should
 batch neighbors and/or keep packed projector buffers resident.
+`CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1` or `CPPAW_CUBLAS_ACC_OFFDEN_BATCH=1`
+switches the cuBLAS diagnostic from one tiny GEMM per neighbor to a stacked
+formulation: neighbors with the same first atom and second-projector size are
+packed into one wider `ZGEMM(N,T)` call. The chunk length is controlled by
+`CPPAW_GPU_OFFDEN_BATCH_SIZE` and defaults to 64. It records
+`PAW_OFFDEN_BATCH_PACK`, `CUBLAS_ZGEMM_OFFDEN_TINV_STACK`, and
+`PAW_OFFDEN_BATCH_ACCUM`. This is still disabled by default because the current
+prototype keeps packing host buffers; use it to quantify whether a resident
+projector/off-site backend is worth implementing.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated
@@ -371,6 +380,8 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_offden_cublas` | Diagnostic that forces `CPPAW_GPU_OFFDEN_CUBLAS=1` and `CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=1` for the scalar off-site DENMAT BLAS prototype. |
 | `gpu_resident_hpsi_offden_cublas` | Combined HPSI residency plus scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_resident_hpsi_denmat_energy_offden_cublas` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar off-site DENMAT cuBLAS diagnostic. |
+| `gpu_resident_hpsi_offden_cublas_batch` | Combined HPSI residency plus stacked scalar off-site DENMAT cuBLAS diagnostic. |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_psim_propagate` | Opt-in diagnostic that propagates `PSIM` on the GPU and copies it back before orthogonalization via `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_hpsi_psim_propagate` | Combined diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -34,6 +34,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `offden-profile-split-20260531-*` | Off-site DENMAT profiling split | `gpu_resident_hpsi_denmat_energy` 36.39 s at 2048/1 | - | `gpu_resident_hpsi` 9.75 s at 512/4 | Splits `PAW_OFFDEN_SUM` into setup/zero/local/combine; off-site time is mostly local contraction, not MPI combine. |
 | `offden-blas-diagnostic-20260531-*` / `offden-blas-combined-20260531-*` | Off-site DENMAT BLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` 36.91 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` 9.76 s at 512/4 | Rewrites scalar `TINV` off-site local work as packed `ZGEMM`; energy-valid, much faster inside `PAW_OFFDEN_SUM_LOCAL`, still opt-in host-data diagnostic. |
 | `offden-cublas-diagnostic-20260531-*` / `offden-cublas-combined-20260531-*` | Naive off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 36.79 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 9.75 s at 512/4 | Adds a forced per-neighbor cuBLAS diagnostic; energy-valid, but kernel timings are worse than host BLAS, so the next GPU attempt must batch or keep buffers resident. |
+| `offden-cublas-stack-diagnostic-20260531-*` / `offden-cublas-stack-combined-20260531-*` | Stacked off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` 36.10 s at 2048/1 | - | `gpu_resident_hpsi_offden_cublas_batch` 9.65 s at 512/4 | Groups neighbors with the same first atom and second-projector size into one wider cuBLAS `ZGEMM`; energy-valid and eliminates the tiny-GEMM launch problem, but host packing still dominates enough to keep it opt-in. |
 
 The latest full-matrix run lives at:
 
@@ -1776,6 +1777,61 @@ off-site local contraction. The useful GPU direction is a batched/strided
 formulation grouped by projector shape, ideally with packed `A`/`B` buffers
 resident across neighbors. A simple one-cuBLAS-call-per-neighbor rewrite should
 not become the default.
+
+## Off-Site DENMAT Stacked cuBLAS Diagnostic
+
+The next diagnostic keeps the same opt-in controls but adds
+`CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1` with `CPPAW_CUBLAS_ACC_OFFDEN_BATCH=1` as an
+alias. For scalar `TINV`/`NDIM=1`, neighbors with the same first atom and
+second-projector size are packed into one wider `ZGEMM(N,T)` call instead of
+one tiny cuBLAS call per neighbor. `CPPAW_GPU_OFFDEN_BATCH_SIZE` defaults to 64.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-cublas-stack-diagnostic-20260531-512-4r-fixed
+runs/offden-cublas-stack-diagnostic-20260531-2048-1r
+runs/offden-cublas-stack-combined-20260531-512-4r
+runs/offden-cublas-stack-combined-20260531-2048-1r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.50 s | 1.7284 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas` | 512 | 4 | 10.31 s | 1.8762 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas_batch` | 512 | 4 | 9.65 s | 1.8208 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 37.28 s | 4.8988 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas` | 2048 | 1 | 37.47 s | 5.3941 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas_batch` | 2048 | 1 | 37.54 s | 5.1624 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.78 s | 1.7591 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 512 | 4 | 9.84 s | 1.8515 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.31 s | 4.9892 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 2048 | 1 | 36.10 s | 5.2528 GB | 0.000000407 Ha |
+
+| Profile row | 2048/1 HPSI+BLAS | 2048/1 HPSI+stacked cuBLAS | 512/4 HPSI+BLAS | 512/4 HPSI+stacked cuBLAS |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BLAS_PACK` | 0.0220 s | - | 0.0247 s | - |
+| `PAW_OFFDEN_BATCH_PACK` | - | 0.0692 s | - | 0.0222 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0486 s | - | 0.0474 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | - | 0.0162 s | - | 0.1737 s |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0723 s | 0.0857 s | 0.0746 s | 0.1980 s |
+
+| Profile row | 2048/1 DENMAT GPU+BLAS | 2048/1 DENMAT GPU+stacked cuBLAS | 512/4 DENMAT GPU+BLAS | 512/4 DENMAT GPU+stacked cuBLAS |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BLAS_PACK` | 0.0218 s | - | 0.0235 s | - |
+| `PAW_OFFDEN_BATCH_PACK` | - | 0.0655 s | - | 0.0221 s |
+| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0489 s | - | 0.0473 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | - | 0.0163 s | - | 0.1739 s |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0727 s | 0.0821 s | 0.0739 s | 0.1981 s |
+
+The stacked form fixes the per-neighbor cuBLAS launch problem: at 2048/1 the
+actual GEMM row drops from about 0.157 s in the naive cuBLAS diagnostic to
+about 0.016 s. The remaining cost is now host-side packing and copy setup, so
+this should stay opt-in. The next implementation step is a resident
+projector/off-site buffer path, not forcing this diagnostic as the default.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -275,6 +275,12 @@ case_note() {
     gpu_resident_hpsi_denmat_energy_offden_cublas)
       echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar TINV off-site DENMAT cuBLAS diagnostic."
       ;;
+    gpu_resident_hpsi_offden_cublas_batch)
+      echo "Combined HPSI residency plus chunked strided-batched cuBLAS diagnostic for scalar TINV off-site DENMAT."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_batch)
+      echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and chunked strided-batched cuBLAS off-site DENMAT diagnostic."
+      ;;
     gpu_resident_offden_blas)
       echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
       ;;
@@ -501,6 +507,8 @@ case_env() {
     gpu_resident_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_hpsi_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
+    gpu_resident_hpsi_offden_cublas_batch) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_batch) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary

This PR adds an opt-in stacked cuBLAS diagnostic for scalar `TINV`/`NDIM=1` off-site DENMAT local contractions.

Instead of launching one tiny cuBLAS `ZGEMM(N,T)` per off-site neighbor, the new path groups task-owned neighbors with the same first atom and second-projector size into one wider `ZGEMM(N,T)` call. The existing host-BLAS path remains the default; this is a profiling/residency target.

## Controls

- `CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1`
- alias: `CPPAW_CUBLAS_ACC_OFFDEN_BATCH=1`
- `CPPAW_GPU_OFFDEN_BATCH_SIZE`, default `64`
- requires the existing `CPPAW_GPU_OFFDEN_LOCAL=1` and `CPPAW_GPU_OFFDEN_CUBLAS=1` diagnostic path

New profile rows:

- `PAW_OFFDEN_BATCH_PACK`
- `CUBLAS_ZGEMM_OFFDEN_TINV_STACK`
- `ZGEMM_OFFDEN_TINV_STACK` for CPU fallback
- `PAW_OFFDEN_BATCH_ACCUM`

New benchmark cases:

- `gpu_resident_hpsi_offden_cublas_batch`
- `gpu_resident_hpsi_denmat_energy_offden_cublas_batch`

## Spark C86C validation

Built successfully:

- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Benchmark runs, all with `NSTEPS=1`:

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_offden_blas` | 512 | 4 | 10.50 s | 1.7284 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_cublas` | 512 | 4 | 10.31 s | 1.8762 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_cublas_batch` | 512 | 4 | 9.65 s | 1.8208 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_blas` | 2048 | 1 | 37.28 s | 4.8988 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_offden_cublas` | 2048 | 1 | 37.47 s | 5.3941 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_offden_cublas_batch` | 2048 | 1 | 37.54 s | 5.1624 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 512 | 4 | 9.78 s | 1.7591 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 512 | 4 | 9.84 s | 1.8515 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_blas` | 2048 | 1 | 36.31 s | 4.9892 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 2048 | 1 | 36.10 s | 5.2528 GB | 0.000000407 Ha |

Focused profile result:

| Profile row | 2048/1 HPSI+BLAS | 2048/1 HPSI+stacked cuBLAS |
| --- | ---: | ---: |
| `ZGEMM_OFFDEN_TINV_NDIM1` | 0.0486 s | - |
| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | - | 0.0162 s |
| `PAW_OFFDEN_BLAS_PACK` | 0.0220 s | - |
| `PAW_OFFDEN_BATCH_PACK` | - | 0.0692 s |
| `PAW_OFFDEN_SUM_LOCAL` | 0.0723 s | 0.0857 s |

## Conclusion

The stacked formulation fixes the per-neighbor cuBLAS launch problem: the actual cuBLAS GEMM row at 2048/1 drops to roughly 0.016 s. The remaining blocker is host-side packing/copy setup, so this should stay opt-in and guide the next resident projector/off-site buffer implementation.
