### PR TITLE
Fix NVLAMATH Gram Cholesky build

### DIFF
--- a/src/paw_waves2.f90
+++ b/src/paw_waves2.f90
@@ -1831,8 +1831,11 @@ END IF
        REAL(8)                    :: ACCEL_CHOL_T1
        REAL(8)                    :: ACCEL_CHOL_TOTAL_T0
 #ENDIF
+#IF DEFINED(CPPVAR_NVLAMATH)
+#ELSE
        EXTERNAL ZPOTRF
        EXTERNAL ZTRTRI
+#ENDIF
 !      *****************************************************************
        TOK=.FALSE.
 #IF DEFINED(CPPVAR_ACCEL_PROFILE)


### PR DESCRIPTION
## Summary
- avoid explicit EXTERNAL declarations for ZPOTRF/ZTRTRI when CPPVAR_NVLAMATH is enabled
- match the existing NVLAMATH pattern used for LAPACK symbols in paw_library.f90
- restore nvhpc_gpu_all_profile and nvhpc_nvlamath_profile builds with NVIDIA HPC SDK NVLAMATH

## Validation
- local: git diff --check
- local: tests/profile/si64/check_harness.sh
- Spark: nvhpc_gpu_all_profile build
- Spark: nvhpc_gpu_all_profile_parallel build
- Spark: nvhpc_nvlamath_profile build
- Spark Si64 smoke, 512 empty bands, NSTEPS=1, 1 rank:
  - gpu_all: ok=yes, wall_s=77.69, energy=302.280854 Ha
  - nvlamath: ok=yes, wall_s=20.30, energy=302.280854 Ha