### PR TITLE
Emit comparison report from NVHPC standard benchmark

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -524,7 +524,9 @@ compares the focused `gpu_resident*` paths on one GPU rank, including the
 opt-in Ortho-X workspace-residency diagnostic, plus one-rank CPU and eight-rank
 CPU/NVHPC references. Override `GPU_CASES`, `CPU_CASES`,
 `EMPTY_BANDS`, `NSTEPS`,
-`GPU_RANKS` or `CPU_RANKS` for a targeted sweep.
+`GPU_RANKS` or `CPU_RANKS` for a targeted sweep. It writes both
+`combined_benchmark.md` and `combined_compare.md` so PR comments can include
+raw timings and the one-GPU versus CPU-resource speedup view.
 
 Set `RUN_GPU_ALL=yes` to include the all-library cases `gpu_all` and
 `gpu_all_off`. The default is `RUN_GPU_ALL=no` because the Spark Si64 matrix

--- a/tests/profile/si64/run_nvhpc_standard.sh
+++ b/tests/profile/si64/run_nvhpc_standard.sh
@@ -283,5 +283,7 @@ log "ALL DONE root=${NVHPC_STANDARD_ROOT}"
 if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
     > "${NVHPC_STANDARD_ROOT}/combined_benchmark.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${NVHPC_STANDARD_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
 fi


### PR DESCRIPTION
## Summary
- have run_nvhpc_standard.sh emit combined_compare.md next to combined_benchmark.md
- document that the standard pre-PR benchmark now provides both raw timings and GPU-vs-CPU speedup view

## Validation
- Local: bash -n tests/profile/si64/run_nvhpc_standard.sh
- Local: tests/profile/si64/check_harness.sh
- Local: synthetic run_nvhpc_standard suite TSV produced 4.00x vs one-rank CPU and 1.60x vs eight-rank CPU
- Local: git diff --check