### PR TITLE
Add PSIM lifecycle benchmark harness

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -520,6 +520,24 @@ run directories. Set `RUN_LARGE_GPU=yes` to add a one-rank
 `SHARED_GPU_RANKS`, `EMPTY_BANDS`, and `RUN_SHARED_GPU=no` for narrower
 checks.
 
+For the PSIM lifecycle comparison across at least two time steps, run:
+
+```
+cd tests/profile/si64
+./run_psim_lifecycle.sh
+```
+
+It uses `NSTEPS=2` by default and compares the same PSIM/HPSI diagnostics as
+`run_psim_focus.sh`, but keeps the run shape centered on one GPU rank. This is
+intended to expose copies around the propagation, orthogonalization, and next
+time-step boundaries before broader cross-step wavefunction residency is enabled.
+Because the one-step Si64 reference energy is not valid for multi-step dynamics,
+the fixed energy check is disabled by default for this harness; compare the
+reported energies between cases instead. It writes the normal combined benchmark
+TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`.
+Override `NSTEPS_LIST`, `EMPTY_BANDS_LIST`, `RUN_SHARED_GPU=yes`,
+`RUN_LARGE_GPU=yes`, or `PSIM_LIFECYCLE_CASES` for wider sweeps.
+
 For the larger orthogonalization preset used in the residency follow-up, run:
 
 ```

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -21,11 +21,13 @@ bash -n tests/profile/si64/run_gpu_exploration.sh
 bash -n tests/profile/si64/run_nvhpc_standard.sh
 bash -n tests/profile/si64/run_nsys.sh
 bash -n tests/profile/si64/run_overnight.sh
+bash -n tests/profile/si64/run_psim_lifecycle.sh
 bash -n src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
 bash -n src/Tools/Scripts/paw_gpu_capabilities.sh
 
 python3 -m py_compile \
   tests/profile/si64/profile_summary.py \
+  tests/profile/si64/profile_copy_rows.py \
   tests/profile/si64/benchmark_summary.py \
   tests/profile/si64/benchmark_markdown.py \
   tests/profile/si64/nsys_sql_summary.py

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -42,6 +42,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `psim-present-copy-20260601-*` | PSIM propagation present-or-copy accounting | `gpu_resident` 6.36 s at 512/1 | - | `gpu_resident` 9.18 s at 512/4 | Changes the PSIM propagation data region to `present_or_copy`; energy-valid and correct for future broader residency, but current Si64 still copies PSIM in/out because no enclosing resident producer is active. |
 | `psim-focus-harness-20260601-*` | Focused PSIM propagation harness | `gpu_psim_propagate` 6.20 s at 512/1 | - | `gpu_psim_propagate` 9.19 s at 512/4 | Adds a reusable PSIM/HPSI propagation sweep; all cases are energy-valid, but the single-run 512-band timings are noisy and the PSIM path still increases copy volume, so this is a regression harness rather than a default promotion. |
 | `psim-phase-residency-20260601-*` | Cross-phase PSIM residency diagnostic | `gpu_resident` 37.61 s, `gpu_resident_psim_phase` 37.75 s at 2048/1 | - | `gpu_resident_psim_phase` 9.11 s at 512/4 | Leaves propagated `PSIM` resident into orthogonalization and copies it back at the orthogonalization boundary; energy-valid and reduces copy volume, but wall time is neutral/noisy, so keep it opt-in. |
+| `psim-lifecycle-20260601-rerun-*` | Two-step PSIM lifecycle harness | `gpu_resident_hpsi` 10.05 s at 512/1 | - | - | Adds an `NSTEPS=2` harness plus per-case copy-row extraction; all cases finish with the same two-step energy, and the profile confirms the next boundary is still `PSI0`/`HPSI`/ADDPRO-style residency rather than another immediate PSIM-only promotion. |
 
 The latest full-matrix run lives at:
 
@@ -2143,6 +2144,47 @@ from 37.29 s to 35.64 s. The 512/4 shared-GPU case is neutral/noisy, so this
 still belongs behind an opt-in switch. The next useful step is to keep the
 consumer of `OSDENMAT` closer to this packed/device representation so the
 host-side scatter is no longer the synchronization boundary.
+
+## PSIM Lifecycle Harness
+
+The follow-up adds `tests/profile/si64/run_psim_lifecycle.sh` and
+`tests/profile/si64/profile_copy_rows.py`. The lifecycle harness defaults to
+`NSTEPS=2`, disables the fixed one-step Si64 energy check, and compares the
+reported energies between cases. The copy-row helper reads the profile CSV
+header and aggregates the `gbyte` column for `ACC_COPY*` rows, avoiding fragile
+positional parsing.
+
+Spark C86C validation:
+
+```
+runs/psim-lifecycle-20260601-rerun-empty512-nstep2-1r
+runs/psim-lifecycle-20260601-rerun-combined.tsv
+runs/psim-lifecycle-20260601-rerun-copy-rows.md
+```
+
+| Case | Empty bands | NSTEPS | Ranks | Wall time | Copy estimate | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident` | 512 | 2 | 1 | 10.14 s | 2.6165 GB | 269.022536 Ha |
+| `gpu_psim_propagate` | 512 | 2 | 1 | 10.05 s | 3.1551 GB | 269.022536 Ha |
+| `gpu_resident_psim_phase` | 512 | 2 | 1 | 10.98 s | 2.8861 GB | 269.022536 Ha |
+| `gpu_resident_hpsi` | 512 | 2 | 1 | 10.05 s | 2.3443 GB | 269.022536 Ha |
+| `gpu_hpsi_psim_propagate` | 512 | 2 | 1 | 10.76 s | 2.8829 GB | 269.022536 Ha |
+| `gpu_resident_hpsi_psim_phase` | 512 | 2 | 1 | 10.60 s | 2.6139 GB | 269.022536 Ha |
+
+| Profile row | Plain PSIM | PSIM phase | HPSI | HPSI + PSIM phase | Interpretation |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `ACC_COPY_PROP_PSIM_OUT` | 0.1345 GB | - | - | - | Cross-phase PSIM residency removes the immediate propagation copy-out. |
+| `ACC_COPY_ORTHO_PSIM_IN` | - | - | 0.1345 GB | - | Plain HPSI still enters orthogonalization through a copied `PSIM`. |
+| `ACC_COPY_FORCE_PSI0_IN` | 0.1345 GB | 0.1345 GB | 0.1345 GB | 0.1345 GB | The force path still creates a new `PSI0` residency boundary each step. |
+| `ACC_COPY_HPSI_ADDPRO_IN` | - | - | 0.1345 GB | 0.1345 GB | HPSI residency is local to the current ADDPRO/overlap envelope. |
+| `ACC_COPY_ADDPRO_OPSI_PSI_IN` | - | 0.1345 GB | 0.1345 GB | 0.1345 GB | The OPSI/ADDPRO side remains a repeated wavefunction copy target. |
+
+Conclusion: the lifecycle run is correctness-clean, but it reinforces the
+earlier design choice. PSIM phase residency is doing the intended copy
+substitution, yet wall time stays noisy and total copy volume still grows when
+PSIM propagation is enabled. The next useful technical lever is broader
+`PSI0`/`HPSI`/ADDPRO consumer residency around `WAVES$ETOT` and the following
+step, not a standalone promotion of `CPPAW_GPU_PSIM_PHASE_RESIDENCY`.
 
 ## Recommended Next Benchmark
 

--- a/tests/profile/si64/profile_copy_rows.py
+++ b/tests/profile/si64/profile_copy_rows.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import csv
+import glob
+import os
+import sys
+
+
+def profile_files(path):
+    matches = glob.glob(path)
+    if not matches:
+        matches = [path]
+    files = []
+    for match in matches:
+        if os.path.isdir(match):
+            files.extend(
+                glob.glob(os.path.join(match, "**", "*_profile*.csv"), recursive=True)
+            )
+        elif os.path.isfile(match):
+            files.append(match)
+    return sorted(set(files))
+
+
+def suite_name(root, path):
+    if root and os.path.isdir(root):
+        return os.path.basename(os.path.normpath(root))
+    parts = os.path.normpath(path).split(os.sep)
+    if len(parts) >= 4 and parts[-2].startswith("rep"):
+        return parts[-4]
+    return ""
+
+
+def case_and_repeat(path):
+    parts = os.path.normpath(path).split(os.sep)
+    if len(parts) >= 3 and parts[-2].startswith("rep"):
+        return parts[-3], parts[-2]
+    base = os.path.basename(path)
+    case = base.split("_profile", 1)[0]
+    return case, ""
+
+
+def collect(paths):
+    rows = collections.defaultdict(
+        lambda: {"calls": 0, "seconds": 0.0, "gbyte": 0.0, "files": set()}
+    )
+    for arg in paths:
+        root = arg if os.path.isdir(arg) else ""
+        for path in profile_files(arg):
+            suite = suite_name(root, path)
+            case, repeat = case_and_repeat(path)
+            with open(path, newline="") as handle:
+                for row in csv.DictReader(handle):
+                    op = row.get("op", "")
+                    if not op.startswith("ACC_COPY"):
+                        continue
+                    gbyte = float(row.get("gbyte") or 0.0)
+                    if gbyte <= 0.0:
+                        continue
+                    key = (suite, case, repeat, op)
+                    data = rows[key]
+                    data["calls"] += int(row.get("calls") or 0)
+                    data["seconds"] += float(row.get("total_seconds") or 0.0)
+                    data["gbyte"] += gbyte
+                    data["files"].add(path)
+    return rows
+
+
+def aggregate(rows, include_repeat):
+    merged = collections.defaultdict(
+        lambda: {"calls": 0, "seconds": 0.0, "gbyte": 0.0, "files": set()}
+    )
+    for (suite, case, repeat, op), data in rows.items():
+        key = (suite, case, repeat if include_repeat else "", op)
+        item = merged[key]
+        item["calls"] += data["calls"]
+        item["seconds"] += data["seconds"]
+        item["gbyte"] += data["gbyte"]
+        item["files"].update(data["files"])
+    return merged
+
+
+def selected_rows(rows, top, per_case, min_gb):
+    items = [
+        (key, data)
+        for key, data in rows.items()
+        if data["gbyte"] >= min_gb
+    ]
+    if not per_case:
+        return sorted(items, key=lambda item: -item[1]["gbyte"])[:top]
+
+    grouped = collections.defaultdict(list)
+    for key, data in items:
+        suite, case, repeat, _op = key
+        grouped[(suite, case, repeat)].append((key, data))
+    selected = []
+    for group_key in sorted(grouped):
+        group = sorted(grouped[group_key], key=lambda item: -item[1]["gbyte"])
+        selected.extend(group[:top])
+    return selected
+
+
+def print_tsv(rows):
+    print("suite\tcase\trepeat\top\tcalls\tcopy_gb\tseconds\tfiles")
+    for (suite, case, repeat, op), data in rows:
+        print(
+            "{}\t{}\t{}\t{}\t{}\t{:.9g}\t{:.9g}\t{}".format(
+                suite,
+                case,
+                repeat,
+                op,
+                data["calls"],
+                data["gbyte"],
+                data["seconds"],
+                len(data["files"]),
+            )
+        )
+
+
+def print_markdown(rows):
+    print("| suite | case | repeat | op | calls | copy_gb | seconds | files |")
+    print("| --- | --- | --- | --- | ---: | ---: | ---: | ---: |")
+    for (suite, case, repeat, op), data in rows:
+        print(
+            "| {} | {} | {} | {} | {} | {:.4f} | {:.4f} | {} |".format(
+                suite,
+                case,
+                repeat,
+                op,
+                data["calls"],
+                data["gbyte"],
+                data["seconds"],
+                len(data["files"]),
+            )
+        )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Summarize ACC_COPY profile rows from CP-PAW profile CSV files."
+    )
+    parser.add_argument("paths", nargs="+", help="profile CSV, glob, or run root")
+    parser.add_argument("--top", type=int, default=10, help="rows per table/group")
+    parser.add_argument(
+        "--per-case",
+        action="store_true",
+        help="emit the top rows separately for each suite/case/repeat group",
+    )
+    parser.add_argument(
+        "--include-repeat",
+        action="store_true",
+        help="keep repeats separate instead of aggregating them",
+    )
+    parser.add_argument("--min-gb", type=float, default=0.0)
+    parser.add_argument("--markdown", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    rows = aggregate(collect(args.paths), args.include_repeat)
+    chosen = selected_rows(rows, args.top, args.per_case, args.min_gb)
+    if not chosen:
+        print("No ACC_COPY rows found.", file=sys.stderr)
+        return 1
+    if args.markdown:
+        print_markdown(chosen)
+    else:
+        print_tsv(chosen)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -19,6 +19,7 @@ MPI_ARGS=${MPI_ARGS:---mca coll ^hcoll}
 CASES=${CASES:-"cpu nvhpc_cpu gpu_resident gpu_off"}
 EXPECTED_ENERGY=${EXPECTED_ENERGY:-}
 ENERGY_TOL=${ENERGY_TOL:-1e-5}
+ENERGY_CHECK=${ENERGY_CHECK:-yes}
 TIMEOUT_PREFIX=""
 if command -v timeout >/dev/null 2>&1; then
   TIMEOUT_PREFIX="timeout ${TIMEOUT}s"
@@ -37,8 +38,20 @@ if [[ -z "${TIME_CMD}" ]]; then
   exit 1
 fi
 
-case "${TEST}" in
-  si64|si64_bands) EXPECTED_ENERGY=${EXPECTED_ENERGY:-302.280854} ;;
+case "${EXPECTED_ENERGY}" in
+  none|off|skip)
+    EXPECTED_ENERGY=
+    ENERGY_CHECK=no
+    ;;
+esac
+
+case "${ENERGY_CHECK}" in
+  no|false|0) EXPECTED_ENERGY= ;;
+  *)
+    case "${TEST}" in
+      si64|si64_bands) EXPECTED_ENERGY=${EXPECTED_ENERGY:-302.280854} ;;
+    esac
+    ;;
 esac
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}

--- a/tests/profile/si64/run_psim_lifecycle.sh
+++ b/tests/profile/si64/run_psim_lifecycle.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+TEST=${TEST:-si64}
+NSTEPS_LIST=${NSTEPS_LIST:-${NSTEPS:-2}}
+EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-${EMPTY_BANDS:-512}}
+GPU_RANKS=${GPU_RANKS:-1}
+SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
+SHARED_EMPTY_BANDS=${SHARED_EMPTY_BANDS:-512}
+REPEATS=${REPEATS:-1}
+TIMEOUT=${TIMEOUT:-900}
+RUN_SHARED_GPU=${RUN_SHARED_GPU:-no}
+RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
+LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
+COPY_TOP=${COPY_TOP:-8}
+RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/psim-lifecycle-$(date +%Y%m%d-%H%M%S)"}}
+PSIM_LIFECYCLE_CASES=${PSIM_LIFECYCLE_CASES:-"gpu_resident gpu_psim_propagate gpu_resident_psim_phase gpu_resident_hpsi gpu_hpsi_psim_propagate gpu_resident_hpsi_psim_phase"}
+
+COMBINED="${RUN_ROOT_BASE}-combined.tsv"
+COPY_COMBINED="${RUN_ROOT_BASE}-copy-rows.md"
+: > "${COMBINED}"
+
+declare -a SUITE_ROOTS=()
+
+append_suite() {
+  local suite=$1
+  local tsv=$2
+
+  [[ -f "${tsv}" ]] || return 0
+  if [[ ! -s "${COMBINED}" ]]; then
+    awk 'NR == 1 { print "suite\t" $0; next } { print suite "\t" $0 }' \
+      suite="${suite}" "${tsv}" > "${COMBINED}"
+  else
+    awk 'NR > 1 { print suite "\t" $0 }' suite="${suite}" "${tsv}" >> "${COMBINED}"
+  fi
+}
+
+run_suite() {
+  local label=$1
+  local nsteps=$2
+  local ranks=$3
+  local empty_bands=$4
+  local timeout=$5
+  local root="${RUN_ROOT_BASE}-${label}"
+
+  echo "Running PSIM lifecycle suite: ${label}"
+  TEST="${TEST}" NSTEPS="${nsteps}" EMPTY_BANDS="${empty_bands}" \
+    RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${PSIM_LIFECYCLE_CASES}" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    ENERGY_CHECK="${ENERGY_CHECK:-no}" \
+    "${HERE}/run_benchmark.sh"
+  append_suite "${label}" "${root}/benchmark.tsv"
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
+      --include-repeat --markdown "${root}" > "${root}/copy_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
+      --include-repeat "${root}" > "${root}/copy_rows.tsv"
+  fi
+  SUITE_ROOTS+=("${root}")
+}
+
+for nsteps in ${NSTEPS_LIST}; do
+  for empty_bands in ${EMPTY_BANDS_LIST}; do
+    run_suite "empty${empty_bands}-nstep${nsteps}-${GPU_RANKS}r" \
+      "${nsteps}" "${GPU_RANKS}" "${empty_bands}" "${TIMEOUT}"
+  done
+done
+
+case "${RUN_SHARED_GPU}" in
+  yes|true|1)
+    for nsteps in ${NSTEPS_LIST}; do
+      run_suite "empty${SHARED_EMPTY_BANDS}-nstep${nsteps}-${SHARED_GPU_RANKS}r" \
+        "${nsteps}" "${SHARED_GPU_RANKS}" "${SHARED_EMPTY_BANDS}" "${TIMEOUT}"
+    done
+    ;;
+esac
+
+case "${RUN_LARGE_GPU}" in
+  yes|true|1)
+    for nsteps in ${NSTEPS_LIST}; do
+      run_suite "empty${LARGE_EMPTY_BANDS}-nstep${nsteps}-${GPU_RANKS}r" \
+        "${nsteps}" "${GPU_RANKS}" "${LARGE_EMPTY_BANDS}" "${TIMEOUT}"
+    done
+    ;;
+esac
+
+if [[ -s "${COMBINED}" ]]; then
+  python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-combined.md" || true
+  echo "Combined benchmark data: ${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
+    --markdown "${SUITE_ROOTS[@]}" > "${COPY_COMBINED}" || true
+  echo "Combined copy-row data: ${COPY_COMBINED}"
+fi


### PR DESCRIPTION
## Summary
- add a focused `run_psim_lifecycle.sh` sweep for PSIM/HPSI diagnostics across at least two time steps
- add `profile_copy_rows.py` to aggregate `ACC_COPY*` profile rows from CSV headers by case
- allow `run_benchmark.sh` to disable the fixed one-step Si64 energy check for multi-step lifecycle runs
- document the Spark C86C `NSTEPS=2`, `EMPTY_BANDS=512`, one-rank validation results

## Spark validation
`tests/profile/si64/check_harness.sh`

`NSTEPS_LIST=2 EMPTY_BANDS_LIST=512 RUN_SHARED_GPU=no REPEATS=1 TIMEOUT=900 RUN_ROOT_BASE="runs/psim-lifecycle-20260601-rerun" ./run_psim_lifecycle.sh`

All six cases completed with `ok=yes` and final energy `269.022536 Ha`. Best wall time in this run was `gpu_resident_hpsi` at `10.05 s`; PSIM phase residency removed the immediate propagation copy-out but remains diagnostic because total copy volume and wall time are still neutral/noisy.