### PR TITLE
Keep superwave OPSI build resident

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -172,7 +172,7 @@
      &           .AND.CPPAW_CUBLAS_ACC_SHOULD_USE_ADDPRODUCT(ACCINVFLOPS)
             END IF
           END IF
-          TRESIDENTOPSIBUILD=TRESIDENTOPSI.AND.(NBH.EQ.NB)
+          TRESIDENTOPSIBUILD=TRESIDENTOPSI
 #ENDIF
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
           CALL ACCELPROFILE$NOW(ACCEL_T0)
@@ -262,17 +262,7 @@ END IF
 !PB070802          END IF
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
           IF(TRESIDENTOPSIBUILD) THEN
-!$ACC DATA COPYIN(MARR(1:NGL)) PRESENT(THIS%OPSI(1:NGL,1:NDIM,1:NBH))
-!$ACC PARALLEL LOOP COLLAPSE(3) PRESENT(MARR,THIS%OPSI)
-            DO IB=1,NBH
-              DO IDIM=1,NDIM
-                DO IG=1,NGL
-                  THIS%OPSI(IG,IDIM,IB)=MARR(IG)*THIS%OPSI(IG,IDIM,IB)
-                ENDDO
-              ENDDO
-            ENDDO
-!$ACC END PARALLEL LOOP
-!$ACC END DATA
+            CALL WAVES_SCALE_OPSI_ACC(NGL,NDIM,NBH,MARR,THIS%OPSI)
           ELSE
 #ENDIF
             DO IB=1,NBH
@@ -287,6 +277,15 @@ END IF
 #ENDIF
           DEALLOCATE(MARR)
 #IF DEFINED(CPPVAR_CUBLAS_ACC)
+          IF(TRESIDENTOPSI.AND.TRESIDENTOPSIBUILD) THEN
+#IF DEFINED(CPPVAR_ACCEL_PROFILE)
+            CALL ACCELPROFILE$ADD('ACC_COPY_OPSI_MASS_OUT' &
+     &          ,INT(NGL,KIND=8),INT(NDIM,KIND=8),INT(NBH,KIND=8) &
+     &          ,0_8,0.D0,16.D0*REAL(NGL,KIND=8) &
+     &          *REAL(NDIM,KIND=8)*REAL(NBH,KIND=8),0.D0)
+#ENDIF
+!$ACC UPDATE SELF(THIS%OPSI(1:NGL,1:NDIM,1:NBH))
+          END IF
           IF(TRESIDENTOPSI.AND.(.NOT.TRESIDENTOPSIBUILD)) THEN
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)
             CALL CPPAW_CUBLAS_ACC_PROFILE_PRESENT_C8_3D &
@@ -844,7 +843,36 @@ END IF
       END
 !
 !     ...1.........2.........3.........4.........5.........6.........7.........8
-       SUBROUTINE WAVES_OPROJ(LNX,LOX,DO,NDIM,LMNX,NB,PROJ,OPROJ)
+      SUBROUTINE WAVES_SCALE_OPSI_ACC(NGL,NDIM,NBH,MARR,OPSI)
+!     **************************************************************************
+!     **  SCALE RESIDENT OPSI BY THE WAVE-FUNCTION MASS FACTOR.                **
+!     **************************************************************************
+      IMPLICIT NONE
+      INTEGER(4),INTENT(IN)    :: NGL
+      INTEGER(4),INTENT(IN)    :: NDIM
+      INTEGER(4),INTENT(IN)    :: NBH
+      REAL(8)   ,INTENT(IN)    :: MARR(NGL)
+      COMPLEX(8),INTENT(INOUT) :: OPSI(NGL,NDIM,NBH)
+      INTEGER(4)               :: IG
+      INTEGER(4)               :: IDIM
+      INTEGER(4)               :: IB
+!     **************************************************************************
+!$ACC DATA COPYIN(MARR(1:NGL)) PRESENT(OPSI(1:NGL,1:NDIM,1:NBH))
+!$ACC PARALLEL LOOP COLLAPSE(3) PRESENT(MARR,OPSI)
+      DO IB=1,NBH
+        DO IDIM=1,NDIM
+          DO IG=1,NGL
+            OPSI(IG,IDIM,IB)=MARR(IG)*OPSI(IG,IDIM,IB)
+          ENDDO
+        ENDDO
+      ENDDO
+!$ACC END PARALLEL LOOP
+!$ACC END DATA
+      RETURN
+      END
+!
+!     ...1.........2.........3.........4.........5.........6.........7.........8
+      SUBROUTINE WAVES_OPROJ(LNX,LOX,DO,NDIM,LMNX,NB,PROJ,OPROJ)
 !      *****************************************************************
 !      **                                                             **
 !      **  DO<PRO|PSI>                                                **

--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -625,10 +625,11 @@ be overridden by kernel category:
   `0` for the previous copy-heavy path.
 - `CPPAW_GPU_OPSI_RESIDENCY`: disabled by default. Set to `1` to keep
   orthogonalization `OPSI` resident through projection, overlap, and
-  `WAVES_ADDOPSI` on eligible non-stress paths. Non-superwave paths can keep
-  OPSI resident from build and mass scaling; superwave paths currently build and
-  mass-scale OPSI on the host before entering the resident region, while later
-  projection and `WAVES_ADDOPSI` consumers use `present_or_copyin` data regions.
+  `WAVES_ADDOPSI` on eligible non-stress paths. Eligible paths keep OPSI
+  resident from build and mass scaling; inversion-symmetric superwave paths take
+  one host snapshot after mass scaling so remaining host-side projection
+  fallbacks see the same OPSI data while later projection and `WAVES_ADDOPSI`
+  consumers use `present_or_copyin` data regions.
   The
   compatibility alias is `CPPAW_CUBLAS_ACC_OPSI_RESIDENCY`.
 - `CPPAW_GPU_PSIM_PROPAGATE`: disabled by default. Set to `1` to run

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -44,6 +44,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `psim-phase-residency-20260601-*` | Cross-phase PSIM residency diagnostic | `gpu_resident` 37.61 s, `gpu_resident_psim_phase` 37.75 s at 2048/1 | - | `gpu_resident_psim_phase` 9.11 s at 512/4 | Leaves propagated `PSIM` resident into orthogonalization and copies it back at the orthogonalization boundary; energy-valid and reduces copy volume, but wall time is neutral/noisy, so keep it opt-in. |
 | `psim-lifecycle-20260601-rerun-*` | Two-step PSIM lifecycle harness | `gpu_resident_hpsi` 10.05 s at 512/1 | - | - | Adds an `NSTEPS=2` harness plus per-case copy-row extraction; all cases finish with the same two-step energy, and the profile confirms the next boundary is still `PSI0`/`HPSI`/ADDPRO-style residency rather than another immediate PSIM-only promotion. |
 | `opsi-present-consumers-20260601-*` | OPSI present-or-copy consumer cleanup | `gpu_resident_hpsi_opsi` 10.13 s at 512/1 | - | - | Converts downstream projection/ADDPRO/ADDOPSI data regions to `present_or_copy*`; correctness is preserved, but the superwave OPSI build remains the real copy target. |
+| `opsi-superwave-build-residency-20260601-final-v2` | Superwave OPSI build residency | `gpu_resident_hpsi_opsi` 10.36 s at 512/1 | - | - | Keeps superwave OPSI resident through build/mass scaling with one post-mass host snapshot; energy-valid and removes ADDPRO-OPSI in/out copies. |
 
 The latest full-matrix run lives at:
 
@@ -2226,6 +2227,45 @@ resident inputs, while the measured copy rows point to the next real step:
 make the superwave `WAVES_OPSI` build/mass-scale path device-resident only once
 the projection path can consume that resident result without falling back to
 stale host data.
+
+## Superwave OPSI Build Residency
+
+The follow-up extends `CPPAW_GPU_OPSI_RESIDENCY=1` to the inversion-symmetric
+superwave path. `WAVES_OPSI` now starts with OPSI present, `WAVES_ADDPRO`
+updates that resident buffer, and mass scaling is performed through the
+explicit `WAVES_SCALE_OPSI_ACC` helper. The path still takes one post-mass host
+snapshot because later superwave projection fallback code can read OPSI on the
+host.
+
+Spark C86C validation:
+
+```
+nvhpc_gpu_acc_residency_profile
+nvhpc_gpu_acc_residency_profile_parallel
+
+runs/opsi-superwave-build-residency-20260601-final-v2
+```
+
+| Case | Empty bands | NSTEPS | Ranks | Wall time | Copy estimate | Final energy |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gpu_resident_hpsi` | 512 | 2 | 1 | 11.11 s | 2.3443 GB | 269.022536 Ha |
+| `gpu_resident_hpsi_opsi` | 512 | 2 | 1 | 10.36 s | 2.2098 GB | 269.022536 Ha |
+
+| Profile row | HPSI | HPSI + OPSI | Interpretation |
+| --- | ---: | ---: | --- |
+| `ACC_COPY_ADDPRO_OPSI_PSI_IN` | 0.1345 GB | - | OPSI build-time ADDPRO no longer copies the input wavefunction. |
+| `ACC_COPY_ADDPRO_OPSI_PSI_OUT` | 0.1345 GB | - | OPSI build-time ADDPRO no longer copies the updated wavefunction back. |
+| `ACC_COPY_ORTHO_OPSI_IN` | 0.1345 GB | - | The later orthogonalization consumer sees OPSI present. |
+| `ACC_COPY_OPSI_BUILD_IN` | - | 0.1345 GB | OPSI enters the build path on device. |
+| `ACC_COPY_OPSI_MASS_OUT` | - | 0.1345 GB | One post-mass host snapshot keeps fallback host readers correct. |
+| `ACC_PRESENT_ADDPRO_OPSI_PSI` | - | 2 calls | Build-time ADDPRO updates resident OPSI. |
+| `ACC_PRESENT_ORTHO_OPSI` | - | 2 calls | Orthogonalization uses the resident OPSI buffer. |
+
+Conclusion: correctness is preserved for the two-step Si64 smoke and the OPSI
+switch now removes the repeated ADDPRO input/output copies for superwave
+builds. The remaining host snapshot is intentional; the next cleanup target is
+the host-side superwave projection fallback so `ACC_COPY_OPSI_MASS_OUT` can be
+reduced or removed later.
 
 ## Recommended Next Benchmark
 


### PR DESCRIPTION
## Summary
- keep eligible superwave OPSI resident through `WAVES_OPSI` build and mass scaling
- move resident mass scaling into an explicit `WAVES_SCALE_OPSI_ACC` helper
- keep one post-mass host snapshot for current superwave projection fallbacks and document the copy-boundary result

## Spark validation
Built on Spark C86C with NVHPC 26.3:
- `nvhpc_gpu_acc_residency_profile`
- `nvhpc_gpu_acc_residency_profile_parallel`

Si64 smoke:
`NSTEPS=2 EMPTY_BANDS=512 RANKS=1 CASES="gpu_resident_hpsi gpu_resident_hpsi_opsi"`

| Case | Wall time | Copy estimate | Final energy |
| --- | ---: | ---: | ---: |
| `gpu_resident_hpsi` | 11.11 s | 2.3443 GB | 269.022536 Ha |
| `gpu_resident_hpsi_opsi` | 10.36 s | 2.2098 GB | 269.022536 Ha |

Key copy rows:
- removed `ACC_COPY_ADDPRO_OPSI_PSI_IN/OUT` from the OPSI case
- removed `ACC_COPY_ORTHO_OPSI_IN` from the OPSI case
- added `ACC_COPY_OPSI_BUILD_IN` and `ACC_COPY_OPSI_MASS_OUT`
- `ACC_PRESENT_ADDPRO_OPSI_PSI`, `ACC_PRESENT_ORTHO_OPSI`, and TINV ADDOPSI rows are present

Local check:
- `tests/profile/si64/check_harness.sh`
