### PR TITLE
Add plane-wave FFT direction summary columns

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -90,8 +90,9 @@ the primary instrumented rank-seconds (`rank_s`), and a residual
 `gap_s = wall_rank_s - rank_s`. Use `gap_s` and `coverage_pct` to decide
 whether the current CSV timers already explain the run or whether additional
 instrumentation is needed. Diagnostic Plane-wave FFT local/MPI-envelope timers
-are reported separately as `pw_trace_s`; they are intentionally kept out of
-`rank_s` because they subdivide the existing `PW_FFT_*_TOTAL` envelope.
+are reported separately as `pw_trace_s`; the GTOR and RTOG subsets are also
+reported as `pw_gtor_s` and `pw_rtog_s`. These columns are intentionally kept
+out of `rank_s` because they subdivide the existing `PW_FFT_*_TOTAL` envelope.
 High-level `PHASE_*` timers are reported separately as `phase_s` and
 `phase_gap_s = wall_rank_s - phase_s`; they are also kept out of `rank_s`
 because they are coarse envelopes around existing numerical kernel timers. Use

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -46,11 +46,11 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | phase_s | phase_gap_s | copy_gb | energy | energy_delta |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | pw_gtor_s | pw_rtog_s | phase_s | phase_gap_s | copy_gb | energy | energy_delta |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
@@ -65,6 +65,8 @@ def main(argv):
                 number(row.get("fft_s")),
                 number(row.get("mpi_s")),
                 number(row.get("pw_trace_s")),
+                number(row.get("pw_gtor_s")),
+                number(row.get("pw_rtog_s")),
                 number(row.get("phase_s")),
                 number(row.get("phase_gap_s")),
                 number(row.get("copy_gb")),

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -15,6 +15,8 @@ def profile_totals(run_dir):
         "mpi": 0.0,
         "paw": 0.0,
         "pw_trace": 0.0,
+        "pw_gtor": 0.0,
+        "pw_rtog": 0.0,
         "phase": 0.0,
         "setup": 0.0,
         "copy_gb": 0.0,
@@ -36,6 +38,10 @@ def profile_totals(run_dir):
                     continue
                 if op.startswith("PW_") and not op.startswith("PW_FFT"):
                     totals["pw_trace"] += seconds
+                    if op.startswith("PW_GTOR_"):
+                        totals["pw_gtor"] += seconds
+                    elif op.startswith("PW_RTOG_"):
+                        totals["pw_rtog"] += seconds
                     continue
                 if op.startswith("PAW_"):
                     totals["paw"] += seconds
@@ -165,6 +171,8 @@ def main(argv):
                 "fft_s": totals["fft"],
                 "mpi_s": totals["mpi"],
                 "pw_trace_s": totals["pw_trace"],
+                "pw_gtor_s": totals["pw_gtor"],
+                "pw_rtog_s": totals["pw_rtog"],
                 "phase_s": totals["phase"],
                 "phase_gap_s": phase_gap,
                 "setup_s": totals["setup"],
@@ -199,6 +207,8 @@ def main(argv):
         "fft_s",
         "mpi_s",
         "pw_trace_s",
+        "pw_gtor_s",
+        "pw_rtog_s",
         "phase_s",
         "phase_gap_s",
         "setup_s",


### PR DESCRIPTION
## Summary
- add pw_gtor_s and pw_rtog_s columns to benchmark_summary.py output
- show those columns in benchmark_markdown.py while keeping old TSVs readable
- document the new direction-specific plane-wave timing columns

## Validation
- Local: git diff --check
- Local: tests/profile/si64/check_harness.sh
- Local: synthetic benchmark_summary.py/benchmark_markdown.py profile CSV test confirmed pw_gtor_s=2.0 and pw_rtog_s=2.25 while PW_FFT_RTOG_TOTAL still contributes to fft_s