### PR TITLE
Emit comparison report from cuSOLVER focus benchmark

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -786,7 +786,8 @@ cd tests/profile/si64
 
 It defaults to `EMPTY_BANDS_LIST="128 256 512"` and compares
 `cusolver`, `cusolver_generalized`, `cusolver_generalized_conservative`,
-`cusolver_off`, one-rank CPU/NVHPC and eight-rank CPU/NVHPC references.
+`cusolver_off`, one-rank CPU/NVHPC and eight-rank CPU/NVHPC references. It
+writes both `combined_benchmark.md` and `combined_compare.md`.
 
 For reproducible comparisons, use the benchmark harness:
 

--- a/tests/profile/si64/benchmark_compare.py
+++ b/tests/profile/si64/benchmark_compare.py
@@ -62,6 +62,7 @@ def suite_group_kind(suite):
         return "default", "cpu8"
     rank_patterns = (
         (r"^(.*)_(\d+)ranks?_gpu$", "gpu"),
+        (r"^(.*)_(\d+)ranks?_cusolver$", "gpu"),
         (r"^(.*)_(\d+)ranks?_cpu_ref$", "cpu8"),
         (r"^(.*)_(\d+)ranks?_cpu$", "cpu"),
     )

--- a/tests/profile/si64/check_benchmark_tools.py
+++ b/tests/profile/si64/check_benchmark_tools.py
@@ -120,6 +120,9 @@ def check_compare(tmpdir):
         "si64_bands_empty128_1steps_1ranks_gpu\tgpu_resident_stack\trep1\t1\t1\tyes\t30\t30\t24\t6\t80\t0\t0\t0\t0\t0\t0\t0\t0\t24\t6\t0\t11\t5\t3\t2\t1\t302.280854\t0\tyes\t",
         "si64_bands_empty128_1steps_1rank_cpu\tnvhpc_cpu\trep1\t1\t1\tyes\t90\t90\t70\t20\t78\t0\t0\t0\t0\t0\t0\t0\t0\t70\t20\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "si64_bands_empty128_1steps_8ranks_cpu_ref\tnvhpc_cpu\trep1\t1\t8\tyes\t45\t360\t280\t80\t78\t0\t0\t0\t0\t0\t0\t0\t0\t280\t80\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
+        "empty128_1rank_cusolver\tcusolver_generalized\trep1\t1\t1\tyes\t25\t25\t20\t5\t80\t0\t0\t0\t0\t0\t0\t0\t0\t20\t5\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
+        "empty128_1rank_cpu\tnvhpc_cpu\trep1\t1\t1\tyes\t100\t100\t80\t20\t80\t0\t0\t0\t0\t0\t0\t0\t0\t80\t20\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
+        "empty128_8rank_cpu_ref\tnvhpc_cpu\trep1\t1\t8\tyes\t40\t320\t260\t60\t81\t0\t0\t0\t0\t0\t0\t0\t0\t260\t60\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "gpu_1rank\tgpu_resident_stack\trep1\t1\t1\tyes\t20\t20\t16\t4\t80\t0\t0\t0\t0\t0\t0\t0\t0\t16\t4\t0\t8\t3\t2\t2\t1\t302.280854\t0\tyes\t",
         "cpu_1rank\tnvhpc_cpu\trep1\t1\t1\tyes\t80\t80\t60\t20\t75\t0\t0\t0\t0\t0\t0\t0\t0\t60\t20\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "cpu_8rank_ref\tnvhpc_cpu\trep1\t1\t8\tyes\t32\t256\t210\t46\t82\t0\t0\t0\t0\t0\t0\t0\t0\t210\t46\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
@@ -129,6 +132,7 @@ def check_compare(tmpdir):
     compare = run_tool("benchmark_compare.py", path)
     assert_contains(compare, "| gpu_acc_1steps_1rank | gpu_resident_stack | 1 | yes | 25.00 | 4.00 | 1.60 |", "gpu_acc speedups")
     assert_contains(compare, "| si64_bands_empty128_1steps_1ranks_gpu | gpu_resident_stack | 1 | yes | 30.00 | 3.00 | 1.50 |", "band speedups")
+    assert_contains(compare, "| empty128_1rank_cusolver | cusolver_generalized | 1 | yes | 25.00 | 4.00 | 1.60 |", "cusolver speedups")
     assert_contains(compare, "| gpu_1rank | gpu_resident_stack | 1 | yes | 20.00 | 4.00 | 1.60 |", "standard speedups")
 
 

--- a/tests/profile/si64/run_cusolver_focus.sh
+++ b/tests/profile/si64/run_cusolver_focus.sh
@@ -71,5 +71,7 @@ log "ALL DONE root=${CUSOLVER_FOCUS_ROOT}"
 if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
     > "${CUSOLVER_FOCUS_ROOT}/combined_benchmark.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${CUSOLVER_FOCUS_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
 fi


### PR DESCRIPTION
## Summary
- have run_cusolver_focus.sh emit combined_compare.md next to combined_benchmark.md
- recognize *_rank_cusolver suite names in benchmark_compare.py so cuSOLVER focus runs get one-rank and eight-rank CPU speedups
- extend the benchmark tool self-test to cover cuSOLVER focus grouping

## Validation
- Local: synthetic cuSOLVER focus TSV produced 4.00x vs one-rank CPU and 1.60x vs eight-rank CPU
- Local: python3 tests/profile/si64/check_benchmark_tools.py
- Local: python3 -m py_compile tests/profile/si64/benchmark_compare.py tests/profile/si64/check_benchmark_tools.py
- Local: bash -n tests/profile/si64/run_cusolver_focus.sh
- Local: tests/profile/si64/check_harness.sh
- Local: git diff --check