### PR TITLE
Add off-site DENMAT device-pack diagnostic

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4464,6 +4464,7 @@ END IF
       LOGICAL(4)             :: TOFFDENBLAS
       LOGICAL(4)             :: TOFFDENCUBLAS
       LOGICAL(4)             :: TOFFDENBATCH
+      LOGICAL(4)             :: TOFFDENDEVICEPACK
       INTEGER(4)             :: OFFDENBATCHSIZE
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
@@ -4491,6 +4492,7 @@ END IF
       TOFFDENBLAS=.FALSE.
       TOFFDENCUBLAS=.FALSE.
       TOFFDENBATCH=.FALSE.
+      TOFFDENDEVICEPACK=.FALSE.
       OFFDENBATCHSIZE=64
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_LOCAL',ENVVAL &
      &                             ,STATUS=ENVSTAT)
@@ -4535,6 +4537,23 @@ END IF
           TOFFDENBATCH=.TRUE.
         CASE DEFAULT
           TOFFDENBATCH=.FALSE.
+        END SELECT
+      END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_DEVICE_PACK' &
+     &                             ,ENVVAL,STATUS=ENVSTAT)
+      IF(ENVSTAT.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_PACK' &
+     &                               ,ENVVAL,STATUS=ENVSTAT)
+      END IF
+      IF(ENVSTAT.EQ.0) THEN
+        SELECT CASE(TRIM(ADJUSTL(ENVVAL)))
+        CASE('1','T','t','TRUE','true','True','YES','yes','ON','on')
+          TOFFDENBLAS=.TRUE.
+          TOFFDENCUBLAS=.TRUE.
+          TOFFDENBATCH=.TRUE.
+          TOFFDENDEVICEPACK=.TRUE.
+        CASE DEFAULT
+          TOFFDENDEVICEPACK=.FALSE.
         END SELECT
       END IF
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_BATCH_SIZE' &
@@ -4597,7 +4616,8 @@ END IF
             CALL WAVES_OFFDEN_TINV_NDIM1_CUBLAS_BATCH(NND,NPRO &
      &           ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD &
      &           ,NSPIN,ISPIN,OFFDENBATCHSIZE,OCC(1,IKPT,ISPIN) &
-     &           ,XK(1,IKPT),THIS%PROJ(1,1,1),OSDENMAT)
+     &           ,XK(1,IKPT),THIS%PROJ(1,1,1),OSDENMAT &
+     &           ,TOFFDENDEVICEPACK)
             CYCLE
           END IF
           ICOUNT=0
@@ -4878,16 +4898,20 @@ END IF
 !     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE WAVES_OFFDEN_TINV_NDIM1_CUBLAS_BATCH(NND,NPRO &
      &          ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD,NSPIN &
-     &          ,ISPIN,BATCHSIZE,OCC,XK,PROJ,OSDENMAT)
+     &          ,ISPIN,BATCHSIZE,OCC,XK,PROJ,OSDENMAT,TDEVICEPACK)
       USE RSPACEOP_MODULE, ONLY: RSPACEMAT_TYPE
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       USE CPPAW_CUBLAS_ACC_MODULE, ONLY: &
-     &        CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY
+     &        CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN &
+     &       ,CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY &
+     &       ,CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT
 #ENDIF
 !     **************************************************************************
 !     **  Chunked cuBLAS diagnostic for scalar, inversion-symmetric off-site  **
 !     **  density-matrix contractions. Neighbors sharing the same first atom  **
 !     **  and second-projector size are stacked into one wide ZGEMM.          **
+!     **  The optional device-pack mode keeps PROJ/OCC in one OpenACC region, **
+!     **  packs A/B on the GPU, and copies only the stacked WORK block back.   **
 !     **************************************************************************
       IMPLICIT NONE
       COMPLEX(8),PARAMETER   :: CI=(0.D0,1.D0)
@@ -4908,17 +4932,21 @@ END IF
       REAL(8)   ,INTENT(IN)  :: XK(3)
       COMPLEX(8),INTENT(IN)  :: PROJ(NBH,NPRO)
       TYPE(RSPACEMAT_TYPE),INTENT(INOUT) :: OSDENMAT(NND)
+      LOGICAL(4),INTENT(IN)  :: TDEVICEPACK
       LOGICAL(4),ALLOCATABLE :: DONE(:)
       INTEGER(4),ALLOCATABLE :: IDX(:)
+      INTEGER(4),ALLOCATABLE :: J0ARR(:)
       COMPLEX(8),ALLOCATABLE :: A(:,:)
       COMPLEX(8),ALLOCATABLE :: B(:,:)
       COMPLEX(8),ALLOCATABLE :: WORK(:,:)
+      COMPLEX(8),ALLOCATABLE :: EIKRARR(:)
       COMPLEX(8)            :: ONE
       COMPLEX(8)            :: ZERO
       COMPLEX(8)            :: EIKR
       REAL(8)               :: SVAR
       REAL(8)               :: FPLUS
       REAL(8)               :: FMINUS
+      REAL(8)               :: OFFDENFLOPS
       INTEGER(4)            :: NN0
       INTEGER(4)            :: NN
       INTEGER(4)            :: K
@@ -4934,6 +4962,7 @@ END IF
       INTEGER(4)            :: COUNT
       INTEGER(4)            :: MAXBATCH
       INTEGER(4)            :: IOFF
+      LOGICAL(4)            :: TDEVICEACTIVE
       LOGICAL(4)            :: TCUBLAS_USED
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)               :: ACCEL_T0
@@ -4948,6 +4977,15 @@ END IF
       ALLOCATE(DONE(NND))
       ALLOCATE(IDX(MAXBATCH))
       DONE=.FALSE.
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+      IF(TDEVICEPACK) THEN
+        CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_PROJ_IN' &
+     &      ,INT(NBH,KIND=8),INT(NPRO,KIND=8),INT(NB,KIND=8),0_8 &
+     &      ,0.D0,16.D0*REAL(NBH,KIND=8)*REAL(NPRO,KIND=8) &
+     &      +8.D0*REAL(NB,KIND=8),0.D0)
+      END IF
+#ENDIF
+!$ACC DATA COPYIN(PROJ(1:NBH,1:NPRO),OCC(1:NB)) IF(TDEVICEPACK)
       DO NN0=1,NND
         IF(DONE(NN0)) CYCLE
         IF(MOD(NN0-1,NTASKS).NE.THISTASK-1) THEN
@@ -4979,64 +5017,154 @@ END IF
         ALLOCATE(A(N1,NBH))
         ALLOCATE(B(N2*COUNT,NBH))
         ALLOCATE(WORK(N1,N2*COUNT))
+        OFFDENFLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &             *REAL(NBH,KIND=8)*REAL(COUNT,KIND=8)
+        TDEVICEACTIVE=.FALSE.
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+        TDEVICEACTIVE=TDEVICEPACK &
+     &      .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN(OFFDENFLOPS)
+#ENDIF
         I0=IPRO1(IAT1)-1
-        DO IBH=1,NBH
-          DO I=1,N1
-            A(I,IBH)=PROJ(IBH,I0+I)
+        IF(TDEVICEACTIVE) THEN
+          ALLOCATE(J0ARR(COUNT))
+          ALLOCATE(EIKRARR(COUNT))
+          DO K=1,COUNT
+            NN=IDX(K)
+            IAT2=OSDENMAT(NN)%IAT2
+            J0ARR(K)=IPRO1(IAT2)-1
+            SVAR=2.D0*PI*SUM(XK(:)*REAL(OSDENMAT(NN)%IT,KIND=8))
+            EIKRARR(K)=EXP(CI*SVAR)
           ENDDO
-        ENDDO
-        DO K=1,COUNT
-          NN=IDX(K)
-          IAT2=OSDENMAT(NN)%IAT2
-          J0=IPRO1(IAT2)-1
-          IOFF=(K-1)*N2
-          SVAR=2.D0*PI*SUM(XK(:)*REAL(OSDENMAT(NN)%IT,KIND=8))
-          EIKR=EXP(CI*SVAR)
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC ENTER DATA CREATE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
+!$ACC&                  ,WORK(1:N1,1:N2*COUNT)) &
+!$ACC& COPYIN(J0ARR(1:COUNT),EIKRARR(1:COUNT))
+!$ACC PARALLEL LOOP COLLAPSE(2) PRESENT(PROJ,A)
           DO IBH=1,NBH
-            FPLUS=0.5D0*(OCC(2*IBH-1)+OCC(2*IBH))
-            FMINUS=0.5D0*(OCC(2*IBH-1)-OCC(2*IBH))
-            DO J=1,N2
-              B(IOFF+J,IBH)=FPLUS*CONJG(PROJ(IBH,J0+J))*CONJG(EIKR) &
-     &                  +FMINUS*PROJ(IBH,J0+J)*EIKR
+            DO I=1,N1
+              A(I,IBH)=PROJ(IBH,I0+I)
             ENDDO
           ENDDO
-        ENDDO
+!$ACC END PARALLEL LOOP
+!$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(IOFF,FPLUS,FMINUS) &
+!$ACC& PRESENT(PROJ,OCC,J0ARR,EIKRARR,B)
+          DO K=1,COUNT
+            DO IBH=1,NBH
+              DO J=1,N2
+                IOFF=(K-1)*N2
+                FPLUS=0.5D0*(OCC(2*IBH-1)+OCC(2*IBH))
+                FMINUS=0.5D0*(OCC(2*IBH-1)-OCC(2*IBH))
+                B(IOFF+J,IBH)=FPLUS &
+     &              *CONJG(PROJ(IBH,J0ARR(K)+J))*CONJG(EIKRARR(K)) &
+     &              +FMINUS*PROJ(IBH,J0ARR(K)+J)*EIKRARR(K)
+              ENDDO
+            ENDDO
+          ENDDO
+!$ACC END PARALLEL LOOP
+!$ACC WAIT
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-        CALL ACCELPROFILE$NOW(ACCEL_T1)
-        CALL ACCELPROFILE$ADD('PAW_OFFDEN_BATCH_PACK' &
-     &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
-     &      ,INT(COUNT,KIND=8),0.D0 &
-     &      ,16.D0*REAL(NBH,KIND=8) &
-     &      *(REAL(N1,KIND=8)+REAL(N2,KIND=8)*REAL(COUNT,KIND=8)) &
-     &      ,ACCEL_T1-ACCEL_T0)
-        CALL ACCELPROFILE$NOW(ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          CALL ACCELPROFILE$ADD('PAW_OFFDEN_DEVICE_PACK' &
+     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &        ,INT(COUNT,KIND=8),0.D0 &
+     &        ,16.D0*REAL(NBH,KIND=8) &
+     &        *(REAL(N1,KIND=8)+REAL(N2,KIND=8)*REAL(COUNT,KIND=8)) &
+     &        ,ACCEL_T1-ACCEL_T0)
+          CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_META_IN' &
+     &        ,INT(COUNT,KIND=8),0_8,0_8,0_8,0.D0 &
+     &        ,REAL(4*COUNT,KIND=8)+16.D0*REAL(COUNT,KIND=8),0.D0)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
-        TCUBLAS_USED=.FALSE.
+          TCUBLAS_USED=.TRUE.
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
-        CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY(N1,N2*COUNT,NBH &
+          CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_PRESENT(N1,N2*COUNT,NBH &
+     &        ,A,B,WORK)
+#ENDIF
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          CALL ACCELPROFILE$ADD('CUBLAS_ZGEMM_OFFDEN_TINV_DPACK' &
+     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &        ,INT(COUNT,KIND=8),OFFDENFLOPS &
+     &        ,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
+     &        +REAL(N1,KIND=8)*REAL(N2,KIND=8))*REAL(COUNT,KIND=8) &
+     &        ,ACCEL_T1-ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC UPDATE SELF(WORK(1:N1,1:N2*COUNT))
+!$ACC WAIT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_WORK_OUT' &
+     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(COUNT,KIND=8),0_8 &
+     &        ,0.D0,16.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &        *REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC EXIT DATA DELETE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
+!$ACC&                 ,WORK(1:N1,1:N2*COUNT),J0ARR(1:COUNT) &
+!$ACC&                 ,EIKRARR(1:COUNT))
+          DEALLOCATE(EIKRARR)
+          DEALLOCATE(J0ARR)
+        ELSE
+          DO IBH=1,NBH
+            DO I=1,N1
+              A(I,IBH)=PROJ(IBH,I0+I)
+            ENDDO
+          ENDDO
+          DO K=1,COUNT
+            NN=IDX(K)
+            IAT2=OSDENMAT(NN)%IAT2
+            J0=IPRO1(IAT2)-1
+            IOFF=(K-1)*N2
+            SVAR=2.D0*PI*SUM(XK(:)*REAL(OSDENMAT(NN)%IT,KIND=8))
+            EIKR=EXP(CI*SVAR)
+            DO IBH=1,NBH
+              FPLUS=0.5D0*(OCC(2*IBH-1)+OCC(2*IBH))
+              FMINUS=0.5D0*(OCC(2*IBH-1)-OCC(2*IBH))
+              DO J=1,N2
+                B(IOFF+J,IBH)=FPLUS*CONJG(PROJ(IBH,J0+J)) &
+     &              *CONJG(EIKR)+FMINUS*PROJ(IBH,J0+J)*EIKR
+              ENDDO
+            ENDDO
+          ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          CALL ACCELPROFILE$ADD('PAW_OFFDEN_BATCH_PACK' &
+     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &        ,INT(COUNT,KIND=8),0.D0 &
+     &        ,16.D0*REAL(NBH,KIND=8) &
+     &        *(REAL(N1,KIND=8)+REAL(N2,KIND=8)*REAL(COUNT,KIND=8)) &
+     &        ,ACCEL_T1-ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+          TCUBLAS_USED=.FALSE.
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+          CALL CPPAW_CUBLAS_ACC_ZGEMM_NT_COPY(N1,N2*COUNT,NBH &
      &       ,A,B,WORK,TCUBLAS_USED)
 #ENDIF
-        IF(.NOT.TCUBLAS_USED) THEN
-          CALL ZGEMM('N','T',N1,N2*COUNT,NBH,ONE,A,N1 &
-     &              ,B,N2*COUNT,ZERO,WORK,N1)
-        END IF
+          IF(.NOT.TCUBLAS_USED) THEN
+            CALL ZGEMM('N','T',N1,N2*COUNT,NBH,ONE,A,N1 &
+     &                ,B,N2*COUNT,ZERO,WORK,N1)
+          END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-        CALL ACCELPROFILE$NOW(ACCEL_T1)
-        ACCEL_FLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
-     &             *REAL(NBH,KIND=8)*REAL(COUNT,KIND=8)
-        IF(TCUBLAS_USED) THEN
-          ACCEL_GEMM_NAME='CUBLAS_ZGEMM_OFFDEN_TINV_STACK'
-        ELSE
-          ACCEL_GEMM_NAME='ZGEMM_OFFDEN_TINV_STACK'
-        END IF
-        CALL ACCELPROFILE$ADD(ACCEL_GEMM_NAME &
-     &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
-     &      ,INT(COUNT,KIND=8),ACCEL_FLOPS &
-     &      ,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
-     &      +REAL(N1,KIND=8)*REAL(N2,KIND=8))*REAL(COUNT,KIND=8) &
-     &      ,ACCEL_T1-ACCEL_T0)
-        CALL ACCELPROFILE$NOW(ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T1)
+          ACCEL_FLOPS=OFFDENFLOPS
+          IF(TCUBLAS_USED) THEN
+            ACCEL_GEMM_NAME='CUBLAS_ZGEMM_OFFDEN_TINV_STACK'
+          ELSE
+            ACCEL_GEMM_NAME='ZGEMM_OFFDEN_TINV_STACK'
+          END IF
+          CALL ACCELPROFILE$ADD(ACCEL_GEMM_NAME &
+     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NBH,KIND=8) &
+     &        ,INT(COUNT,KIND=8),ACCEL_FLOPS &
+     &        ,16.D0*(REAL(NBH,KIND=8)*REAL(N1+N2,KIND=8) &
+     &        +REAL(N1,KIND=8)*REAL(N2,KIND=8))*REAL(COUNT,KIND=8) &
+     &        ,ACCEL_T1-ACCEL_T0)
+          CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
+        END IF
         DO K=1,COUNT
           NN=IDX(K)
           IOFF=(K-1)*N2
@@ -5079,6 +5207,7 @@ END IF
         DEALLOCATE(B)
         DEALLOCATE(A)
       ENDDO
+!$ACC END DATA
       DEALLOCATE(IDX)
       DEALLOCATE(DONE)
       RETURN

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -304,6 +304,15 @@ packed into one wider `ZGEMM(N,T)` call. The chunk length is controlled by
 `PAW_OFFDEN_BATCH_ACCUM`. This is still disabled by default because the current
 prototype keeps packing host buffers; use it to quantify whether a resident
 projector/off-site backend is worth implementing.
+`CPPAW_GPU_OFFDEN_DEVICE_PACK=1` or
+`CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_PACK=1` moves that stacked packing step into an
+OpenACC region: `PROJ` and `OCC` are copied once for the off-site pass, A/B are
+packed on the GPU, cuBLAS uses present data, and only the stacked `WORK` block
+is copied back. It records `PAW_OFFDEN_DEVICE_PACK`,
+`CUBLAS_ZGEMM_OFFDEN_TINV_DPACK`, `ACC_COPY_OFFDEN_DPACK_PROJ_IN`,
+`ACC_COPY_OFFDEN_DPACK_META_IN`, and `ACC_COPY_OFFDEN_DPACK_WORK_OUT`. Spark
+Si64 shows this is useful for the 1 MPI rank / 1 GPU comparison, but can be a
+negative diagnostic when several MPI ranks share one GPU.
 Inversion-symmetric Hermitian/symmetric scalarproducts no longer include the unused second
 wavefunction array in the OpenACC data region. These rows are meant to guide the
 next change: extend resident regions only where the profile shows repeated
@@ -382,6 +391,8 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_hpsi_denmat_energy_offden_cublas` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_resident_hpsi_offden_cublas_batch` | Combined HPSI residency plus stacked scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked scalar off-site DENMAT cuBLAS diagnostic. |
+| `gpu_resident_hpsi_offden_cublas_devicepack` | Combined HPSI residency plus stacked scalar off-site DENMAT cuBLAS with OpenACC device packing. |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked scalar off-site DENMAT cuBLAS with OpenACC device packing. |
 | `gpu_psim_propagate` | Opt-in diagnostic that propagates `PSIM` on the GPU and copies it back before orthogonalization via `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_hpsi_psim_propagate` | Combined diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -35,6 +35,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `offden-blas-diagnostic-20260531-*` / `offden-blas-combined-20260531-*` | Off-site DENMAT BLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` 36.91 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` 9.76 s at 512/4 | Rewrites scalar `TINV` off-site local work as packed `ZGEMM`; energy-valid, much faster inside `PAW_OFFDEN_SUM_LOCAL`, still opt-in host-data diagnostic. |
 | `offden-cublas-diagnostic-20260531-*` / `offden-cublas-combined-20260531-*` | Naive off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 36.79 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_blas` remains better at 9.75 s at 512/4 | Adds a forced per-neighbor cuBLAS diagnostic; energy-valid, but kernel timings are worse than host BLAS, so the next GPU attempt must batch or keep buffers resident. |
 | `offden-cublas-stack-diagnostic-20260531-*` / `offden-cublas-stack-combined-20260531-*` | Stacked off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` 36.10 s at 2048/1 | - | `gpu_resident_hpsi_offden_cublas_batch` 9.65 s at 512/4 | Groups neighbors with the same first atom and second-projector size into one wider cuBLAS `ZGEMM`; energy-valid and eliminates the tiny-GEMM launch problem, but host packing still dominates enough to keep it opt-in. |
+| `offden-device-pack-20260531-*` / `offden-device-pack-combined-20260531-*` | Off-site DENMAT device-pack diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 36.03 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 9.87 s at 512/4 | Packs the stacked off-site A/B buffers on the GPU and copies back only WORK; strong for 1 MPI/GPU, diagnostic-only when several ranks share one GPU. |
 
 The latest full-matrix run lives at:
 
@@ -1832,6 +1833,67 @@ actual GEMM row drops from about 0.157 s in the naive cuBLAS diagnostic to
 about 0.016 s. The remaining cost is now host-side packing and copy setup, so
 this should stay opt-in. The next implementation step is a resident
 projector/off-site buffer path, not forcing this diagnostic as the default.
+
+## Off-Site DENMAT Device-Pack Diagnostic
+
+The follow-up diagnostic adds `CPPAW_GPU_OFFDEN_DEVICE_PACK=1` with
+`CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_PACK=1` as an alias. It keeps the stacked
+cuBLAS formulation, copies `PROJ` and `OCC` once for the off-site pass, packs
+the A/B buffers in OpenACC kernels, calls cuBLAS on present data, and copies
+only the stacked `WORK` block back for the existing host-side accumulation.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-device-pack-20260531-512-4r
+runs/offden-device-pack-20260531-2048-1r
+runs/offden-device-pack-combined-20260531-512-4r
+runs/offden-device-pack-combined-20260531-2048-1r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi_offden_cublas_batch` | 512 | 4 | 10.60 s | 1.8208 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas_devicepack` | 512 | 4 | 9.51 s | 1.7485 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas_batch` | 2048 | 1 | 37.45 s | 5.1624 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas_devicepack` | 2048 | 1 | 37.37 s | 4.9162 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 512 | 4 | 10.01 s | 1.8515 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.87 s | 1.7791 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 2048 | 1 | 37.58 s | 5.2528 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 36.03 s | 5.0066 GB | 0.000000407 Ha |
+
+| Profile row | 2048/1 HPSI stacked | 2048/1 HPSI device-pack | 512/4 HPSI stacked | 512/4 HPSI device-pack |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BATCH_PACK` | 0.0692 s | - | 0.0212 s | - |
+| `PAW_OFFDEN_DEVICE_PACK` | - | 0.0035 s | - | 0.2960 s |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | 0.0162 s | - | 0.1738 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | - | 0.0090 s | - | 0.1377 s |
+| `ACC_COPY_CUBLAS_ZGEMM_NT` | 0.2636 GB | - | 0.0924 GB | - |
+| `ACC_COPY_OFFDEN_DPACK_PROJ_IN` | - | 0.0145 GB | - | 0.0171 GB |
+| `ACC_COPY_OFFDEN_DPACK_WORK_OUT` | - | 0.0029 GB | - | 0.0029 GB |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0858 s | 0.0138 s | 0.1969 s | 0.4444 s |
+
+| Profile row | 2048/1 DENMAT GPU stacked | 2048/1 DENMAT GPU device-pack | 512/4 DENMAT GPU stacked | 512/4 DENMAT GPU device-pack |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_BATCH_PACK` | 0.0685 s | - | 0.0225 s | - |
+| `PAW_OFFDEN_DEVICE_PACK` | - | 0.0034 s | - | 0.2978 s |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | 0.0165 s | - | 0.1738 s | - |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | - | 0.0090 s | - | 0.1384 s |
+| `ACC_COPY_CUBLAS_ZGEMM_NT` | 0.2636 GB | - | 0.0924 GB | - |
+| `ACC_COPY_OFFDEN_DPACK_PROJ_IN` | - | 0.0145 GB | - | 0.0171 GB |
+| `ACC_COPY_OFFDEN_DPACK_WORK_OUT` | - | 0.0029 GB | - | 0.0029 GB |
+| `PAW_OFFDEN_SUM_LOCAL` | 0.0954 s | 0.0137 s | 0.1987 s | 0.4480 s |
+
+Device-pack is the first off-site DENMAT path that materially reduces the
+local contraction for the 1 MPI rank / 1 GPU resource comparison. It should not
+be promoted to a default for GPU-sharing runs: the 512/4 profile shows the GPU
+packing kernels serialize poorly when four ranks share the same device. The
+next useful implementation step is true `THIS%PROJ` residency across the
+projection/off-site consumers, plus a device-side accumulation path that avoids
+copying `WORK` back for host accumulation.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -276,10 +276,16 @@ case_note() {
       echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and scalar TINV off-site DENMAT cuBLAS diagnostic."
       ;;
     gpu_resident_hpsi_offden_cublas_batch)
-      echo "Combined HPSI residency plus chunked strided-batched cuBLAS diagnostic for scalar TINV off-site DENMAT."
+      echo "Combined HPSI residency plus stacked cuBLAS diagnostic for scalar TINV off-site DENMAT."
       ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas_batch)
-      echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and chunked strided-batched cuBLAS off-site DENMAT diagnostic."
+      echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked cuBLAS off-site DENMAT diagnostic."
+      ;;
+    gpu_resident_hpsi_offden_cublas_devicepack)
+      echo "Combined HPSI residency plus stacked cuBLAS off-site DENMAT with OpenACC device packing."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack)
+      echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked cuBLAS off-site DENMAT with OpenACC device packing."
       ;;
     gpu_resident_offden_blas)
       echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
@@ -509,6 +515,8 @@ case_env() {
     gpu_resident_hpsi_denmat_energy_offden_cublas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} $(cublas_env)" ;;
     gpu_resident_hpsi_offden_cublas_batch) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas_batch) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_offden_cublas_devicepack) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary

This PR adds an opt-in OpenACC device-pack mode for the stacked scalar `TINV`/`NDIM=1` off-site DENMAT cuBLAS diagnostic.

The previous stacked path fixed the tiny-per-neighbor cuBLAS launch problem, but still packed A/B on the CPU and copied those packed buffers to the GPU per chunk. The new device-pack mode copies `PROJ` and `OCC` once for the off-site pass, packs A/B in OpenACC kernels, calls cuBLAS on present data, and copies only the stacked `WORK` block back for the existing host-side accumulation.

The path is diagnostic-only and disabled by default.

## Controls

- `CPPAW_GPU_OFFDEN_DEVICE_PACK=1`
- alias: `CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_PACK=1`
- requires the existing stacked path controls: `CPPAW_GPU_OFFDEN_LOCAL=1`, `CPPAW_GPU_OFFDEN_CUBLAS=1`, `CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1`
- `CPPAW_GPU_OFFDEN_BATCH_SIZE`, default `64`

New profile rows:

- `PAW_OFFDEN_DEVICE_PACK`
- `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK`
- `ACC_COPY_OFFDEN_DPACK_PROJ_IN`
- `ACC_COPY_OFFDEN_DPACK_META_IN`
- `ACC_COPY_OFFDEN_DPACK_WORK_OUT`

New benchmark cases:

- `gpu_resident_hpsi_offden_cublas_devicepack`
- `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack`

## Spark C86C validation

Built successfully:

- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Benchmark runs, all with `NSTEPS=1`:

| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_offden_cublas_batch` | 512 | 4 | 10.60 s | 1.8208 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_cublas_devicepack` | 512 | 4 | 9.51 s | 1.7485 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_offden_cublas_batch` | 2048 | 1 | 37.45 s | 5.1624 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_offden_cublas_devicepack` | 2048 | 1 | 37.37 s | 4.9162 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 512 | 4 | 10.01 s | 1.8515 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.87 s | 1.7791 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | 2048 | 1 | 37.58 s | 5.2528 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 36.03 s | 5.0066 GB | 0.000000407 Ha |

Focused profile result:

| Profile row | 2048/1 stacked | 2048/1 device-pack |
| --- | ---: | ---: |
| `PAW_OFFDEN_BATCH_PACK` | 0.0685 s | - |
| `PAW_OFFDEN_DEVICE_PACK` | - | 0.0034 s |
| `CUBLAS_ZGEMM_OFFDEN_TINV_STACK` | 0.0165 s | - |
| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | - | 0.0090 s |
| `ACC_COPY_CUBLAS_ZGEMM_NT` | 0.2636 GB | - |
| `ACC_COPY_OFFDEN_DPACK_PROJ_IN` | - | 0.0145 GB |
| `ACC_COPY_OFFDEN_DPACK_WORK_OUT` | - | 0.0029 GB |
| `PAW_OFFDEN_SUM_LOCAL` | 0.0954 s | 0.0137 s |

## Conclusion

Device-pack is a clear win for the 1 MPI rank / 1 GPU resource comparison and reduces off-site local contraction by about 7x in the combined 2048-band case. It should remain opt-in for now: the 512/4 profile shows GPU-packing kernels can be negative when several MPI ranks share one GPU. The next step is true `THIS%PROJ` residency across projection/off-site consumers plus device-side accumulation.
