### PR TITLE
Add GPU residency copy breakdown columns

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -97,7 +97,12 @@ High-level `PHASE_*` timers are reported separately as `phase_s` and
 `phase_gap_s = wall_rank_s - phase_s`; they are also kept out of `rank_s`
 because they are coarse envelopes around existing numerical kernel timers. Use
 the phase columns to localize unexplained wall time before adding lower-level
-kernel instrumentation.
+kernel instrumentation. The aggregate copy estimate `copy_gb` is split into
+semantic buckets for the GPU-residency work: `copy_wave_gb` for wavefunction
+arrays, `copy_proj_gb` for projector/projection arrays, `copy_offden_gb` for
+off-site density-matrix transfers, and `copy_denmat_gb` for one-center
+density-matrix transfers. These buckets are subsets of `copy_gb` and are meant
+to show whether a residency change actually removes the expected data motion.
 For the bundled `si64` and `si64_bands` cases, the harness also checks the
 final constant energy against the built-in reference (`EXPECTED_ENERGY`,
 default `302.280854`) with `ENERGY_TOL=1e-5`. A run with normal termination but

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -46,11 +46,11 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | pw_gtor_s | pw_rtog_s | phase_s | phase_gap_s | copy_gb | energy | energy_delta |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | pw_gtor_s | pw_rtog_s | phase_s | phase_gap_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | copy_denmat_gb | energy | energy_delta |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
@@ -70,6 +70,10 @@ def main(argv):
                 number(row.get("phase_s")),
                 number(row.get("phase_gap_s")),
                 number(row.get("copy_gb")),
+                number(row.get("copy_wave_gb")),
+                number(row.get("copy_proj_gb")),
+                number(row.get("copy_offden_gb")),
+                number(row.get("copy_denmat_gb")),
                 number(row.get("energy"), 6),
                 number(row.get("energy_delta"), 6),
             )

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -6,6 +6,32 @@ import re
 import sys
 
 
+def copy_bucket(op):
+    if "OFFDEN" in op:
+        return "copy_offden_gb"
+    if "DENMAT" in op:
+        return "copy_denmat_gb"
+    if any(token in op for token in ("PROPSI", "PRO_CACHE", "THIS_PROJ")):
+        return "copy_proj_gb"
+    if any(
+        token in op
+        for token in (
+            "_PSI0",
+            "_PSI1",
+            "_PSI2",
+            "_PSI_IN",
+            "_PSI_OUT",
+            "_PSIM",
+            "_OPSI",
+            "_HPSI",
+        )
+    ):
+        return "copy_wave_gb"
+    if any(token in op for token in ("PROJ", "ADDPRO")):
+        return "copy_proj_gb"
+    return None
+
+
 def profile_totals(run_dir):
     totals = {
         "instrumented": 0.0,
@@ -20,6 +46,10 @@ def profile_totals(run_dir):
         "phase": 0.0,
         "setup": 0.0,
         "copy_gb": 0.0,
+        "copy_wave_gb": 0.0,
+        "copy_proj_gb": 0.0,
+        "copy_offden_gb": 0.0,
+        "copy_denmat_gb": 0.0,
     }
     for path in glob.glob(os.path.join(run_dir, "*_profile*.csv")):
         with open(path, newline="") as handle:
@@ -29,6 +59,9 @@ def profile_totals(run_dir):
                 gbyte = float(row["gbyte"])
                 if op.startswith("ACC_COPY"):
                     totals["copy_gb"] += gbyte
+                    bucket = copy_bucket(op)
+                    if bucket:
+                        totals[bucket] += gbyte
                     continue
                 if op.startswith("ACC_SETUP"):
                     totals["setup"] += seconds
@@ -177,6 +210,10 @@ def main(argv):
                 "phase_gap_s": phase_gap,
                 "setup_s": totals["setup"],
                 "copy_gb": totals["copy_gb"],
+                "copy_wave_gb": totals["copy_wave_gb"],
+                "copy_proj_gb": totals["copy_proj_gb"],
+                "copy_offden_gb": totals["copy_offden_gb"],
+                "copy_denmat_gb": totals["copy_denmat_gb"],
                 "energy": energy,
                 "energy_delta": energy_delta,
                 "energy_ok": (
@@ -213,6 +250,10 @@ def main(argv):
         "phase_gap_s",
         "setup_s",
         "copy_gb",
+        "copy_wave_gb",
+        "copy_proj_gb",
+        "copy_offden_gb",
+        "copy_denmat_gb",
         "energy",
         "energy_delta",
         "energy_ok",


### PR DESCRIPTION
## Summary
- add copy_wave_gb, copy_proj_gb, copy_offden_gb, and copy_denmat_gb to benchmark_summary.py output
- include the new copy buckets in benchmark_markdown.py while keeping old TSVs readable
- document how the buckets support GPU residency decisions

## Validation
- Local: git diff --check
- Local: tests/profile/si64/check_harness.sh
- Local: synthetic benchmark_summary.py profile CSV test confirmed copy_wave_gb=1.75, copy_proj_gb=3.0, copy_offden_gb=3.5, copy_denmat_gb=4.5, and copy_gb=13.5