### PR TITLE
Add NVHPC VPSI cuFFT phase cases

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -461,6 +461,7 @@ The Si64 benchmark harness uses these `CASES` keywords:
 | `gpu_resident_hpsi_opsi_proj` | Combined HPSI/OPSI diagnostic with persistent `THIS%PROJ` residency enabled. |
 | `gpu_resident_hpsi_opsi_offden_cublas_devicepack_accum` | Combined HPSI/OPSI diagnostic with off-site DENMAT device packing and GPU-side real-matrix accumulation. |
 | `gpu_resident_stack` | Focused residency stack keyword via `CPPAW_GPU_RESIDENCY_STACK=1`; enables the validated HPSI, OPSI, PROJ, DENMAT energy, and off-site device-pack accumulation combination. |
+| `gpu_resident_stack_cufft` / `gpu_resident_stack_cufft_force` | Focused residency stack plus native cuFFT enabled with the conservative threshold, or forced for all `LIB$FFTC8` calls. |
 | `gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum` | Full residency diagnostic that combines HPSI, OPSI, DENMAT energy, persistent `THIS%PROJ`, and off-site device-pack accumulation. |
 | `gpu_resident_projection_conservative` / `gpu_resident_overlap_conservative` / `gpu_resident_addproduct_conservative` / `gpu_resident_matmul_conservative` | Residency diagnostics with only one cuBLAS kernel category raised to the conservative threshold. |
 | `gpu_resident_force_all` | Residency diagnostic that also forces cuFFT and small cuSOLVER offload. |
@@ -585,10 +586,12 @@ cd tests/profile/si64
 It focuses on the current remaining HPSI boundary: `WAVES_VPSI` still receives
 host-side FFT/RTOG output, then refreshes or creates the device-present `HPSI`
 buffer for the following `WAVES_ADDPRO` consumer. The harness compares
-`gpu_resident_hpsi`, `gpu_resident_hpsi_opsi`, and `gpu_resident_stack` with
-`NSTEPS=2` by default and writes combined benchmark tables plus selected
-profile tables for `ACC_COPY`/`ACC_UPDATE`/`ACC_PRESENT` rows and separate
-seconds-sorted `PAW_VPSI_*` timing rows.
+`gpu_resident_hpsi`, `gpu_resident_hpsi_opsi`, `gpu_resident_stack`, and
+stack-plus-cuFFT variants with `NSTEPS=2` by default and writes combined
+benchmark tables plus selected profile tables for
+`ACC_COPY`/`ACC_UPDATE`/`ACC_PRESENT` rows, separate seconds-sorted
+`PAW_VPSI_*` timing rows, and separate seconds-sorted `PW_GTOR_*`/`PW_RTOG_*`
+phase rows.
 Because multi-step Si64 energies are not the one-step reference, fixed energy
 checking is disabled by default; compare energies between cases. Override
 `VPSI_BOUNDARY_CASES`, `NSTEPS_LIST`, `EMPTY_BANDS_LIST`,

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -351,6 +351,12 @@ case_note() {
     gpu_resident_stack)
       echo "Focused residency stack keyword: HPSI, OPSI, PROJ, DENMAT energy, and off-site device-pack accumulation."
       ;;
+    gpu_resident_stack_cufft)
+      echo "Focused residency stack plus threshold-gated native cuFFT for LIB\\$FFTC8 calls."
+      ;;
+    gpu_resident_stack_cufft_force)
+      echo "Focused residency stack plus force-all native cuFFT for LIB\\$FFTC8 calls."
+      ;;
     gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum)
       echo "Full residency diagnostic combining HPSI, OPSI, DENMAT energy, persistent THIS%PROJ, and off-site device-pack accumulation."
       ;;
@@ -586,6 +592,8 @@ case_env() {
     gpu_resident_hpsi_opsi_proj) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 CPPAW_GPU_PROJ_RESIDENCY=1 $(cublas_env)" ;;
     gpu_resident_hpsi_opsi_offden_cublas_devicepack_accum) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_stack) echo "CPPAW_GPU_RESIDENCY_STACK=1 $(cublas_env)" ;;
+    gpu_resident_stack_cufft) echo "CPPAW_GPU_RESIDENCY_STACK=1 $(cufft_env) $(cublas_env)" ;;
+    gpu_resident_stack_cufft_force) echo "CPPAW_GPU_RESIDENCY_STACK=1 $(cufft_force_env) $(cublas_env)" ;;
     gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_HPSI_RESIDENCY=1 CPPAW_GPU_OPSI_RESIDENCY=1 CPPAW_GPU_PROJ_RESIDENCY=1 CPPAW_GPU_DENMAT_ENERGY=1 CPPAW_GPU_DENMAT_MINFLOP=${CPPAW_GPU_DENMAT_MINFLOP:-1} CPPAW_GPU_OFFDEN_LOCAL=1 CPPAW_GPU_OFFDEN_CUBLAS=1 CPPAW_GPU_OFFDEN_CUBLAS_BATCH=1 CPPAW_GPU_OFFDEN_DEVICE_PACK=1 CPPAW_GPU_OFFDEN_DEVICE_ACCUM=1 CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP=${CPPAW_CUBLAS_ACC_OFFDEN_MINFLOP:-1} CPPAW_GPU_OFFDEN_BATCH_SIZE=${CPPAW_GPU_OFFDEN_BATCH_SIZE:-64} $(cublas_env)" ;;
     gpu_resident_1coverlap_host) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GPU_1COVERLAP=0 $(cublas_env)" ;;
     gpu_resident_gram_cholesky) echo "CPPAW_GPU_RESIDENCY=1 CPPAW_GRAM_CHOLESKY=1 $(cublas_env)" ;;

--- a/tests/profile/si64/run_vpsi_boundary.sh
+++ b/tests/profile/si64/run_vpsi_boundary.sh
@@ -16,12 +16,14 @@ RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
 ROW_TOP=${ROW_TOP:-16}
 VPSI_ROW_TOP=${VPSI_ROW_TOP:-8}
+FFT_ROW_TOP=${FFT_ROW_TOP:-12}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/vpsi-boundary-$(date +%Y%m%d-%H%M%S)"}}
-VPSI_BOUNDARY_CASES=${VPSI_BOUNDARY_CASES:-"gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack"}
+VPSI_BOUNDARY_CASES=${VPSI_BOUNDARY_CASES:-"gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack gpu_resident_stack_cufft gpu_resident_stack_cufft_force"}
 
 COMBINED="${RUN_ROOT_BASE}-combined.tsv"
 ROWS_COMBINED="${RUN_ROOT_BASE}-profile-rows.md"
 VPSI_ROWS_COMBINED="${RUN_ROOT_BASE}-vpsi-rows.md"
+FFT_ROWS_COMBINED="${RUN_ROOT_BASE}-fft-phase-rows.md"
 : > "${COMBINED}"
 
 declare -a SUITE_ROOTS=()
@@ -33,6 +35,12 @@ PROFILE_ROW_ARGS=(
 )
 VPSI_ROW_ARGS=(
   --op-prefix PAW_VPSI_
+  --include-zero
+  --sort-by seconds
+)
+FFT_ROW_ARGS=(
+  --op-prefix PW_GTOR_
+  --op-prefix PW_RTOG_
   --include-zero
   --sort-by seconds
 )
@@ -79,6 +87,13 @@ run_suite() {
       --include-repeat "${VPSI_ROW_ARGS[@]}" "${root}" \
       > "${root}/vpsi_rows.tsv"
   fi
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
+      --include-repeat --markdown "${FFT_ROW_ARGS[@]}" "${root}" \
+      > "${root}/fft_phase_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
+      --include-repeat "${FFT_ROW_ARGS[@]}" "${root}" \
+      > "${root}/fft_phase_rows.tsv"
+  fi
   SUITE_ROOTS+=("${root}")
 }
 
@@ -122,4 +137,8 @@ if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
     --markdown "${VPSI_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
     > "${VPSI_ROWS_COMBINED}" || true
   echo "Combined VPSI-row data: ${VPSI_ROWS_COMBINED}"
+  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
+    --markdown "${FFT_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+    > "${FFT_ROWS_COMBINED}" || true
+  echo "Combined FFT phase-row data: ${FFT_ROWS_COMBINED}"
 fi


### PR DESCRIPTION
## Summary
- add gpu_resident_stack_cufft and gpu_resident_stack_cufft_force benchmark cases so the focused residency stack can be compared with threshold-gated or force-all native cuFFT
- extend run_vpsi_boundary.sh to include the stack+cuFFT cases by default
- add separate seconds-sorted PW_GTOR_*/PW_RTOG_* phase summaries next to the existing copy/present/update and PAW_VPSI_* reports

## Validation
- Local: git diff --check
- Local: tests/profile/si64/check_harness.sh
- Local: synthetic profile_copy_rows.py check for PW_GTOR_/PW_RTOG_ timing rows plus ACC_COPY/ACC_PRESENT rows

Spark C86C was not reachable over SSH during this pass, so this PR intentionally stays harness-only and does not claim new performance numbers.