### PR TITLE
Add GPU focus baseline comparison reports

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -550,7 +550,9 @@ combined projection-plus-accumulation paths for both HPSI-only and
 DENMAT-energy cases. By default it runs `EMPTY_BANDS=2048` on one GPU rank and
 `SHARED_EMPTY_BANDS=512` on four ranks sharing the GPU. Override
 `OFFDEN_CASES`, `GPU_RANKS`, `SHARED_GPU_RANKS`, `EMPTY_BANDS`, or
-`RUN_SHARED_GPU=no` for narrower checks.
+`RUN_SHARED_GPU=no` for narrower checks. It writes combined benchmark and
+comparison Markdown so the device-pack variants can be compared against the
+first successful focus-case baseline.
 
 For the focused PSIM propagation comparison, run:
 
@@ -564,7 +566,8 @@ propagation residency, HPSI residency, and the combined HPSI-plus-PSIM
 diagnostics. By default it runs
 `EMPTY_BANDS=512` with one GPU rank and `SHARED_EMPTY_BANDS=512` with four
 ranks sharing the GPU, then writes a combined TSV/Markdown summary next to the
-run directories. Set `RUN_LARGE_GPU=yes` to add a one-rank
+run directories, including a comparison table against the focus baseline. Set
+`RUN_LARGE_GPU=yes` to add a one-rank
 `LARGE_EMPTY_BANDS=2048` sweep, or override `PSIM_CASES`, `GPU_RANKS`,
 `SHARED_GPU_RANKS`, `EMPTY_BANDS`, and `RUN_SHARED_GPU=no` for narrower
 checks.
@@ -584,7 +587,9 @@ Because the one-step Si64 reference energy is not valid for multi-step dynamics,
 the fixed energy check is disabled by default for this harness; compare the
 reported energies between cases instead. It writes the normal combined benchmark
 TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`;
-the helper also accepts `--op-prefix`, `--op-regex`, and `--include-zero` for
+the comparison Markdown reports each GPU-only focus case relative to the
+selected group baseline. The helper also accepts `--op-prefix`, `--op-regex`,
+and `--include-zero` for
 broader profile-row reports such as present/update/timing rows.
 Override `NSTEPS_LIST`, `EMPTY_BANDS_LIST`, `RUN_SHARED_GPU=yes`,
 `RUN_LARGE_GPU=yes`, or `PSIM_LIFECYCLE_CASES` for wider sweeps.
@@ -604,7 +609,8 @@ stack-plus-cuFFT variants with `NSTEPS=2` by default and writes combined
 benchmark tables plus selected profile tables for
 `ACC_COPY`/`ACC_UPDATE`/`ACC_PRESENT` rows, separate seconds-sorted
 `PAW_VPSI_*` timing rows, and separate seconds-sorted `PW_GTOR_*`/`PW_RTOG_*`
-phase rows.
+phase rows. Its comparison Markdown reports the stack and cuFFT variants
+relative to the selected focus baseline.
 Because multi-step Si64 energies are not the one-step reference, fixed energy
 checking is disabled by default; compare energies between cases. Override
 `VPSI_BOUNDARY_CASES`, `NSTEPS_LIST`, `EMPTY_BANDS_LIST`,

--- a/tests/profile/si64/benchmark_compare.py
+++ b/tests/profile/si64/benchmark_compare.py
@@ -7,6 +7,15 @@ import sys
 
 
 CPU_BASELINE_CASES = ("nvhpc_cpu", "cpu")
+GROUP_BASELINE_CASES = (
+    "gpu_resident",
+    "gpu_resident_stack",
+    "gpu",
+    "cusolver_generalized",
+    "cusolver",
+    "nvhpc_cpu",
+    "cpu",
+)
 
 
 def parse_float(value):
@@ -133,6 +142,23 @@ def baseline_for(rows, kind):
     return min(candidates, key=lambda row: row["_wall"])
 
 
+def group_baseline_for(rows):
+    candidates = [
+        row for row in rows
+        if row.get("ok", "") == "yes" and row.get("_wall") is not None
+    ]
+    if not candidates:
+        return None
+    for case in GROUP_BASELINE_CASES:
+        for row in candidates:
+            if row.get("case") == case:
+                return row
+    for row in candidates:
+        if row.get("_kind") == "gpu":
+            return row
+    return candidates[0]
+
+
 def suite_label(row):
     suite = row.get("suite", "")
     if not suite:
@@ -161,18 +187,21 @@ def main(argv):
     print(f"Source: `{os.path.basename(path)}`")
     print()
     print(
-        "| suite | case | ranks | ok | wall_s | vs_1cpu | vs_8cpu | "
-        "rank_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | "
+        "| suite | case | ranks | ok | wall_s | base_case | vs_base | "
+        "vs_1cpu | vs_8cpu | rank_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | "
         "copy_denmat_gb | energy_delta |"
     )
     print(
-        "| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | "
-        "---: | ---: | ---: | ---: | ---: |"
+        "| --- | --- | ---: | --- | ---: | --- | ---: | ---: | ---: | "
+        "---: | ---: | ---: | ---: | ---: | ---: | ---: |"
     )
     for group in sorted(groups):
         group_rows = groups[group]
+        group_base = group_baseline_for(group_rows)
         one_cpu = baseline_for(group_rows, "cpu1")
         eight_cpu = baseline_for(group_rows, "cpu8")
+        group_base_wall = None if group_base is None else group_base["_wall"]
+        group_base_case = "" if group_base is None else group_base.get("case", "")
         one_cpu_wall = None if one_cpu is None else one_cpu["_wall"]
         eight_cpu_wall = None if eight_cpu is None else eight_cpu["_wall"]
         for row in sorted(
@@ -184,12 +213,14 @@ def main(argv):
             ),
         ):
             print(
-                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                     suite_label(row),
                     row.get("case", ""),
                     row.get("ranks", ""),
                     row.get("ok", ""),
                     number(row.get("_wall")),
+                    group_base_case,
+                    number(speedup(group_base_wall, row.get("_wall"))),
                     number(speedup(one_cpu_wall, row.get("_wall"))),
                     number(speedup(eight_cpu_wall, row.get("_wall"))),
                     number(row.get("rank_s")),

--- a/tests/profile/si64/check_benchmark_tools.py
+++ b/tests/profile/si64/check_benchmark_tools.py
@@ -123,6 +123,8 @@ def check_compare(tmpdir):
         "empty128_1rank_cusolver\tcusolver_generalized\trep1\t1\t1\tyes\t25\t25\t20\t5\t80\t0\t0\t0\t0\t0\t0\t0\t0\t20\t5\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "empty128_1rank_cpu\tnvhpc_cpu\trep1\t1\t1\tyes\t100\t100\t80\t20\t80\t0\t0\t0\t0\t0\t0\t0\t0\t80\t20\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "empty128_8rank_cpu_ref\tnvhpc_cpu\trep1\t1\t8\tyes\t40\t320\t260\t60\t81\t0\t0\t0\t0\t0\t0\t0\t0\t260\t60\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
+        "empty512-nstep2-1r\tgpu_resident\trep1\t2\t1\tyes\t20\t20\t16\t4\t80\t0\t0\t0\t0\t0\t0\t0\t0\t16\t4\t0\t8\t3\t2\t2\t1\t302.280854\t0\tyes\t",
+        "empty512-nstep2-1r\tgpu_resident_stack\trep1\t2\t1\tyes\t10\t10\t8\t2\t80\t0\t0\t0\t0\t0\t0\t0\t0\t8\t2\t0\t4\t1.5\t1\t1\t0.5\t302.280854\t0\tyes\t",
         "gpu_1rank\tgpu_resident_stack\trep1\t1\t1\tyes\t20\t20\t16\t4\t80\t0\t0\t0\t0\t0\t0\t0\t0\t16\t4\t0\t8\t3\t2\t2\t1\t302.280854\t0\tyes\t",
         "cpu_1rank\tnvhpc_cpu\trep1\t1\t1\tyes\t80\t80\t60\t20\t75\t0\t0\t0\t0\t0\t0\t0\t0\t60\t20\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
         "cpu_8rank_ref\tnvhpc_cpu\trep1\t1\t8\tyes\t32\t256\t210\t46\t82\t0\t0\t0\t0\t0\t0\t0\t0\t210\t46\t0\t0\t0\t0\t0\t0\t302.280854\t0\tyes\t",
@@ -130,10 +132,11 @@ def check_compare(tmpdir):
     write(path, "\n".join([header, *rows]) + "\n")
 
     compare = run_tool("benchmark_compare.py", path)
-    assert_contains(compare, "| gpu_acc_1steps_1rank | gpu_resident_stack | 1 | yes | 25.00 | 4.00 | 1.60 |", "gpu_acc speedups")
-    assert_contains(compare, "| si64_bands_empty128_1steps_1ranks_gpu | gpu_resident_stack | 1 | yes | 30.00 | 3.00 | 1.50 |", "band speedups")
-    assert_contains(compare, "| empty128_1rank_cusolver | cusolver_generalized | 1 | yes | 25.00 | 4.00 | 1.60 |", "cusolver speedups")
-    assert_contains(compare, "| gpu_1rank | gpu_resident_stack | 1 | yes | 20.00 | 4.00 | 1.60 |", "standard speedups")
+    assert_contains(compare, "| gpu_acc_1steps_1rank | gpu_resident_stack | 1 | yes | 25.00 | gpu_resident_stack | 1.00 | 4.00 | 1.60 |", "gpu_acc speedups")
+    assert_contains(compare, "| si64_bands_empty128_1steps_1ranks_gpu | gpu_resident_stack | 1 | yes | 30.00 | gpu_resident_stack | 1.00 | 3.00 | 1.50 |", "band speedups")
+    assert_contains(compare, "| empty128_1rank_cusolver | cusolver_generalized | 1 | yes | 25.00 | cusolver_generalized | 1.00 | 4.00 | 1.60 |", "cusolver speedups")
+    assert_contains(compare, "| empty=512, nsteps=2 | gpu_resident_stack | 1 | yes | 10.00 | gpu_resident | 2.00 |  |  |", "gpu-only base speedup")
+    assert_contains(compare, "| gpu_1rank | gpu_resident_stack | 1 | yes | 20.00 | gpu_resident_stack | 1.00 | 4.00 | 1.60 |", "standard speedups")
 
 
 def main():

--- a/tests/profile/si64/run_offden_focus.sh
+++ b/tests/profile/si64/run_offden_focus.sh
@@ -15,6 +15,22 @@ RUN_SHARED_GPU=${RUN_SHARED_GPU:-yes}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/offden-focus-$(date +%Y%m%d-%H%M%S)"}}
 OFFDEN_CASES=${OFFDEN_CASES:-"gpu_resident_hpsi_offden_cublas_devicepack gpu_resident_hpsi_offden_cublas_devicepack_accum gpu_resident_hpsi_offden_cublas_devicepack_proj gpu_resident_hpsi_offden_cublas_devicepack_proj_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum"}
 
+COMBINED="${RUN_ROOT_BASE}-combined.tsv"
+: > "${COMBINED}"
+
+append_suite() {
+  local suite=$1
+  local tsv=$2
+
+  [[ -f "${tsv}" ]] || return 0
+  if [[ ! -s "${COMBINED}" ]]; then
+    awk 'NR == 1 { print "suite\t" $0; next } { print suite "\t" $0 }' \
+      suite="${suite}" "${tsv}" > "${COMBINED}"
+  else
+    awk 'NR > 1 { print suite "\t" $0 }' suite="${suite}" "${tsv}" >> "${COMBINED}"
+  fi
+}
+
 run_suite() {
   local label=$1
   local ranks=$2
@@ -27,6 +43,7 @@ run_suite() {
     RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${OFFDEN_CASES}" \
     TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
     "${HERE}/run_benchmark.sh"
+  append_suite "${label}" "${root}/benchmark.tsv"
 }
 
 run_suite "${EMPTY_BANDS}-${GPU_RANKS}r" "${GPU_RANKS}" "${EMPTY_BANDS}" "${TIMEOUT}"
@@ -37,3 +54,11 @@ case "${RUN_SHARED_GPU}" in
       "${SHARED_GPU_RANKS}" "${SHARED_EMPTY_BANDS}" "${TIMEOUT}"
     ;;
 esac
+
+if [[ -s "${COMBINED}" ]]; then
+  python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-combined.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-compare.md" || true
+  echo "Combined benchmark data: ${COMBINED}"
+fi

--- a/tests/profile/si64/run_psim_focus.sh
+++ b/tests/profile/si64/run_psim_focus.sh
@@ -67,5 +67,7 @@ esac
 if [[ -s "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
     > "${RUN_ROOT_BASE}-combined.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-compare.md" || true
   echo "Combined benchmark data: ${COMBINED}"
 fi

--- a/tests/profile/si64/run_psim_lifecycle.sh
+++ b/tests/profile/si64/run_psim_lifecycle.sh
@@ -88,6 +88,8 @@ esac
 if [[ -s "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
     > "${RUN_ROOT_BASE}-combined.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-compare.md" || true
   echo "Combined benchmark data: ${COMBINED}"
 fi
 

--- a/tests/profile/si64/run_vpsi_boundary.sh
+++ b/tests/profile/si64/run_vpsi_boundary.sh
@@ -125,6 +125,8 @@ esac
 if [[ -s "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_markdown.py" "${COMBINED}" \
     > "${RUN_ROOT_BASE}-combined.md" || true
+  python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
+    > "${RUN_ROOT_BASE}-compare.md" || true
   echo "Combined benchmark data: ${COMBINED}"
 fi
 


### PR DESCRIPTION
## Summary
- add base_case/vs_base columns to benchmark_compare.py so GPU-only focus runs can compare variants against a selected group baseline
- emit comparison Markdown from offden, PSIM, PSIM lifecycle, and VPSI boundary focus harnesses
- extend the benchmark tool self-test to cover GPU-only focus baseline comparisons

## Validation
- Local: python3 tests/profile/si64/check_benchmark_tools.py
- Local: python3 -m py_compile tests/profile/si64/benchmark_compare.py tests/profile/si64/check_benchmark_tools.py
- Local: bash -n tests/profile/si64/run_offden_focus.sh tests/profile/si64/run_psim_focus.sh tests/profile/si64/run_psim_lifecycle.sh tests/profile/si64/run_vpsi_boundary.sh
- Local: tests/profile/si64/check_harness.sh
- Local: git diff --check
