### PR TITLE
Add profile copy bucket categories

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -103,6 +103,8 @@ arrays, `copy_proj_gb` for projector/projection arrays, `copy_offden_gb` for
 off-site density-matrix transfers, and `copy_denmat_gb` for one-center
 density-matrix transfers. These buckets are subsets of `copy_gb` and are meant
 to show whether a residency change actually removes the expected data motion.
+`profile_summary.py` uses the same buckets in its category summary and prints
+their GB totals for single-run CSV inspection.
 For the bundled `si64` and `si64_bands` cases, the harness also checks the
 final constant energy against the built-in reference (`EXPECTED_ENERGY`,
 default `302.280854`) with `ENERGY_TOL=1e-5`. A run with normal termination but

--- a/tests/profile/si64/profile_summary.py
+++ b/tests/profile/si64/profile_summary.py
@@ -5,11 +5,37 @@ import glob
 import sys
 
 
+def copy_bucket(op):
+    if "OFFDEN" in op:
+        return "ACC copy offden"
+    if "DENMAT" in op:
+        return "ACC copy denmat"
+    if any(token in op for token in ("PROPSI", "PRO_CACHE", "THIS_PROJ")):
+        return "ACC copy proj"
+    if any(
+        token in op
+        for token in (
+            "_PSI0",
+            "_PSI1",
+            "_PSI2",
+            "_PSI_IN",
+            "_PSI_OUT",
+            "_PSIM",
+            "_OPSI",
+            "_HPSI",
+        )
+    ):
+        return "ACC copy wave"
+    if any(token in op for token in ("PROJ", "ADDPRO")):
+        return "ACC copy proj"
+    return "ACC copy other"
+
+
 def category(op):
     if op.startswith("PHASE_"):
         return "Phase trace"
     if op.startswith("ACC_COPY"):
-        return "ACC copy est"
+        return copy_bucket(op)
     if op.startswith("ACC_PRESENT"):
         return "ACC residency"
     if op.startswith("ACC_SETUP"):
@@ -100,6 +126,10 @@ def main(argv):
         data["gbyte"] for op, data in per_op.items()
         if op.startswith("ACC_COPY")
     )
+    copy_bucket_gbyte = collections.defaultdict(float)
+    for op, data in per_op.items():
+        if op.startswith("ACC_COPY"):
+            copy_bucket_gbyte[copy_bucket(op)] += data["gbyte"]
 
     print("Profile files: {}".format(len(files)))
     print("Instrumented rank-seconds: {:.6f}".format(primary_total))
@@ -115,6 +145,12 @@ def main(argv):
                 setup_total, copy_gbyte
             )
         )
+    if copy_bucket_gbyte:
+        print("Copy bucket estimates")
+        for name, gbyte in sorted(
+            copy_bucket_gbyte.items(), key=lambda item: -item[1]
+        ):
+            print("  {:<16s} {:10.4f} GB".format(name, gbyte))
     print("")
     print("Category summary")
     for name, seconds in sorted(by_category.items(), key=lambda item: -item[1]):


### PR DESCRIPTION
## Summary
- split profile_summary.py ACC_COPY categories into wave, projection, offden, denmat, and other buckets
- print copy bucket GB totals for quick single-run residency inspection
- document that profile_summary.py mirrors the benchmark copy buckets

## Validation
- Local: git diff --check
- Local: tests/profile/si64/check_harness.sh
- Local: synthetic profile_summary.py CSV test printed separate wave/proj/offden/denmat copy bucket estimates