### PR TITLE
Accumulate off-site DENMAT device output into flat buffer

### DIFF
--- a/src/paw_waves1.f90
+++ b/src/paw_waves1.f90
@@ -4999,8 +4999,8 @@ END IF
 !     **  density-matrix contractions. Neighbors sharing the same first atom  **
 !     **  and second-projector size are stacked into one wide ZGEMM.          **
 !     **  The optional device-pack mode keeps PROJ/OCC in one OpenACC region, **
-!     **  packs A/B on the GPU, and can accumulate WORK into real MATPACK     **
-!     **  output on device before copying the host-visible result back.       **
+!     **  packs A/B on the GPU, and can accumulate WORK into a flat real      **
+!     **  off-site matrix buffer before one host-visible result copy.         **
 !     **************************************************************************
       IMPLICIT NONE
       COMPLEX(8),PARAMETER   :: CI=(0.D0,1.D0)
@@ -5026,11 +5026,13 @@ END IF
       LOGICAL(4),ALLOCATABLE :: DONE(:)
       INTEGER(4),ALLOCATABLE :: IDX(:)
       INTEGER(4),ALLOCATABLE :: J0ARR(:)
+      INTEGER(4),ALLOCATABLE :: MOFFARR(:)
+      INTEGER(4),ALLOCATABLE :: MATOFF(:)
       COMPLEX(8),ALLOCATABLE :: A(:,:)
       COMPLEX(8),ALLOCATABLE :: B(:,:)
       COMPLEX(8),ALLOCATABLE :: WORK(:,:)
       COMPLEX(8),ALLOCATABLE :: EIKRARR(:)
-      REAL(8)   ,ALLOCATABLE :: MATPACK(:,:,:,:)
+      REAL(8)   ,ALLOCATABLE :: MATFLAT(:)
       COMPLEX(8)            :: ONE
       COMPLEX(8)            :: ZERO
       COMPLEX(8)            :: EIKR
@@ -5054,8 +5056,11 @@ END IF
       INTEGER(4)            :: COUNT
       INTEGER(4)            :: MAXBATCH
       INTEGER(4)            :: IOFF
+      INTEGER(4)            :: MOFF
+      INTEGER(4)            :: NTOT
       LOGICAL(4)            :: TDEVICEACTIVE
       LOGICAL(4)            :: TDEVICEACCUMACTIVE
+      LOGICAL(4)            :: TDEVICEFLAT
       LOGICAL(4)            :: TCUBLAS_USED
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       REAL(8)               :: ACCEL_T0
@@ -5070,6 +5075,32 @@ END IF
       ALLOCATE(DONE(NND))
       ALLOCATE(IDX(MAXBATCH))
       DONE=.FALSE.
+      TDEVICEFLAT=.FALSE.
+#IF DEFINED(CPPVAR_CUBLAS_ACC)
+      TDEVICEFLAT=TDEVICEPACK.AND.TDEVICEACCUM
+#ENDIF
+      NTOT=0
+      IF(TDEVICEFLAT) THEN
+        ALLOCATE(MATOFF(NND))
+        MATOFF=0
+        DO NN=1,NND
+          IF(MOD(NN-1,NTASKS).NE.THISTASK-1) CYCLE
+          IAT1=OSDENMAT(NN)%IAT1
+          IAT2=OSDENMAT(NN)%IAT2
+          N1=NPROAT(IAT1)
+          N2=NPROAT(IAT2)
+          MATOFF(NN)=NTOT+1
+          NTOT=NTOT+N1*N2*NDIMD
+        ENDDO
+        IF(NTOT.GT.0) THEN
+          ALLOCATE(MATFLAT(NTOT))
+          MATFLAT=0.D0
+!$ACC ENTER DATA COPYIN(MATFLAT(1:NTOT))
+        ELSE
+          TDEVICEFLAT=.FALSE.
+          DEALLOCATE(MATOFF)
+        END IF
+      END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
       IF(TDEVICEPACK) THEN
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
@@ -5130,25 +5161,25 @@ END IF
 #ENDIF
         I0=IPRO1(IAT1)-1
         IF(TDEVICEACTIVE) THEN
-          TDEVICEACCUMACTIVE=TDEVICEACCUM
+          TDEVICEACCUMACTIVE=TDEVICEFLAT
           ALLOCATE(J0ARR(COUNT))
           ALLOCATE(EIKRARR(COUNT))
-          IF(TDEVICEACCUMACTIVE) ALLOCATE(MATPACK(N1,N2,NDIMD,COUNT))
+          IF(TDEVICEACCUMACTIVE) ALLOCATE(MOFFARR(COUNT))
           DO K=1,COUNT
             NN=IDX(K)
             IAT2=OSDENMAT(NN)%IAT2
             J0ARR(K)=IPRO1(IAT2)-1
             SVAR=2.D0*PI*SUM(XK(:)*REAL(OSDENMAT(NN)%IT,KIND=8))
             EIKRARR(K)=EXP(CI*SVAR)
+            IF(TDEVICEACCUMACTIVE) MOFFARR(K)=MATOFF(NN)
           ENDDO
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
           IF(TDEVICEACCUMACTIVE) THEN
 !$ACC ENTER DATA CREATE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
-!$ACC&                  ,WORK(1:N1,1:N2*COUNT) &
-!$ACC&                  ,MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT)) &
-!$ACC& COPYIN(J0ARR(1:COUNT),EIKRARR(1:COUNT))
+!$ACC&                  ,WORK(1:N1,1:N2*COUNT)) &
+!$ACC& COPYIN(J0ARR(1:COUNT),EIKRARR(1:COUNT),MOFFARR(1:COUNT))
           ELSE
 !$ACC ENTER DATA CREATE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
 !$ACC&                  ,WORK(1:N1,1:N2*COUNT)) &
@@ -5206,20 +5237,28 @@ END IF
           CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
           IF(TDEVICEACCUMACTIVE) THEN
-!$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(IOFF) PRESENT(WORK,MATPACK)
+!$ACC WAIT
+!$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(IOFF,MOFF) &
+!$ACC& PRESENT(WORK,MATFLAT,MOFFARR)
             DO K=1,COUNT
               DO J=1,N2
                 DO I=1,N1
                   IOFF=(K-1)*N2
+                  MOFF=MOFFARR(K)+(J-1)*N1+I-1
                   IF(NSPIN.EQ.1) THEN
-                    MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                    MATFLAT(MOFF)=MATFLAT(MOFF) &
+     &                  +REAL(WORK(I,IOFF+J),KIND=8)
                   ELSE IF(NSPIN.EQ.2) THEN
                     IF(ISPIN.EQ.1) THEN
-                      MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
-                      MATPACK(I,J,2,K)=REAL(WORK(I,IOFF+J),KIND=8)
+                      MATFLAT(MOFF)=MATFLAT(MOFF) &
+     &                    +REAL(WORK(I,IOFF+J),KIND=8)
+                      MATFLAT(MOFF+N1*N2)=MATFLAT(MOFF+N1*N2) &
+     &                    +REAL(WORK(I,IOFF+J),KIND=8)
                     ELSE
-                      MATPACK(I,J,1,K)=REAL(WORK(I,IOFF+J),KIND=8)
-                      MATPACK(I,J,2,K)=-REAL(WORK(I,IOFF+J),KIND=8)
+                      MATFLAT(MOFF)=MATFLAT(MOFF) &
+     &                    +REAL(WORK(I,IOFF+J),KIND=8)
+                      MATFLAT(MOFF+N1*N2)=MATFLAT(MOFF+N1*N2) &
+     &                    -REAL(WORK(I,IOFF+J),KIND=8)
                     END IF
                   END IF
                 ENDDO
@@ -5236,21 +5275,9 @@ END IF
      &          *REAL(NDIMD,KIND=8)*REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
             CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
-!$ACC UPDATE SELF(MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT))
-!$ACC WAIT
-#IF DEFINED(CPPVAR_ACCEL_PROFILE)
-            CALL ACCELPROFILE$NOW(ACCEL_T1)
-            CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_MAT_OUT' &
-     &          ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
-     &          ,INT(COUNT,KIND=8),0.D0 &
-     &          ,8.D0*REAL(N1,KIND=8)*REAL(N2,KIND=8) &
-     &          *REAL(NDIMD,KIND=8)*REAL(COUNT,KIND=8),ACCEL_T1-ACCEL_T0)
-            CALL ACCELPROFILE$NOW(ACCEL_T0)
-#ENDIF
 !$ACC EXIT DATA DELETE(A(1:N1,1:NBH),B(1:N2*COUNT,1:NBH) &
-!$ACC&                 ,WORK(1:N1,1:N2*COUNT) &
-!$ACC&                 ,MATPACK(1:N1,1:N2,1:NDIMD,1:COUNT) &
-!$ACC&                 ,J0ARR(1:COUNT),EIKRARR(1:COUNT))
+!$ACC&                 ,WORK(1:N1,1:N2*COUNT),J0ARR(1:COUNT) &
+!$ACC&                 ,EIKRARR(1:COUNT),MOFFARR(1:COUNT))
           ELSE
 !$ACC UPDATE SELF(WORK(1:N1,1:N2*COUNT))
 !$ACC WAIT
@@ -5266,6 +5293,7 @@ END IF
 !$ACC&                 ,WORK(1:N1,1:N2*COUNT),J0ARR(1:COUNT) &
 !$ACC&                 ,EIKRARR(1:COUNT))
           END IF
+          IF(TDEVICEACCUMACTIVE) DEALLOCATE(MOFFARR)
           DEALLOCATE(EIKRARR)
           DEALLOCATE(J0ARR)
         ELSE
@@ -5326,19 +5354,10 @@ END IF
           CALL ACCELPROFILE$NOW(ACCEL_T0)
 #ENDIF
         END IF
-        DO K=1,COUNT
-          NN=IDX(K)
-          IOFF=(K-1)*N2
-          IF(TDEVICEACCUMACTIVE) THEN
-            DO JDIM=1,NDIMD
-              DO J=1,N2
-                DO I=1,N1
-                  OSDENMAT(NN)%MAT(I,J,JDIM) &
-     &              =OSDENMAT(NN)%MAT(I,J,JDIM)+MATPACK(I,J,JDIM,K)
-                ENDDO
-              ENDDO
-            ENDDO
-          ELSE
+        IF(.NOT.TDEVICEACCUMACTIVE) THEN
+          DO K=1,COUNT
+            NN=IDX(K)
+            IOFF=(K-1)*N2
             IF(NSPIN.EQ.1) THEN
               DO J=1,N2
                 DO I=1,N1
@@ -5367,19 +5386,57 @@ END IF
                 ENDDO
               END IF
             END IF
-          END IF
-        ENDDO
+          ENDDO
+        END IF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
         CALL ACCELPROFILE$NOW(ACCEL_T1)
         CALL ACCELPROFILE$ADD('PAW_OFFDEN_BATCH_ACCUM' &
      &      ,INT(N1,KIND=8),INT(N2,KIND=8),INT(NDIMD,KIND=8) &
      &      ,INT(COUNT,KIND=8),0.D0,0.D0,ACCEL_T1-ACCEL_T0)
 #ENDIF
-        IF(TDEVICEACCUMACTIVE) DEALLOCATE(MATPACK)
         DEALLOCATE(WORK)
         DEALLOCATE(B)
         DEALLOCATE(A)
       ENDDO
+      IF(TDEVICEFLAT) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC UPDATE SELF(MATFLAT(1:NTOT))
+!$ACC WAIT
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        CALL ACCELPROFILE$ADD('ACC_COPY_OFFDEN_DPACK_FLAT_OUT' &
+     &      ,INT(NTOT,KIND=8),INT(NDIMD,KIND=8),0_8,0_8,0.D0 &
+     &      ,8.D0*REAL(NTOT,KIND=8),ACCEL_T1-ACCEL_T0)
+        CALL ACCELPROFILE$NOW(ACCEL_T0)
+#ENDIF
+!$ACC EXIT DATA DELETE(MATFLAT(1:NTOT))
+        DO NN=1,NND
+          IF(MATOFF(NN).EQ.0) CYCLE
+          IAT1=OSDENMAT(NN)%IAT1
+          IAT2=OSDENMAT(NN)%IAT2
+          N1=NPROAT(IAT1)
+          N2=NPROAT(IAT2)
+          DO JDIM=1,NDIMD
+            DO J=1,N2
+              DO I=1,N1
+                MOFF=MATOFF(NN)+(JDIM-1)*N1*N2+(J-1)*N1+I-1
+                OSDENMAT(NN)%MAT(I,J,JDIM) &
+     &            =OSDENMAT(NN)%MAT(I,J,JDIM)+MATFLAT(MOFF)
+              ENDDO
+            ENDDO
+          ENDDO
+        ENDDO
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+        CALL ACCELPROFILE$NOW(ACCEL_T1)
+        CALL ACCELPROFILE$ADD('PAW_OFFDEN_FLAT_ACCUM_SCATTER' &
+     &      ,INT(NTOT,KIND=8),INT(NND,KIND=8),INT(NDIMD,KIND=8),0_8 &
+     &      ,0.D0,0.D0,ACCEL_T1-ACCEL_T0)
+#ENDIF
+        DEALLOCATE(MATFLAT)
+        DEALLOCATE(MATOFF)
+      END IF
 !$ACC END DATA
       DEALLOCATE(IDX)
       DEALLOCATE(DONE)

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -315,11 +315,12 @@ Si64 shows this is useful for the 1 MPI rank / 1 GPU comparison, but can be a
 negative diagnostic when several MPI ranks share one GPU.
 `CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1` or
 `CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM=1` keeps the device-pack path active and
-accumulates the complex `WORK` block into a real `MATPACK` result on the GPU.
-It then copies back `MATPACK` instead of `WORK`, recording
-`PAW_OFFDEN_DEVICE_ACCUM` and `ACC_COPY_OFFDEN_DPACK_MAT_OUT`. This is an
-opt-in diagnostic for reducing host round-trips before a fully device-resident
-off-site accumulation path exists.
+accumulates the complex `WORK` blocks into a flat real off-site matrix buffer
+on the GPU. It then copies that flat buffer back once per k-point/spin pass
+instead of copying each batch's complex `WORK`, recording
+`PAW_OFFDEN_DEVICE_ACCUM`, `ACC_COPY_OFFDEN_DPACK_FLAT_OUT`, and
+`PAW_OFFDEN_FLAT_ACCUM_SCATTER`. This is an opt-in diagnostic for reducing host
+round-trips before a fully device-resident off-site accumulation path exists.
 `CPPAW_GPU_PROJ_RESIDENCY=1` or `CPPAW_CUBLAS_ACC_PROJ_RESIDENCY=1` keeps
 `THIS%PROJ` present after `WAVES$PROJECTIONS` and the `K`-communicator combine.
 That lets downstream `PRESENT_OR_COPYIN` users reuse projections instead of

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -38,6 +38,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `offden-device-pack-20260531-*` / `offden-device-pack-combined-20260531-*` | Off-site DENMAT device-pack diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 36.03 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` 9.87 s at 512/4 | Packs the stacked off-site A/B buffers on the GPU and copies back only WORK; strong for 1 MPI/GPU, diagnostic-only when several ranks share one GPU. |
 | `proj-residency-fixed-20260531-*` | `THIS%PROJ` residency diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` 36.57 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` 9.48 s at 512/4 | Keeps the combined projection result present for eligible off-site device-pack consumers; energy-valid after invalidating stale present `PROPSI`, useful as an opt-in diagnostic but too narrow for default promotion. |
 | `offden-device-accum-20260601-*` | Off-site DENMAT device-accum diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` 35.26 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` 9.59 s at 512/4 | Converts stacked complex `WORK` to real `MATPACK` on the GPU and copies that back; energy-valid and reduces copy volume, but kernel overhead keeps it opt-in. |
+| `offden-flat-accum-20260601-*` | Off-site DENMAT flat device-accum diagnostic | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` 35.64 s at 2048/1 | - | `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` 9.62 s at 512/4 | Accumulates batches into one flat real off-site matrix buffer on the GPU and copies it back once per k-point/spin pass; energy-valid, useful at 1 MPI/GPU, neutral/noisy when four ranks share one GPU. |
 
 The latest full-matrix run lives at:
 
@@ -1947,15 +1948,17 @@ from the off-site consumer to the post-projection residency step. Keep it
 opt-in until more consumers can reuse the same resident `THIS%PROJ` block or the
 off-site accumulation path stays fully on the GPU.
 
-## Off-Site DENMAT Device-Accum Diagnostic
+## Off-Site DENMAT Flat Device-Accum Diagnostic
 
 The next diagnostic adds `CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1` with
 `CPPAW_CUBLAS_ACC_OFFDEN_DEVICE_ACCUM=1` as an alias. It implies the existing
 device-pack path, leaves the stacked cuBLAS `ZGEMM` result in device `WORK`,
-converts/accumulates that complex block into a real `MATPACK` result on the GPU,
-and copies `MATPACK` back for the existing host-side `OSDENMAT` update. This
+converts/accumulates each batch into one flat real off-site matrix buffer on the
+GPU, and copies that flat buffer back once per k-point/spin pass for the
+existing host-side `OSDENMAT` update. This
 removes `ACC_COPY_OFFDEN_DPACK_WORK_OUT` and replaces it with
-`PAW_OFFDEN_DEVICE_ACCUM` plus `ACC_COPY_OFFDEN_DPACK_MAT_OUT`.
+`PAW_OFFDEN_DEVICE_ACCUM`, `ACC_COPY_OFFDEN_DPACK_FLAT_OUT`, and
+`PAW_OFFDEN_FLAT_ACCUM_SCATTER`.
 
 Spark C86C validation:
 
@@ -1965,41 +1968,40 @@ nvhpc_gpu_acc_residency_profile_parallel
 
 runs/offden-device-accum-20260601-2048-1r
 runs/offden-device-accum-20260601-512-4r
+runs/offden-flat-accum-20260601-2048-1r
+runs/offden-flat-accum-20260601-512-4r
 ```
 
 | Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `gpu_resident_hpsi_offden_cublas_devicepack` | 2048 | 1 | 37.84 s | 4.9162 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | 2048 | 1 | 39.32 s | 4.9148 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 36.88 s | 5.0066 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 2048 | 1 | 38.86 s | 5.0052 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 2048 | 1 | 35.29 s | 5.0066 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 2048 | 1 | 35.26 s | 5.0052 GB | 0.000000407 Ha |
-| `gpu_resident_hpsi_offden_cublas_devicepack` | 512 | 4 | 9.74 s | 1.7485 GB | 0.000000401 Ha |
-| `gpu_resident_hpsi_offden_cublas_devicepack_accum` | 512 | 4 | 9.77 s | 1.7470 GB | 0.000000401 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.54 s | 1.7791 GB | 0.000000401 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 512 | 4 | 9.80 s | 1.7776 GB | 0.000000401 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 512 | 4 | 9.78 s | 1.7791 GB | 0.000000401 Ha |
-| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 512 | 4 | 9.59 s | 1.7776 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 37.91 s | 5.0066 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 2048 | 1 | 37.30 s | 5.0052 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 2048 | 1 | 37.29 s | 5.0066 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 2048 | 1 | 35.64 s | 5.0052 GB | 0.000000407 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.89 s | 1.7791 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 512 | 4 | 9.62 s | 1.7776 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 512 | 4 | 9.71 s | 1.7791 GB | 0.000000401 Ha |
+| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 512 | 4 | 9.73 s | 1.7776 GB | 0.000000401 Ha |
 
 | Profile row | 2048/1 device-pack | 2048/1 device-accum | 2048/1 proj device-pack | 2048/1 proj device-accum |
 | --- | ---: | ---: | ---: | ---: |
-| `PAW_OFFDEN_DEVICE_PACK` | 0.0037 s | 0.0034 s | 0.0034 s | 0.0035 s |
-| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | 0.0091 s | 0.0091 s | 0.0092 s | 0.0091 s |
+| `PAW_OFFDEN_DEVICE_PACK` | 0.0035 s | 0.0037 s | 0.0036 s | 0.0035 s |
+| `CUBLAS_ZGEMM_OFFDEN_TINV_DPACK` | 0.0090 s | 0.0091 s | 0.0091 s | 0.0091 s |
 | `ACC_COPY_OFFDEN_DPACK_WORK_OUT` | 0.0029 GB | - | 0.0029 GB | - |
-| `PAW_OFFDEN_DEVICE_ACCUM` | - | 0.0005 s, 0.0015 GB | - | 0.0004 s, 0.0015 GB |
-| `ACC_COPY_OFFDEN_DPACK_MAT_OUT` | - | 0.0015 GB | - | 0.0015 GB |
+| `PAW_OFFDEN_DEVICE_ACCUM` | - | 0.0006 s, 0.0015 GB | - | 0.0006 s, 0.0015 GB |
+| `ACC_COPY_OFFDEN_DPACK_FLAT_OUT` | - | 0.0015 GB | - | 0.0015 GB |
+| `PAW_OFFDEN_FLAT_ACCUM_SCATTER` | - | 0.0001 s | - | 0.0001 s |
 | `ACC_COPY_OFFDEN_DPACK_PROJ_IN` | 0.0145 GB | 0.0145 GB | - | - |
 | `ACC_PRESENT_OFFDEN_DPACK_PROJ` | - | - | 1 call, 0 GB | 1 call, 0 GB |
 
-Conclusion: the implementation is correct and provides a useful accounting
-split for the next residency step, but it is not a default-performance win for
-Si64. In the scalar 2048/1 case it halves the final off-site result copy
-(`WORK` complex to real `MATPACK`) from 0.0029 GB to 0.0015 GB, but the extra
-device kernel and allocation/copy overhead offset the smaller transfer. Keep it
-opt-in and use it as a stepping stone toward a real device-side accumulation
-target where the `OSDENMAT` update and possibly the monomer combine no longer
-force per-batch host-visible buffers.
+Conclusion: the implementation is correct and now avoids per-batch result
+copies by copying one flat real off-site buffer back at the end of the pass. It
+halves the final off-site result copy (`WORK` complex to real flat matrix) from
+0.0029 GB to 0.0015 GB and the combined 2048/1 projection-residency case drops
+from 37.29 s to 35.64 s. The 512/4 shared-GPU case is neutral/noisy, so this
+still belongs behind an opt-in switch. The next useful step is to keep the
+consumer of `OSDENMAT` closer to this packed/device representation so the
+host-side scatter is no longer the synchronization boundary.
 
 ## Recommended Next Benchmark
 


### PR DESCRIPTION
## Summary
- changes the opt-in off-site DENMAT device-accum path to accumulate stacked cuBLAS output into one flat real off-site matrix buffer on the GPU
- copies the flat buffer back once per k-point/spin pass and scatters into the existing host `OSDENMAT` representation
- updates the profiling docs and Spark Si64 benchmark summary for the flat accumulation variant

## Validation
- `git diff --check`
- `bash -n tests/profile/si64/run_benchmark.sh`
- Spark C86C: `nvhpc_gpu_acc_residency_profile`
- Spark C86C: `nvhpc_gpu_acc_residency_profile_parallel`
- Spark C86C Si64, `NSTEPS=1`, `EMPTY_BANDS=2048`, `RANKS=1`: all four devicepack/devicepack_accum/proj/proj_accum cases energy-valid
- Spark C86C Si64, `NSTEPS=1`, `EMPTY_BANDS=512`, `RANKS=4`: all four cases energy-valid

## Spark Si64 Results
| Case | Empty bands | Ranks | Wall time | Copy estimate | Energy delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 2048 | 1 | 37.91 s | 5.0066 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 2048 | 1 | 37.30 s | 5.0052 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 2048 | 1 | 37.29 s | 5.0066 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 2048 | 1 | 35.64 s | 5.0052 GB | 0.000000407 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack` | 512 | 4 | 9.89 s | 1.7791 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum` | 512 | 4 | 9.62 s | 1.7776 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj` | 512 | 4 | 9.71 s | 1.7791 GB | 0.000000401 Ha |
| `gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum` | 512 | 4 | 9.73 s | 1.7776 GB | 0.000000401 Ha |

The 2048/1 combined projection-residency case improves from 37.29 s to 35.64 s. The 512/4 shared-GPU comparison is neutral/noisy, so the switch remains opt-in.