### PR TITLE
Track OpenACC update transfers in benchmarks

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -101,10 +101,14 @@ kernel instrumentation. The aggregate copy estimate `copy_gb` is split into
 semantic buckets for the GPU-residency work: `copy_wave_gb` for wavefunction
 arrays, `copy_proj_gb` for projector/projection arrays, `copy_offden_gb` for
 off-site density-matrix transfers, and `copy_denmat_gb` for one-center
-density-matrix transfers. These buckets are subsets of `copy_gb` and are meant
-to show whether a residency change actually removes the expected data motion.
-`profile_summary.py` uses the same buckets in its category summary and prints
-their GB totals for single-run CSV inspection.
+density-matrix transfers. OpenACC `ACC_UPDATE_*` rows are reported separately
+as `update_gb` with matching `update_wave_gb`, `update_proj_gb`,
+`update_offden_gb`, and `update_denmat_gb` buckets, so required boundary
+refreshes are visible without inflating the pure copy estimate. These buckets
+are subsets of `copy_gb` or `update_gb` and are meant to show whether a
+residency change actually removes the expected data motion. `profile_summary.py`
+uses the same buckets in its category summary and prints their GB totals for
+single-run CSV inspection.
 For the bundled `si64` and `si64_bands` cases, the harness also checks the
 final constant energy against the built-in reference (`EXPECTED_ENERGY`,
 default `302.280854`) with `ENERGY_TOL=1e-5`. A run with normal termination but

--- a/tests/profile/si64/benchmark_compare.py
+++ b/tests/profile/si64/benchmark_compare.py
@@ -189,11 +189,12 @@ def main(argv):
     print(
         "| suite | case | ranks | ok | wall_s | base_case | vs_base | "
         "vs_1cpu | vs_8cpu | rank_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | "
-        "copy_denmat_gb | energy_delta |"
+        "copy_denmat_gb | update_gb | update_wave_gb | update_proj_gb | update_offden_gb | "
+        "update_denmat_gb | energy_delta |"
     )
     print(
         "| --- | --- | ---: | --- | ---: | --- | ---: | ---: | ---: | "
-        "---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        "---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
     )
     for group in sorted(groups):
         group_rows = groups[group]
@@ -213,7 +214,7 @@ def main(argv):
             ),
         ):
             print(
-                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                     suite_label(row),
                     row.get("case", ""),
                     row.get("ranks", ""),
@@ -229,6 +230,11 @@ def main(argv):
                     number(row.get("copy_proj_gb")),
                     number(row.get("copy_offden_gb")),
                     number(row.get("copy_denmat_gb")),
+                    number(row.get("update_gb")),
+                    number(row.get("update_wave_gb")),
+                    number(row.get("update_proj_gb")),
+                    number(row.get("update_offden_gb")),
+                    number(row.get("update_denmat_gb")),
                     number(row.get("energy_delta"), 6),
                 )
             )

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -46,11 +46,11 @@ def main(argv):
     print()
     print(f"Source: `{os.path.basename(path)}`")
     print()
-    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | pw_gtor_s | pw_rtog_s | phase_s | phase_gap_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | copy_denmat_gb | energy | energy_delta |")
-    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print("| suite | case | ranks | ok | wall_s | rank_s | gap_s | coverage_% | paw_s | blas_s | lapack_s | fft_s | mpi_s | pw_trace_s | pw_gtor_s | pw_rtog_s | phase_s | phase_gap_s | copy_gb | copy_wave_gb | copy_proj_gb | copy_offden_gb | copy_denmat_gb | update_gb | update_wave_gb | update_proj_gb | update_offden_gb | update_denmat_gb | energy | energy_delta |")
+    print("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in rows:
         print(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 suite_label(row),
                 row.get("case", ""),
                 row.get("ranks", ""),
@@ -74,6 +74,11 @@ def main(argv):
                 number(row.get("copy_proj_gb")),
                 number(row.get("copy_offden_gb")),
                 number(row.get("copy_denmat_gb")),
+                number(row.get("update_gb")),
+                number(row.get("update_wave_gb")),
+                number(row.get("update_proj_gb")),
+                number(row.get("update_offden_gb")),
+                number(row.get("update_denmat_gb")),
                 number(row.get("energy"), 6),
                 number(row.get("energy_delta"), 6),
             )

--- a/tests/profile/si64/benchmark_summary.py
+++ b/tests/profile/si64/benchmark_summary.py
@@ -6,13 +6,13 @@ import re
 import sys
 
 
-def copy_bucket(op):
+def transfer_kind(op):
     if "OFFDEN" in op:
-        return "copy_offden_gb"
+        return "offden"
     if "DENMAT" in op:
-        return "copy_denmat_gb"
+        return "denmat"
     if any(token in op for token in ("PROPSI", "PRO_CACHE", "THIS_PROJ")):
-        return "copy_proj_gb"
+        return "proj"
     if any(
         token in op
         for token in (
@@ -26,10 +26,25 @@ def copy_bucket(op):
             "_HPSI",
         )
     ):
-        return "copy_wave_gb"
+        return "wave"
     if any(token in op for token in ("PROJ", "ADDPRO")):
-        return "copy_proj_gb"
+        return "proj"
     return None
+
+
+def transfer_bucket(op, prefix):
+    kind = transfer_kind(op)
+    if not kind:
+        return None
+    return f"{prefix}_{kind}_gb"
+
+
+def copy_bucket(op):
+    return transfer_bucket(op, "copy")
+
+
+def update_bucket(op):
+    return transfer_bucket(op, "update")
 
 
 def profile_totals(run_dir):
@@ -50,6 +65,11 @@ def profile_totals(run_dir):
         "copy_proj_gb": 0.0,
         "copy_offden_gb": 0.0,
         "copy_denmat_gb": 0.0,
+        "update_gb": 0.0,
+        "update_wave_gb": 0.0,
+        "update_proj_gb": 0.0,
+        "update_offden_gb": 0.0,
+        "update_denmat_gb": 0.0,
     }
     for path in glob.glob(os.path.join(run_dir, "*_profile*.csv")):
         with open(path, newline="") as handle:
@@ -60,6 +80,12 @@ def profile_totals(run_dir):
                 if op.startswith("ACC_COPY"):
                     totals["copy_gb"] += gbyte
                     bucket = copy_bucket(op)
+                    if bucket:
+                        totals[bucket] += gbyte
+                    continue
+                if op.startswith("ACC_UPDATE"):
+                    totals["update_gb"] += gbyte
+                    bucket = update_bucket(op)
                     if bucket:
                         totals[bucket] += gbyte
                     continue
@@ -214,6 +240,11 @@ def main(argv):
                 "copy_proj_gb": totals["copy_proj_gb"],
                 "copy_offden_gb": totals["copy_offden_gb"],
                 "copy_denmat_gb": totals["copy_denmat_gb"],
+                "update_gb": totals["update_gb"],
+                "update_wave_gb": totals["update_wave_gb"],
+                "update_proj_gb": totals["update_proj_gb"],
+                "update_offden_gb": totals["update_offden_gb"],
+                "update_denmat_gb": totals["update_denmat_gb"],
                 "energy": energy,
                 "energy_delta": energy_delta,
                 "energy_ok": (
@@ -254,6 +285,11 @@ def main(argv):
         "copy_proj_gb",
         "copy_offden_gb",
         "copy_denmat_gb",
+        "update_gb",
+        "update_wave_gb",
+        "update_proj_gb",
+        "update_offden_gb",
+        "update_denmat_gb",
         "energy",
         "energy_delta",
         "energy_ok",

--- a/tests/profile/si64/check_benchmark_tools.py
+++ b/tests/profile/si64/check_benchmark_tools.py
@@ -60,6 +60,8 @@ def check_summary_and_markdown(tmpdir):
                 "ACC_COPY_OFFDEN_DPACK_PROJ_IN,1,1,1,0,1,0,0,0,0,3.5,0,0",
                 "ACC_COPY_DENMAT_LAGR_IN,1,1,1,0,1,0,0,0,0,4.5,0,0",
                 "ACC_COPY_MISC_IN,1,1,1,0,1,0,0,0,0,0.75,0,0",
+                "ACC_UPDATE_VPSI_HPSI_IN,1,1,1,0,1,0,0,0,0,1.25,0,0",
+                "ACC_PRESENT_ADDOPSI_PSIM,1,1,1,0,2,0,0,0,0,0,0,0",
                 "PW_GTOR_TOTAL,1,1,1,0,1,1,1,1,0,0,0,0",
                 "PW_RTOG_TOTAL,1,1,1,0,1,2,2,2,0,0,0,0",
                 "PW_FFT_RTOG_TOTAL,1,1,1,0,1,4,4,4,0,0,0,0",
@@ -90,9 +92,13 @@ def check_summary_and_markdown(tmpdir):
     assert_equal(row["copy_proj_gb"], "3", "copy_proj_gb")
     assert_equal(row["copy_offden_gb"], "3.5", "copy_offden_gb")
     assert_equal(row["copy_denmat_gb"], "4.5", "copy_denmat_gb")
+    assert_equal(row["update_gb"], "1.25", "update_gb")
+    assert_equal(row["update_wave_gb"], "1.25", "update_wave_gb")
+    assert_equal(row["update_proj_gb"], "0", "update_proj_gb")
 
     markdown = run_tool("benchmark_markdown.py", tsv_path)
     assert_contains(markdown, "copy_wave_gb", "benchmark markdown header")
+    assert_contains(markdown, "update_wave_gb", "benchmark markdown update header")
     assert_contains(markdown, "|  | case | 1 | yes | 10.00 |", "benchmark markdown row")
 
     profile_summary = run_tool(
@@ -102,6 +108,7 @@ def check_summary_and_markdown(tmpdir):
     assert_contains(profile_summary, "ACC copy proj", "profile copy proj bucket")
     assert_contains(profile_summary, "ACC copy offden", "profile copy offden bucket")
     assert_contains(profile_summary, "ACC copy denmat", "profile copy denmat bucket")
+    assert_contains(profile_summary, "ACC update wave", "profile update wave bucket")
 
 
 def check_compare(tmpdir):

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -20,7 +20,9 @@ bash -n tests/profile/si64/run_large_bands_long.sh
 bash -n tests/profile/si64/run_gpu_exploration.sh
 bash -n tests/profile/si64/run_nvhpc_standard.sh
 bash -n tests/profile/si64/run_nsys.sh
+bash -n tests/profile/si64/run_offden_focus.sh
 bash -n tests/profile/si64/run_overnight.sh
+bash -n tests/profile/si64/run_psim_focus.sh
 bash -n tests/profile/si64/run_psim_lifecycle.sh
 bash -n tests/profile/si64/run_vpsi_boundary.sh
 bash -n src/Tools/Scripts/paw_cuda_aware_mpi_probe.sh

--- a/tests/profile/si64/profile_summary.py
+++ b/tests/profile/si64/profile_summary.py
@@ -5,13 +5,13 @@ import glob
 import sys
 
 
-def copy_bucket(op):
+def transfer_kind(op):
     if "OFFDEN" in op:
-        return "ACC copy offden"
+        return "offden"
     if "DENMAT" in op:
-        return "ACC copy denmat"
+        return "denmat"
     if any(token in op for token in ("PROPSI", "PRO_CACHE", "THIS_PROJ")):
-        return "ACC copy proj"
+        return "proj"
     if any(
         token in op
         for token in (
@@ -25,10 +25,22 @@ def copy_bucket(op):
             "_HPSI",
         )
     ):
-        return "ACC copy wave"
+        return "wave"
     if any(token in op for token in ("PROJ", "ADDPRO")):
-        return "ACC copy proj"
-    return "ACC copy other"
+        return "proj"
+    return "other"
+
+
+def transfer_bucket(op, prefix):
+    return f"{prefix} {transfer_kind(op)}"
+
+
+def copy_bucket(op):
+    return transfer_bucket(op, "ACC copy")
+
+
+def update_bucket(op):
+    return transfer_bucket(op, "ACC update")
 
 
 def category(op):
@@ -36,6 +48,8 @@ def category(op):
         return "Phase trace"
     if op.startswith("ACC_COPY"):
         return copy_bucket(op)
+    if op.startswith("ACC_UPDATE"):
+        return update_bucket(op)
     if op.startswith("ACC_PRESENT"):
         return "ACC residency"
     if op.startswith("ACC_SETUP"):
@@ -126,10 +140,17 @@ def main(argv):
         data["gbyte"] for op, data in per_op.items()
         if op.startswith("ACC_COPY")
     )
+    update_gbyte = sum(
+        data["gbyte"] for op, data in per_op.items()
+        if op.startswith("ACC_UPDATE")
+    )
     copy_bucket_gbyte = collections.defaultdict(float)
+    update_bucket_gbyte = collections.defaultdict(float)
     for op, data in per_op.items():
         if op.startswith("ACC_COPY"):
             copy_bucket_gbyte[copy_bucket(op)] += data["gbyte"]
+        elif op.startswith("ACC_UPDATE"):
+            update_bucket_gbyte[update_bucket(op)] += data["gbyte"]
 
     print("Profile files: {}".format(len(files)))
     print("Instrumented rank-seconds: {:.6f}".format(primary_total))
@@ -139,16 +160,22 @@ def main(argv):
         print("Diagnostic phase rank-seconds: {:.6f}".format(phase_total))
     if trace_total:
         print("Diagnostic PW trace rank-seconds: {:.6f}".format(trace_total))
-    if setup_total or copy_gbyte:
+    if setup_total or copy_gbyte or update_gbyte:
         print(
-            "Accelerator setup seconds: {:.6f}  copy estimate: {:.6f} GB".format(
-                setup_total, copy_gbyte
+            "Accelerator setup seconds: {:.6f}  copy estimate: {:.6f} GB  update estimate: {:.6f} GB".format(
+                setup_total, copy_gbyte, update_gbyte
             )
         )
     if copy_bucket_gbyte:
         print("Copy bucket estimates")
         for name, gbyte in sorted(
             copy_bucket_gbyte.items(), key=lambda item: -item[1]
+        ):
+            print("  {:<16s} {:10.4f} GB".format(name, gbyte))
+    if update_bucket_gbyte:
+        print("Update bucket estimates")
+        for name, gbyte in sorted(
+            update_bucket_gbyte.items(), key=lambda item: -item[1]
         ):
             print("  {:<16s} {:10.4f} GB".format(name, gbyte))
     print("")


### PR DESCRIPTION
## Summary
- add update_gb and semantic update buckets for ACC_UPDATE_* rows in benchmark summaries
- include update transfer columns in benchmark Markdown and comparison reports while keeping copy_gb unchanged
- extend the profile helper self-test and harness syntax check coverage for the focus scripts

## Validation
- Local: python3 tests/profile/si64/check_benchmark_tools.py
- Local: python3 -m py_compile tests/profile/si64/profile_summary.py tests/profile/si64/benchmark_summary.py tests/profile/si64/benchmark_markdown.py tests/profile/si64/benchmark_compare.py tests/profile/si64/check_benchmark_tools.py
- Local: tests/profile/si64/check_harness.sh
- Local: python3 tests/profile/si64/benchmark_markdown.py tests/profile/si64/runs/si64_bands-nstep1-1ranks-20260430-090817/benchmark.tsv
- Local: python3 tests/profile/si64/benchmark_compare.py tests/profile/si64/runs/si64_bands-nstep1-1ranks-20260430-090817/benchmark.tsv
- Local: git diff --check
