### PR TITLE
Add NVHPC VPSI boundary profiling harness

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -569,9 +569,30 @@ time-step boundaries before broader cross-step wavefunction residency is enabled
 Because the one-step Si64 reference energy is not valid for multi-step dynamics,
 the fixed energy check is disabled by default for this harness; compare the
 reported energies between cases instead. It writes the normal combined benchmark
-TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`.
+TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`;
+the helper also accepts `--op-prefix`, `--op-regex`, and `--include-zero` for
+broader profile-row reports such as present/update/timing rows.
 Override `NSTEPS_LIST`, `EMPTY_BANDS_LIST`, `RUN_SHARED_GPU=yes`,
 `RUN_LARGE_GPU=yes`, or `PSIM_LIFECYCLE_CASES` for wider sweeps.
+
+For the VPSI/HPSI producer-boundary comparison, run:
+
+```
+cd tests/profile/si64
+./run_vpsi_boundary.sh
+```
+
+It focuses on the current remaining HPSI boundary: `WAVES_VPSI` still receives
+host-side FFT/RTOG output, then refreshes or creates the device-present `HPSI`
+buffer for the following `WAVES_ADDPRO` consumer. The harness compares
+`gpu_resident_hpsi`, `gpu_resident_hpsi_opsi`, and `gpu_resident_stack` with
+`NSTEPS=2` by default and writes combined benchmark tables plus selected
+profile tables for `ACC_COPY`/`ACC_UPDATE`/`ACC_PRESENT` rows and separate
+seconds-sorted `PAW_VPSI_*` timing rows.
+Because multi-step Si64 energies are not the one-step reference, fixed energy
+checking is disabled by default; compare energies between cases. Override
+`VPSI_BOUNDARY_CASES`, `NSTEPS_LIST`, `EMPTY_BANDS_LIST`,
+`RUN_SHARED_GPU=yes`, or `RUN_LARGE_GPU=yes` for wider sweeps.
 
 For the larger orthogonalization preset used in the residency follow-up, run:
 

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -22,6 +22,7 @@ bash -n tests/profile/si64/run_nvhpc_standard.sh
 bash -n tests/profile/si64/run_nsys.sh
 bash -n tests/profile/si64/run_overnight.sh
 bash -n tests/profile/si64/run_psim_lifecycle.sh
+bash -n tests/profile/si64/run_vpsi_boundary.sh
 bash -n src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh
 bash -n src/Tools/Scripts/paw_gpu_capabilities.sh
 

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -53,6 +53,7 @@ dedicated follow-up runs before promoting any path to production default.
 | `hpsi-opsi-combo-cases-20260601-512-nstep2-*` | Combined HPSI/OPSI diagnostic keywords | `gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum` 9.58 s at 512/1 | - | `gpu_resident_hpsi_opsi_offden_cublas_devicepack_accum` 15.02 s at 512/4 | Adds harness cases for HPSI+OPSI with PROJ/off-site/DENMAT combinations; all cases are energy-valid, so future standard sweeps can compare the full stack directly. |
 | `si64_bands-nvhpc-standard-20260601-4fbe2cd-1024-nstep1` | Current standard refresh with combined HPSI/OPSI cases | `gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum` 12.21 s | `cpu` 77.79 s, `nvhpc_cpu` 75.23 s | `cpu` 672.52 s, `nvhpc_cpu` 392.07 s | Full focused residency stack is now the best 1024/1 case; eight-rank CPU is a poor resource comparison for this small smoke. |
 | `si64_bands-focus-20260601-0a43a65-2048-nstep1-1r` | 2048-band focused stack validation | `gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum` 35.28 s | - | - | Confirms the focused stack also wins at 2048/1, so expose it as a short benchmark keyword. |
+| `vpsi-boundary-20260601-d3cd6cc-512-nstep1` / `vpsi-boundary-20260601-7ad2625-smoke` | VPSI/HPSI boundary harness | `gpu_resident_stack` 6.56 s at 512/1, 28.46 s at 512/4 | - | - | Adds a focused producer-boundary harness plus seconds-sorted `PAW_VPSI_*` rows; the final smoke shows VPSI time is almost entirely GTOR/RTOG. |
 
 The latest full-matrix run lives at:
 
@@ -187,6 +188,49 @@ The keyword was smoke-tested after adding the lowered stack thresholds:
 | `residency-stack-keyword-20260601-fixed-512-nstep1-1r` | 1 | 6.22 s | 6.74 s | yes | Same energy and copy estimate as the long explicit case. |
 | `residency-stack-keyword-20260601-fixed-512-nstep1-4r` | 4 | 16.77 s | 9.70 s | yes | Both cases use the same profile path, including `CUBLAS_ZGEMM_PROJ_RES`; this short four-rank smoke is run-order/noise sensitive. |
 | `residency-stack-keyword-20260601-fixed-512-nstep1-4r-rev` | 4 | 33.65 s | 32.28 s | yes | Reversing the case order makes the wall times converge, confirming that the keyword is not missing the projection/off-site stack. |
+
+## VPSI Boundary Harness
+
+The next focused harness is `run_vpsi_boundary.sh`. It compares
+`gpu_resident_hpsi`, `gpu_resident_hpsi_opsi`, and `gpu_resident_stack` around
+the `WAVES_VPSI` producer boundary, then writes both the normal benchmark
+summary and selected profile rows. `profile_copy_rows.py` now accepts
+`--op-prefix`, `--op-regex`, `--include-zero`, and `--sort-by`, so the harness
+can report copy/present/update rows separately from seconds-sorted
+`PAW_VPSI_*` timing rows.
+
+Spark C86C validation:
+
+```
+runs/vpsi-boundary-20260601-d3cd6cc-512-nstep1
+runs/vpsi-boundary-20260601-7ad2625-smoke
+```
+
+| Suite | Case | Ranks | Wall time | Copy estimate | Energy check |
+| --- | --- | ---: | ---: | ---: | --- |
+| 512/NSTEPS=1 | `gpu_resident_hpsi` | 1 | 6.00 s | 1.2332 GB | yes |
+| 512/NSTEPS=1 | `gpu_resident_hpsi_opsi` | 1 | 6.85 s | 1.0988 GB | yes |
+| 512/NSTEPS=1 | `gpu_resident_stack` | 1 | 6.56 s | 1.1155 GB | yes |
+| 512/NSTEPS=1 | `gpu_resident_hpsi` | 4 | 31.37 s | 1.5941 GB | yes |
+| 512/NSTEPS=1 | `gpu_resident_hpsi_opsi` | 4 | 31.75 s | 1.4596 GB | yes |
+| 512/NSTEPS=1 | `gpu_resident_stack` | 4 | 28.46 s | 1.5088 GB | yes |
+
+The final one-case reporting smoke for `gpu_resident_stack` produced these
+VPSI timing rows:
+
+| Row | Seconds |
+| --- | ---: |
+| `PAW_VPSI_TOTAL` | 0.7235 |
+| `PAW_VPSI_FFT_GTOR` | 0.3565 |
+| `PAW_VPSI_FFT_RTOG` | 0.3565 |
+| `PAW_VPSI_POT` | 0.0083 |
+| `PAW_VPSI_KIN` | 0.0009 |
+
+This confirms the design direction: optimizing the scalar real-space potential
+or kinetic loops inside `WAVES_VPSI` will not move the needle for Si64. The next
+actual implementation target should be GPU-resident FFT/RTOG or a broader
+producer-side wavefunction region that removes the required `HPSI` refresh
+after host-side FFT output.
 
 ## Current Conclusions
 

--- a/tests/profile/si64/profile_copy_rows.py
+++ b/tests/profile/si64/profile_copy_rows.py
@@ -4,6 +4,7 @@ import collections
 import csv
 import glob
 import os
+import re
 import sys
 
 
@@ -40,7 +41,13 @@ def case_and_repeat(path):
     return case, ""
 
 
-def collect(paths):
+def selected_op(op, prefixes, regexes):
+    if any(op.startswith(prefix) for prefix in prefixes):
+        return True
+    return any(regex.search(op) for regex in regexes)
+
+
+def collect(paths, prefixes, regexes, include_zero):
     rows = collections.defaultdict(
         lambda: {"calls": 0, "seconds": 0.0, "gbyte": 0.0, "files": set()}
     )
@@ -52,15 +59,17 @@ def collect(paths):
             with open(path, newline="") as handle:
                 for row in csv.DictReader(handle):
                     op = row.get("op", "")
-                    if not op.startswith("ACC_COPY"):
+                    if not selected_op(op, prefixes, regexes):
                         continue
                     gbyte = float(row.get("gbyte") or 0.0)
-                    if gbyte <= 0.0:
+                    seconds = float(row.get("total_seconds") or 0.0)
+                    calls = int(row.get("calls") or 0)
+                    if not include_zero and gbyte <= 0.0:
                         continue
                     key = (suite, case, repeat, op)
                     data = rows[key]
-                    data["calls"] += int(row.get("calls") or 0)
-                    data["seconds"] += float(row.get("total_seconds") or 0.0)
+                    data["calls"] += calls
+                    data["seconds"] += seconds
                     data["gbyte"] += gbyte
                     data["files"].add(path)
     return rows
@@ -80,14 +89,22 @@ def aggregate(rows, include_repeat):
     return merged
 
 
-def selected_rows(rows, top, per_case, min_gb):
+def sort_key(item, sort_by):
+    if sort_by == "seconds":
+        return (-item[1]["seconds"], -item[1]["gbyte"], -item[1]["calls"])
+    if sort_by == "calls":
+        return (-item[1]["calls"], -item[1]["gbyte"], -item[1]["seconds"])
+    return (-item[1]["gbyte"], -item[1]["seconds"], -item[1]["calls"])
+
+
+def selected_rows(rows, top, per_case, min_gb, sort_by):
     items = [
         (key, data)
         for key, data in rows.items()
         if data["gbyte"] >= min_gb
     ]
     if not per_case:
-        return sorted(items, key=lambda item: -item[1]["gbyte"])[:top]
+        return sorted(items, key=lambda item: sort_key(item, sort_by))[:top]
 
     grouped = collections.defaultdict(list)
     for key, data in items:
@@ -95,7 +112,7 @@ def selected_rows(rows, top, per_case, min_gb):
         grouped[(suite, case, repeat)].append((key, data))
     selected = []
     for group_key in sorted(grouped):
-        group = sorted(grouped[group_key], key=lambda item: -item[1]["gbyte"])
+        group = sorted(grouped[group_key], key=lambda item: sort_key(item, sort_by))
         selected.extend(group[:top])
     return selected
 
@@ -137,7 +154,7 @@ def print_markdown(rows):
 
 def main(argv):
     parser = argparse.ArgumentParser(
-        description="Summarize ACC_COPY profile rows from CP-PAW profile CSV files."
+        description="Summarize selected CP-PAW profile rows from profile CSV files."
     )
     parser.add_argument("paths", nargs="+", help="profile CSV, glob, or run root")
     parser.add_argument("--top", type=int, default=10, help="rows per table/group")
@@ -152,13 +169,41 @@ def main(argv):
         help="keep repeats separate instead of aggregating them",
     )
     parser.add_argument("--min-gb", type=float, default=0.0)
+    parser.add_argument(
+        "--op-prefix",
+        action="append",
+        dest="op_prefixes",
+        help="include operations with this prefix; default is ACC_COPY",
+    )
+    parser.add_argument(
+        "--op-regex",
+        action="append",
+        default=[],
+        help="include operations matching this regular expression",
+    )
+    parser.add_argument(
+        "--include-zero",
+        action="store_true",
+        help="keep rows with zero copied GB, useful for ACC_PRESENT or timing rows",
+    )
+    parser.add_argument(
+        "--sort-by",
+        choices=("gbyte", "seconds", "calls"),
+        default="gbyte",
+        help="primary row ordering key; default is gbyte",
+    )
     parser.add_argument("--markdown", action="store_true")
     args = parser.parse_args(argv[1:])
 
-    rows = aggregate(collect(args.paths), args.include_repeat)
-    chosen = selected_rows(rows, args.top, args.per_case, args.min_gb)
+    prefixes = args.op_prefixes if args.op_prefixes else ["ACC_COPY"]
+    regexes = [re.compile(pattern) for pattern in args.op_regex]
+    rows = aggregate(
+        collect(args.paths, prefixes, regexes, args.include_zero),
+        args.include_repeat,
+    )
+    chosen = selected_rows(rows, args.top, args.per_case, args.min_gb, args.sort_by)
     if not chosen:
-        print("No ACC_COPY rows found.", file=sys.stderr)
+        print("No matching profile rows found.", file=sys.stderr)
         return 1
     if args.markdown:
         print_markdown(chosen)

--- a/tests/profile/si64/run_vpsi_boundary.sh
+++ b/tests/profile/si64/run_vpsi_boundary.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+TEST=${TEST:-si64_bands}
+NSTEPS_LIST=${NSTEPS_LIST:-${NSTEPS:-2}}
+EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-${EMPTY_BANDS:-512}}
+GPU_RANKS=${GPU_RANKS:-1}
+SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
+SHARED_EMPTY_BANDS=${SHARED_EMPTY_BANDS:-512}
+REPEATS=${REPEATS:-1}
+TIMEOUT=${TIMEOUT:-900}
+RUN_SHARED_GPU=${RUN_SHARED_GPU:-no}
+RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
+LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
+ROW_TOP=${ROW_TOP:-16}
+VPSI_ROW_TOP=${VPSI_ROW_TOP:-8}
+RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/vpsi-boundary-$(date +%Y%m%d-%H%M%S)"}}
+VPSI_BOUNDARY_CASES=${VPSI_BOUNDARY_CASES:-"gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack"}
+
+COMBINED="${RUN_ROOT_BASE}-combined.tsv"
+ROWS_COMBINED="${RUN_ROOT_BASE}-profile-rows.md"
+VPSI_ROWS_COMBINED="${RUN_ROOT_BASE}-vpsi-rows.md"
+: > "${COMBINED}"
+
+declare -a SUITE_ROOTS=()
+PROFILE_ROW_ARGS=(
+  --op-prefix ACC_COPY
+  --op-prefix ACC_UPDATE
+  --op-prefix ACC_PRESENT
+  --include-zero
+)
+VPSI_ROW_ARGS=(
+  --op-prefix PAW_VPSI_
+  --include-zero
+  --sort-by seconds
+)
+
+append_suite() {
+  local suite=$1
+  local tsv=$2
+
+  [[ -f "${tsv}" ]] || return 0
+  if [[ ! -s "${COMBINED}" ]]; then
+    awk 'NR == 1 { print "suite\t" $0; next } { print suite "\t" $0 }' \
+      suite="${suite}" "${tsv}" > "${COMBINED}"
+  else
+    awk 'NR > 1 { print suite "\t" $0 }' suite="${suite}" "${tsv}" >> "${COMBINED}"
+  fi
+}
+
+run_suite() {
+  local label=$1
+  local nsteps=$2
+  local ranks=$3
+  local empty_bands=$4
+  local timeout=$5
+  local root="${RUN_ROOT_BASE}-${label}"
+
+  echo "Running VPSI boundary suite: ${label}"
+  TEST="${TEST}" NSTEPS="${nsteps}" EMPTY_BANDS="${empty_bands}" \
+    RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${VPSI_BOUNDARY_CASES}" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    ENERGY_CHECK="${ENERGY_CHECK:-no}" \
+    "${HERE}/run_benchmark.sh"
+  append_suite "${label}" "${root}/benchmark.tsv"
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
+      --include-repeat --markdown "${PROFILE_ROW_ARGS[@]}" "${root}" \
+      > "${root}/profile_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
+      --include-repeat "${PROFILE_ROW_ARGS[@]}" "${root}" \
+      > "${root}/profile_rows.tsv"
+  fi
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
+      --include-repeat --markdown "${VPSI_ROW_ARGS[@]}" "${root}" \
+      > "${root}/vpsi_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
+      --include-repeat "${VPSI_ROW_ARGS[@]}" "${root}" \
+      > "${root}/vpsi_rows.tsv"
+  fi
+  SUITE_ROOTS+=("${root}")
+}
+
+for nsteps in ${NSTEPS_LIST}; do
+  for empty_bands in ${EMPTY_BANDS_LIST}; do
+    run_suite "empty${empty_bands}-nstep${nsteps}-${GPU_RANKS}r" \
+      "${nsteps}" "${GPU_RANKS}" "${empty_bands}" "${TIMEOUT}"
+  done
+done
+
+case "${RUN_SHARED_GPU}" in
+  yes|true|1)
+    for nsteps in ${NSTEPS_LIST}; do
+      run_suite "empty${SHARED_EMPTY_BANDS}-nstep${nsteps}-${SHARED_GPU_RANKS}r" \
+        "${nsteps}" "${SHARED_GPU_RANKS}" "${SHARED_EMPTY_BANDS}" "${TIMEOUT}"
+    done
+    ;;
+esac
+
+case "${RUN_LARGE_GPU}" in
+  yes|true|1)
+    for nsteps in ${NSTEPS_LIST}; do
+      run_suite "empty${LARGE_EMPTY_BANDS}-nstep${nsteps}-${GPU_RANKS}r" \
+        "${nsteps}" "${GPU_RANKS}" "${LARGE_EMPTY_BANDS}" "${TIMEOUT}"
+    done
+    ;;
+esac
+
+if [[ -s "${COMBINED}" ]]; then
+  python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-combined.md" || true
+  echo "Combined benchmark data: ${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
+    --markdown "${PROFILE_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+    > "${ROWS_COMBINED}" || true
+  echo "Combined profile-row data: ${ROWS_COMBINED}"
+  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
+    --markdown "${VPSI_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+    > "${VPSI_ROWS_COMBINED}" || true
+  echo "Combined VPSI-row data: ${VPSI_ROWS_COMBINED}"
+fi


### PR DESCRIPTION
## Summary
- add run_vpsi_boundary.sh to compare HPSI, HPSI+OPSI, and full residency-stack cases around the WAVES_VPSI producer boundary
- extend profile_copy_rows.py so profile reports can include ACC_UPDATE, ACC_PRESENT, PAW_VPSI_* timing rows, regex/prefix filters, zero-GB rows, and seconds/calls sorting
- document the Spark C86C VPSI boundary smoke results and keep the next implementation target focused on FFT/RTOG or broader producer-side residency

## Validation
- Local: git diff --check
- Local: tests/profile/si64/check_harness.sh
- Local: python3 tests/profile/si64/profile_copy_rows.py --help
- Spark C86C: run_vpsi_boundary.sh with NSTEPS=1 EMPTY_BANDS=512 RUN_SHARED_GPU=yes over gpu_resident_hpsi, gpu_resident_hpsi_opsi, gpu_resident_stack; all cases energy-valid
- Spark C86C: final reporting smoke with gpu_resident_stack produced combined benchmark, profile-row, and vpsi-row outputs; PAW_VPSI_TOTAL=0.7235 s with GTOR/RTOG dominating