### PR TITLE
Polish accelerator transfer reports

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -594,8 +594,9 @@ reported energies between cases instead. It writes the normal combined benchmark
 TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`;
 the comparison Markdown reports each GPU-only focus case relative to the
 selected group baseline. The helper also accepts `--op-prefix`, `--op-regex`,
-and `--include-zero` for
-broader profile-row reports such as present/update/timing rows.
+and `--include-zero` for broader profile-row reports such as
+present/update/timing rows; its size column is `gbyte`, so mixed copy, update,
+and present reports do not imply every selected row is a copy.
 Override `NSTEPS_LIST`, `EMPTY_BANDS_LIST`, `RUN_SHARED_GPU=yes`,
 `RUN_LARGE_GPU=yes`, or `PSIM_LIFECYCLE_CASES` for wider sweeps.
 

--- a/tests/profile/si64/benchmark_compare.py
+++ b/tests/profile/si64/benchmark_compare.py
@@ -117,6 +117,11 @@ def read_rows(path):
         rows = list(csv.DictReader(handle, delimiter="\t"))
     for row in rows:
         row.setdefault("suite", "")
+        if row.get("transfer_gb") in (None, ""):
+            copy_gb = parse_float(row.get("copy_gb"))
+            update_gb = parse_float(row.get("update_gb"))
+            if copy_gb is not None or update_gb is not None:
+                row["transfer_gb"] = str((copy_gb or 0.0) + (update_gb or 0.0))
         row["_wall"] = parse_float(row.get("wall_s"))
         row["_group"], row["_kind"] = case_kind(row)
     return rows

--- a/tests/profile/si64/benchmark_markdown.py
+++ b/tests/profile/si64/benchmark_markdown.py
@@ -5,6 +5,15 @@ import re
 import sys
 
 
+def parse_float(value):
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 def number(value, digits=2):
     if value is None or value == "":
         return ""
@@ -30,6 +39,11 @@ def read_rows(path):
     for row in rows:
         if "suite" not in row:
             row["suite"] = ""
+        if row.get("transfer_gb") in (None, ""):
+            copy_gb = parse_float(row.get("copy_gb"))
+            update_gb = parse_float(row.get("update_gb"))
+            if copy_gb is not None or update_gb is not None:
+                row["transfer_gb"] = str((copy_gb or 0.0) + (update_gb or 0.0))
     return rows
 
 

--- a/tests/profile/si64/check_benchmark_tools.py
+++ b/tests/profile/si64/check_benchmark_tools.py
@@ -45,6 +45,18 @@ def assert_contains(text, needle, label):
         raise AssertionError(f"{label}: missing {needle!r}")
 
 
+def markdown_table(text):
+    rows = [line for line in text.splitlines() if line.startswith("| ")]
+    if len(rows) < 3:
+        raise AssertionError("markdown table: no data rows")
+    header = [cell.strip() for cell in rows[0].strip("|").split("|")]
+    data = [
+        [cell.strip() for cell in row.strip("|").split("|")]
+        for row in rows[2:]
+    ]
+    return header, data
+
+
 def check_summary_and_markdown(tmpdir):
     run_dir = os.path.join(tmpdir, "case", "rep1")
     os.makedirs(run_dir)
@@ -113,6 +125,42 @@ def check_summary_and_markdown(tmpdir):
     assert_contains(profile_summary, "ACC update wave", "profile update wave bucket")
     assert_contains(profile_summary, "transfer estimate: 14.750000 GB", "profile transfer total")
 
+    copy_rows = run_tool(
+        "profile_copy_rows.py",
+        "--op-prefix",
+        "ACC_COPY",
+        "--op-prefix",
+        "ACC_UPDATE",
+        "--op-prefix",
+        "ACC_PRESENT",
+        "--include-zero",
+        os.path.join(run_dir, "test_profile.csv"),
+    )
+    assert_contains(
+        copy_rows,
+        "suite\tcase\trepeat\top\tcalls\tgbyte\tseconds\tfiles",
+        "profile row TSV header",
+    )
+    assert_contains(
+        copy_rows,
+        "ACC_UPDATE_VPSI_HPSI_IN\t1\t1.25",
+        "profile row update bytes",
+    )
+    assert_contains(
+        copy_rows,
+        "ACC_PRESENT_ADDOPSI_PSIM\t2\t0",
+        "profile row present zero bytes",
+    )
+
+    copy_rows_md = run_tool(
+        "profile_copy_rows.py",
+        "--op-prefix",
+        "ACC_UPDATE",
+        "--markdown",
+        os.path.join(run_dir, "test_profile.csv"),
+    )
+    assert_contains(copy_rows_md, "| suite | case | repeat | op | calls | gbyte | seconds | files |", "profile row markdown header")
+
 
 def check_compare(tmpdir):
     path = os.path.join(tmpdir, "combined.tsv")
@@ -142,11 +190,18 @@ def check_compare(tmpdir):
     write(path, "\n".join([header, *rows]) + "\n")
 
     compare = run_tool("benchmark_compare.py", path)
-    assert_contains(compare, "| gpu_acc_1steps_1rank | gpu_resident_stack | 1 | yes | 25.00 | gpu_resident_stack | 1.00 | 4.00 | 1.60 |", "gpu_acc speedups")
+    assert_contains(compare, "| gpu_acc_1steps_1rank | gpu_resident_stack | 1 | yes | 25.00 | gpu_resident_stack | 1.00 | 4.00 | 1.60 | 20.00 | 10.00 | 10.00 |", "gpu_acc speedups and legacy transfer")
     assert_contains(compare, "| si64_bands_empty128_1steps_1ranks_gpu | gpu_resident_stack | 1 | yes | 30.00 | gpu_resident_stack | 1.00 | 3.00 | 1.50 |", "band speedups")
     assert_contains(compare, "| empty128_1rank_cusolver | cusolver_generalized | 1 | yes | 25.00 | cusolver_generalized | 1.00 | 4.00 | 1.60 |", "cusolver speedups")
     assert_contains(compare, "| empty=512, nsteps=2 | gpu_resident_stack | 1 | yes | 10.00 | gpu_resident | 2.00 |  |  |", "gpu-only base speedup")
     assert_contains(compare, "| gpu_1rank | gpu_resident_stack | 1 | yes | 20.00 | gpu_resident_stack | 1.00 | 4.00 | 1.60 |", "standard speedups")
+
+    markdown = run_tool("benchmark_markdown.py", path)
+    header_cells, data_rows = markdown_table(markdown)
+    transfer_index = header_cells.index("transfer_gb")
+    copy_index = header_cells.index("copy_gb")
+    assert_equal(data_rows[0][transfer_index], "10.00", "legacy markdown transfer_gb")
+    assert_equal(data_rows[0][copy_index], "10.00", "legacy markdown copy_gb")
 
 
 def main():

--- a/tests/profile/si64/profile_copy_rows.py
+++ b/tests/profile/si64/profile_copy_rows.py
@@ -118,7 +118,7 @@ def selected_rows(rows, top, per_case, min_gb, sort_by):
 
 
 def print_tsv(rows):
-    print("suite\tcase\trepeat\top\tcalls\tcopy_gb\tseconds\tfiles")
+    print("suite\tcase\trepeat\top\tcalls\tgbyte\tseconds\tfiles")
     for (suite, case, repeat, op), data in rows:
         print(
             "{}\t{}\t{}\t{}\t{}\t{:.9g}\t{:.9g}\t{}".format(
@@ -135,7 +135,7 @@ def print_tsv(rows):
 
 
 def print_markdown(rows):
-    print("| suite | case | repeat | op | calls | copy_gb | seconds | files |")
+    print("| suite | case | repeat | op | calls | gbyte | seconds | files |")
     print("| --- | --- | --- | --- | ---: | ---: | ---: | ---: |")
     for (suite, case, repeat, op), data in rows:
         print(
@@ -184,7 +184,7 @@ def main(argv):
     parser.add_argument(
         "--include-zero",
         action="store_true",
-        help="keep rows with zero copied GB, useful for ACC_PRESENT or timing rows",
+        help="keep rows with zero transferred GB, useful for ACC_PRESENT or timing rows",
     )
     parser.add_argument(
         "--sort-by",


### PR DESCRIPTION
## Summary
- derive transfer_gb when reading older benchmark TSVs that only have copy/update buckets
- rename profile_copy_rows.py output volume column from copy_gb to neutral gbyte for mixed ACC_COPY/ACC_UPDATE/ACC_PRESENT reports
- extend the benchmark helper self-test to cover legacy transfer derivation and mixed profile-row reports

## Validation
- Local: python3 tests/profile/si64/check_benchmark_tools.py
- Local: python3 -m py_compile tests/profile/si64/profile_summary.py tests/profile/si64/profile_copy_rows.py tests/profile/si64/benchmark_summary.py tests/profile/si64/benchmark_markdown.py tests/profile/si64/benchmark_compare.py tests/profile/si64/check_benchmark_tools.py
- Local: tests/profile/si64/check_harness.sh
- Local: old benchmark.tsv compatibility check for benchmark_markdown.py and benchmark_compare.py
- Local: git diff --check
