### PR TITLE
Add off-site DENMAT device accumulation diagnostic

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4531,6 +4531,7 @@ END IF
       LOGICAL(4)             :: TOFFDENCUBLAS
       LOGICAL(4)             :: TOFFDENBATCH
       LOGICAL(4)             :: TOFFDENDEVICEPACK
+      LOGICAL(4)             :: TOFFDENDEVICEACCUM
       INTEGER(4)             :: OFFDENBATCHSIZE
       INTEGER(4)             :: IAT1,IAT2,IT(3),I0,J0,IDIM,JDIM
       COMPLEX(8)             :: EIKR,C1(NDIM),C2(NDIM),CSVAR22(NDIM,NDIM)
@@ -4559,6 +4560,7 @@ END IF
       TOFFDENCUBLAS=.FALSE.
       TOFFDENBATCH=.FALSE.
       TOFFDENDEVICEPACK=.FALSE.
+      TOFFDENDEVICEACCUM=.FALSE.
       OFFDENBATCHSIZE=64
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_LOCAL',ENVVAL &
      &                             ,STATUS=ENVSTAT)
@@ -4622,6 +4624,24 @@ END IF
           TOFFDENDEVICEPACK=.FALSE.
         END SELECT
       END IF
+      CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_DEVICE_ACCUM' &
+     &                             ,ENVVAL,STATUS=ENVSTAT)
+      IF(ENVSTAT.NE.0) THEN
+        CALL GET_ENVIRONMENT_VARIABLE('CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM' &
+     &                               ,ENVVAL,STATUS=ENVSTAT)
+      END IF
+      IF(ENVSTAT.EQ.0) THEN
+        SELECT CASE(TRIM(ADJUSTL(ENVVAL)))
+        CASE('1','T','t','TRUE','true','True','YES','yes','ON','on')
+          TOFFDENBLAS=.TRUE.
+          TOFFDENCUBLAS=.TRUE.
+          TOFFDENBATCH=.TRUE.
+          TOFFDENDEVICEPACK=.TRUE.
+          TOFFDENDEVICEACCUM=.TRUE.
+        CASE DEFAULT
+          TOFFDENDEVICEACCUM=.FALSE.
+        END SELECT
+      END IF
       CALL GET_ENVIRONMENT_VARIABLE('CPPAW_GPU_OFFDEN_BATCH_SIZE' &
      &                             ,ENVVAL,STATUS=ENVSTAT)
       IF(ENVSTAT.EQ.0) READ(ENVVAL,*,ERR=101,END=101) OFFDENBATCHSIZE
@@ -4683,7 +4703,7 @@ END IF
      &           ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD &
      &           ,NSPIN,ISPIN,OFFDENBATCHSIZE,OCC(1,IKPT,ISPIN) &
      &           ,XK(1,IKPT),THIS%PROJ(1,1,1),OSDENMAT &
-     &           ,TOFFDENDEVICEPACK)
+     &           ,TOFFDENDEVICEPACK,TOFFDENDEVICEACCUM)
             CYCLE
           END IF
           ICOUNT=0
@@ -4964,7 +4984,8 @@ END IF
 !     ...1.........2.........3.........4.........5.........6.........7.........8
       SUBROUTINE WAVES_OFFDEN_TINV_NDIM1_CUBLAS_BATCH(NND,NPRO &
      &          ,NPROAT,IPRO1,NTASKS,THISTASK,NBH,NB,NDIMD,NSPIN &
-     &          ,ISPIN,BATCHSIZE,OCC,XK,PROJ,OSDENMAT,TDEVICEPACK)
+     &          ,ISPIN,BATCHSIZE,OCC,XK,PROJ,OSDENMAT,TDEVICEPACK &
+     &          ,TDEVICEACCUM)
       USE RSPACEOP_MODULE, ONLY: RSPACEMAT_TYPE
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
       USE OPENACC
@@ -4978,7 +4999,8 @@ END IF
 !     **  density-matrix contractions. Neighbors sharing the same first atom  **
 !     **  and second-projector size are stacked into one wide ZGEMM.          **
 !     **  The optional device-pack mode keeps PROJ/OCC in one OpenACC region, **
-!     **  packs A/B on the GPU, and copies only the stacked WORK block back.   **
+!     **  packs A/B on the GPU, and can accumulate WORK into real MATPACK     **
+!     **  output on device before copying the host-visible result back.       **
 !     **************************************************************************
       IMPLICIT NONE
       COMPLEX(8),PARAMETER   :: CI=(0.D0,1.D0)
@@ -5000,6 +5022,7 @@ END IF
       COMPLEX(8),INTENT(IN)  :: PROJ(NBH,NPRO)
       TYPE(RSPACEMAT_TYPE),INTENT(INOUT) :: OSDENMAT(NND)
       LOGICAL(4),INTENT(IN)  :: TDEVICEPACK
+      LOGICAL(4),INTENT(IN)  :: TDEVICEACCUM
       LOGICAL(4),ALLOCATABLE :: DONE(:)
       INTEGER(4),ALLOCATABLE :: IDX(:)
       INTEGER(4),ALLOCATABLE :: J0ARR(:)
@@ -5007,6 +5030,7 @@ END IF
       COMPLEX(8),ALLOCATABLE :: B(:,:)
       COMPLEX(8),ALLOCATABLE :: WORK(:,:)
       COMPLEX(8),ALLOCATABLE :: EIKRARR(:)
+      REAL(8)   ,ALLOCATABLE :: MATPACK(:,:,:,:)
       COMPLEX(8)            :: ONE
       COMPLEX(8)            :: ZERO
       COMPLEX(8)            :: EIKR
@@ -5019,6 +5043,7 @@ END IF
       INTEGER(4)            :: K
       INTEGER(4)            :: I
       INTEGER(4)            :: J
+      INTEGER(4)            :: JDIM
       INTEGER(4)            :: IBH
       INTEGER(4)            :: IAT1
       INTEGER(4)            :: IAT2
@@ -5030,6 +5055,7 @@ END IF
       INTEGER(4)            :: MAXBATCH
       INTEGER(4)            :: IOFF
       LOGICAL(4)            :: TDEVICEACTIVE
+      LOGICAL(4)            :: TDEVICEACCUMACTIVE
       LOGICAL(4)            :: TCUBLAS_USED
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)               :: ACCEL_T0
@@ -5097,14 +5123,17 @@ END IF
         OFFDENFLOPS=8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
      &             *REAL(NBH,KIND=8)*REAL(COUNT,KIND=8)
         TDEVICEACTIVE=.FALSE.
+        TDEVICEACCUMACTIVE=.FALSE.
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
         TDEVICEACTIVE=TDEVICEPACK &
      &      .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_OFFDEN(OFFDENFLOPS)
 #ENDIF
         I0=IPRO1(IAT1)-1
         IF(TDEVICEACTIVE) THEN
+          TDEVICEACCUMACTIVE=TDEVICEACCUM
           ALLOCATE(J0ARR(COUNT))
           ALLOCATE(EIKRARR(COUNT))
+          IF(TDEVICEACCUMACTIVE) ALLOCATE(MATPACK(N1,N2,NDIMD,COUNT))
           DO K=1,COUNT
             NN=IDX(K)
             IAT2=OSDENMAT(NN)%IAT2
@@ -5115,9 +5144,16 @@ END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
+          IF(TDEVICEACCUMACTIVE) THEN
+!$ACC ENTER DATA CREATE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
+!$ACC&                  ,WORK(1:N1,1:N2*COUNT) &
+!$ACC&                  ,MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT)) &
+!$ACC& COPYIN(J0ARR(1:COUNT),EIKRARR(1:COUNT))
+          ELSE
 !$ACC ENTER DATA CREATE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
 !$ACC&                  ,WORK(1:N1,1:N2*COUNT)) &
 !$ACC& COPYIN(J0ARR(1:COUNT),EIKRARR(1:COUNT))
+          END IF
 !$ACC PARALLEL LOOP COLLAPSE(2) PRESENT(PROJ,A)
           DO IBH=1,NBH
             DO I=1,N1
@@ -5169,19 +5205,67 @@ END IF
      &        ,ACCEL_T1-ACCEL_T0)
           CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
+          IF(TDEVICEACCUMACTIVE) THEN
+!$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(IOFF) PRESENT(WORK,MATPACK)
+            DO K=1,COUNT
+              DO J=1,N2
+                DO I=1,N1
+                  IOFF=(K-1)*N2
+                  IF(NSPIN.EQ.1) THEN
+                    MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                  ELSE IF(NSPIN.EQ.2) THEN
+                    IF(ISPIN.EQ.1) THEN
+                      MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                      MATPACK(I,J,2,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                    ELSE
+                      MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                      MATPACK(I,J,2,K)=-REAL(WORK(I,IOFF+J),KIND=8)
+                    END IF
+                  END IF
+                ENDDO
+              ENDDO
+            ENDDO
+!$ACC END PARALLEL LOOP
+!$ACC WAIT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('PAW_OFFDEN_DEVICE_ACCUM' &
+     &          ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
+     &          ,INT(COUNT,KIND=8),0.D0 &
+     &          ,8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &          *REAL(NDIMD,KIND=8)*REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC UPDATE SELF(MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT))
+!$ACC WAIT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_MAT_OUT' &
+     &          ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
+     &          ,INT(COUNT,KIND=8),0.D0 &
+     &          ,8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &          *REAL(NDIMD,KIND=8)*REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC EXIT DATA DELETE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
+!$ACC&                 ,WORK(1:N1,1:N2*COUNT) &
+!$ACC&                 ,MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT) &
+!$ACC&                 ,J0ARR(1:COUNT),EIKRARR(1:COUNT))
+          ELSE
 !$ACC UPDATE SELF(WORK(1:N1,1:N2*COUNT))
 !$ACC WAIT
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
-          CALL ACCELPROFILE$NOW(ACCEL_T1)
-          CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_WORK_OUT' &
-     &        ,INT(N1,KIND=8),INT(N2,KIND=8),INT(COUNT,KIND=8),0_8 &
-     &        ,0.D0,16.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
-     &        *REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
-          CALL ACCELPROFILE$NOW(ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T1)
+            CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_WORK_OUT' &
+     &          ,INT(N1,KIND=8),INT(N2,KIND=8),INT(COUNT,KIND=8),0_8 &
+     &          ,0.D0,16.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
+     &          *REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
+            CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
 !$ACC EXIT DATA DELETE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
 !$ACC&                 ,WORK(1:N1,1:N2*COUNT),J0ARR(1:COUNT) &
 !$ACC&                 ,EIKRARR(1:COUNT))
+          END IF
           DEALLOCATE(EIKRARR)
           DEALLOCATE(J0ARR)
         ELSE
@@ -5245,32 +5329,43 @@ END IF
         DO K=1,COUNT
           NN=IDX(K)
           IOFF=(K-1)*N2
-          IF(NSPIN.EQ.1) THEN
-            DO J=1,N2
-              DO I=1,N1
-                OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
-     &              +REAL(WORK(I,IOFF+J),KIND=8)
+          IF(TDEVICEACCUMACTIVE) THEN
+            DO JDIM=1,NDIMD
+              DO J=1,N2
+                DO I=1,N1
+                  OSDENMAT(NN)%MAT(I,J,JDIM) &
+     &              =OSDENMAT(NN)%MAT(I,J,JDIM)+MATPACK(I,J,JDIM,K)
+                ENDDO
               ENDDO
             ENDDO
-          ELSE IF(NSPIN.EQ.2) THEN
-            IF(ISPIN.EQ.1) THEN
+          ELSE
+            IF(NSPIN.EQ.1) THEN
               DO J=1,N2
                 DO I=1,N1
                   OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
      &                +REAL(WORK(I,IOFF+J),KIND=8)
-                  OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
-     &                +REAL(WORK(I,IOFF+J),KIND=8)
                 ENDDO
               ENDDO
-            ELSE
-              DO J=1,N2
-                DO I=1,N1
-                  OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
-     &                +REAL(WORK(I,IOFF+J),KIND=8)
-                  OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
-     &                -REAL(WORK(I,IOFF+J),KIND=8)
+            ELSE IF(NSPIN.EQ.2) THEN
+              IF(ISPIN.EQ.1) THEN
+                DO J=1,N2
+                  DO I=1,N1
+                    OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
+     &                  +REAL(WORK(I,IOFF+J),KIND=8)
+                    OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
+     &                  +REAL(WORK(I,IOFF+J),KIND=8)
+                  ENDDO
                 ENDDO
-              ENDDO
+              ELSE
+                DO J=1,N2
+                  DO I=1,N1
+                    OSDENMAT(NN)%MAT(I,J,1)=OSDENMAT(NN)%MAT(I,J,1) &
+     &                  +REAL(WORK(I,IOFF+J),KIND=8)
+                    OSDENMAT(NN)%MAT(I,J,2)=OSDENMAT(NN)%MAT(I,J,2) &
+     &                  -REAL(WORK(I,IOFF+J),KIND=8)
+                  ENDDO
+                ENDDO
+              END IF
             END IF
           END IF
         ENDDO
@@ -5280,6 +5375,7 @@ END IF
      &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
      &      ,INT(COUNT,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
 #ENDIF
+        IF(TDEVICEACCUMACTIVE) DEALLOCATE(MATPACK)
         DEALLOCATE(WORK)
         DEALLOCATE(B)
         DEALLOCATE(A)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -313,6 +313,13 @@ is copied back. It records `PAW_OFFDEN_DEVICE_PACK`,
 `ACC_COPY_OFFDEN_DPACK_META_IN`, and `ACC_COPY_OFFDEN_DPACK_WORK_OUT`. Spark
 Si64 shows this is useful for the 1 MPI rank / 1 GPU comparison, but can be a
 negative diagnostic when several MPI ranks share one GPU.
+`CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1` or
+`CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM=1` keeps the device-pack path active and
+accumulates the complex `WORK` block into a real `MATPACK` result on the GPU.
+It then copies back `MATPACK` instead of `WORK`, recording
+`PAW_OFFDEN_DEVICE_ACCUM` and `ACC_COPY_OFFDEN_DPACK_MAT_OUT`. This is an
+opt-in diagnostic for reducing host round-trips before a fully device-resident
+off-site accumulation path exists.
 `CPPAW_GPU_PROJ_RESIDENCY=1` or `CPPAW_CUBLAS_ACC_PROJ_RESIDENCY=1` keeps
 `THIS%PROJ` present after `WAVES$PROJECTIONS` and the `K`-communicator combine.
 That lets downstream `PRESENT_OR_COPYIN` users reuse projections instead of
@@ -400,8 +407,11 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked scalar off-site DENMAT cuBLAS diagnostic. |
 | `gpu_resident_hpsi_offden_cublas_devicepack` | Combined HPSI residency plus stacked scalar off-site DENMAT cuBLAS with OpenACC device packing. |
 | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked scalar off-site DENMAT cuBLAS with OpenACC device packing. |
+| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | Device-pack off-site DENMAT diagnostic with GPU-side real-matrix accumulation. |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | Combined DENMAT energy/device-pack diagnostic with GPU-side real-matrix accumulation. |
 | `gpu_resident_hpsi_offden_cublas_devicepack_proj` | Device-pack off-site DENMAT diagnostic with HPSI and persistent `THIS%PROJ` residency enabled. |
 | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | Combined DENMAT energy/device-pack off-site diagnostic with persistent `THIS%PROJ` residency enabled. |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | Combined DENMAT energy/device-pack diagnostic with persistent `THIS%PROJ` and GPU-side real-matrix accumulation. |
 | `gpu_psim_propagate` | Opt-in diagnostic that propagates `PSIM` on the GPU and copies it back before orthogonalization via `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_hpsi_psim_propagate` | Combined diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_PSIM_PROPAGATE=1`. |
 | `gpu_resident_hpsi_opsi` | Combined residency diagnostic with both `CPPAW_GPU_HPSI_RESIDENCY=1` and `CPPAW_GPU_OPSI_RESIDENCY=1`. |

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -37,6 +37,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `offden-cublas-stack-diagnostic-20260531-*` / `offden-cublas-stack-combined-20260531-*` | Stacked off-site DENMAT cuBLAS diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_batch` 36.10 s at 2048/1 | - | `gpu_resident_hpsi_offden_cublas_batch` 9.65 s at 512/4 | Groups neighbors with the same first atom and second-projector size into one wider cuBLAS `ZGEMM`; energy-valid and eliminates the tiny-GEMM launch problem, but host packing still dominates enough to keep it opt-in. |
 | `offden-device-pack-20260531-*` / `offden-device-pack-combined-20260531-*` | Off-site DENMAT device-pack diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 36.03 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 9.87 s at 512/4 | Packs the stacked off-site A/B buffers on the GPU and copies back only WORK; strong for 1 MPI/GPU, diagnostic-only when several ranks share one GPU. |
 | `proj-residency-fixed-20260531-*` | `THIS%PROJ` residency diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` 36.57 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` 9.48 s at 512/4 | Keeps the combined projection result present for eligible off-site device-pack consumers; energy-valid after invalidating stale present `PROPSI`, useful as an opt-in diagnostic but too narrow for default promotion. |
+| `offden-device-accum-20260601-*` | Off-site DENMAT device-accum diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` 35.26 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` 9.59 s at 512/4 | Converts stacked complex `WORK` to real `MATPACK` on the GPU and copies that back; energy-valid and reduces copy volume, but kernel overhead keeps it opt-in. |
 
 The latest full-matrix run lives at:
 
@@ -1945,6 +1946,60 @@ net copy estimate does not drop in the current shape because the copy is moved
 from the off-site consumer to the post-projection residency step. Keep it
 opt-in until more consumers can reuse the same resident `THIS%PROJ` block or the
 off-site accumulation path stays fully on the GPU.
+
+## Off-Site DENMAT Device-Accum Diagnostic
+
+The next diagnostic adds `CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1` with
+`CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM=1` as an alias. It implies the existing
+device-pack path, leaves the stacked cuBLAS `ZGEMM` result in device `WORK`,
+converts/accumulates that complex block into a real `MATPACK` result on the GPU,
+and copies `MATPACK` back for the existing host-side `OSDENMAT` update. This
+removes `ACC_COPY_OFFDEN_DPACK_WORK_OUT` and replaces it with
+`PAW_OFFDEN_DEVICE_ACCUM` plus `ACC_COPY_OFFDEN_DPACK_MAT_OUT`.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/offden-device-accum-20260601-2048-1r
+runs/offden-device-accum-20260601-512-4r
+```
+
+| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi_offden_cublas_devicepack` | 2048 | 1 | 37.84 s | 4.9162 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | 2048 | 1 | 39.32 s | 4.9148 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 36.88 s | 5.0066 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 2048 | 1 | 38.86 s | 5.0052 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 2048 | 1 | 35.29 s | 5.0066 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 2048 | 1 | 35.26 s | 5.0052 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_offden_cublas_devicepack` | 512 | 4 | 9.74 s | 1.7485 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | 512 | 4 | 9.77 s | 1.7470 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.54 s | 1.7791 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 512 | 4 | 9.80 s | 1.7776 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 512 | 4 | 9.78 s | 1.7791 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 512 | 4 | 9.59 s | 1.7776 GB | 0.000000401 Ha |
+
+| Profile row | 2048/1 device-pack | 2048/1 device-accum | 2048/1 proj device-pack | 2048/1 proj device-accum |
+| --- | ---: | ---: | ---: | ---: |
+| `PAW_OFFDEN_DEVICE_PACK` | 0.0037 s | 0.0034 s | 0.0034 s | 0.0035 s |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | 0.0091 s | 0.0091 s | 0.0092 s | 0.0091 s |
+| `ACC_COPY_OFFDEN_DPACK_WORK_OUT` | 0.0029 GB | - | 0.0029 GB | - |
+| `PAW_OFFDEN_DEVICE_ACCUM` | - | 0.0005 s, 0.0015 GB | - | 0.0004 s, 0.0015 GB |
+| `ACC_COPY_OFFDEN_DPACK_MAT_OUT` | - | 0.0015 GB | - | 0.0015 GB |
+| `ACC_COPY_OFFDEN_DPACK_PROJ_IN` | 0.0145 GB | 0.0145 GB | - | - |
+| `ACC_PRESENT_OFFDEN_DPACK_PROJ` | - | - | 1 call, 0 GB | 1 call, 0 GB |
+
+Conclusion: the implementation is correct and provides a useful accounting
+split for the next residency step, but it is not a default-performance win for
+Si64. In the scalar 2048/1 case it halves the final off-site result copy
+(`WORK` complex to real `MATPACK`) from 0.0029 GB to 0.0015 GB, but the extra
+device kernel and allocation/copy overhead offset the smaller transfer. Keep it
+opt-in and use it as a stepping stone toward a real device-side accumulation
+target where the `OSDENMAT` update and possibly the monomer combine no longer
+force per-batch host-visible buffers.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -290,11 +290,20 @@ case_note() {
     gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack)
       echo "Combined HPSI residency, DENMAT energy/Lambda diagnostic, and stacked cuBLAS off-site DENMAT with OpenACC device packing."
       ;;
+    gpu_resident_hpsi_offden_cublas_devicepack_accum)
+      echo "Device-pack off-site DENMAT diagnostic that accumulates the stacked cuBLAS result into a real matrix pack on the GPU."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum)
+      echo "Combined DENMAT energy/device-pack diagnostic with GPU-side off-site real-matrix accumulation."
+      ;;
     gpu_resident_hpsi_offden_cublas_devicepack_proj)
       echo "Device-pack off-site DENMAT diagnostic with HPSI and persistent THIS%PROJ residency enabled."
       ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj)
       echo "Combined DENMAT energy/device-pack off-site diagnostic with persistent THIS%PROJ residency enabled."
+      ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum)
+      echo "Combined DENMAT energy/device-pack off-site diagnostic with persistent THIS%PROJ and GPU-side real-matrix accumulation."
       ;;
     gpu_resident_offden_blas)
       echo "Residency diagnostic that enables the opt-in scalar TINV off-site DENMAT BLAS prototype."
@@ -527,8 +536,11 @@ case_env() {
     gpu_resident_hpsi_denmat_energy_offden_cublas_batch) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_hpsi_offden_cublas_devicepack) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_offden_cublas_devicepack_accum) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_hpsi_offden_cublas_devicepack_proj) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PROJ_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PROJ_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
+    gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PROJ_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_resident_hpsi_offden_blas) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 $(cublas_env)" ;;
     gpu_psim_propagate|gpu_resident_psim) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_PSIM_PROPAGATE=1 $(cublas_env)" ;;


### PR DESCRIPTION
## Summary
- Add opt-in `CPPAW_GPU_OFFDEN_DEVICE_ACCUM` / `CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM` for the off-site DENMAT device-pack path.
- Convert stacked complex cuBLAS `WORK` into a real `MATPACK` result on the GPU, then copy that real result back for the existing host-side `OSDENMAT` update.
- Add profile rows `PAW_OFFDEN_DEVICE_ACCUM` and `ACC_COPY_OFFDEN_DPACK_MAT_OUT` while preserving the previous `WORK_OUT` path when the new switch is disabled.
- Extend the Si64 harness and Spark benchmark summary with `*_devicepack_accum` cases.

## Validation
Spark C86C, NVIDIA HPC SDK 26.3:
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile -j16`
- `CPPAW_TOOLCHAIN=nvhpc src/Buildtools/paw_build.sh -z -c nvhpc_gpu_acc_residency_profile_parallel -j16`
- `NSTEPS=1 EMPTY_BANDS=2048 RANKS=1` for device-pack/device-accum combinations
- `NSTEPS=1 EMPTY_BANDS=512 RANKS=4` for the same combinations

## Benchmark Snapshot
All tested cases are energy-valid:

| Case | 2048/1 wall | 2048/1 copy | 512/4 wall | 512/4 copy |
| --- | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_offden_cublas_devicepack` | 37.84 s | 4.9162 GB | 9.74 s | 1.7485 GB |
| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | 39.32 s | 4.9148 GB | 9.77 s | 1.7470 GB |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 36.88 s | 5.0066 GB | 9.54 s | 1.7791 GB |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 38.86 s | 5.0052 GB | 9.80 s | 1.7776 GB |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 35.29 s | 5.0066 GB | 9.78 s | 1.7791 GB |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 35.26 s | 5.0052 GB | 9.59 s | 1.7776 GB |

Conclusion: the diagnostic is correctness-safe and reduces the final off-site result copy (`WORK` complex to real `MATPACK`) from 0.0029 GB to 0.0015 GB in the 2048/1 scalar case. The extra device accumulation kernel keeps this opt-in rather than default for Si64, but it gives a concrete stepping stone toward fully device-resident off-site accumulation.