### PR TITLE
Emit profile row reports from followup benchmarks

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -509,7 +509,9 @@ TEST=si64_bands EMPTY_BANDS=128 NSTEPS=1 ./run_benchmark.sh
 The stacked follow-up benchmark compares the larger-band case across the
 resource split we want for the next optimization pass: one rank on one GPU,
 one-rank CPU references, and eight-rank CPU/NVHPC references. It defaults to
-`NSTEPS_LIST="1 3 10"` and accepts `EMPTY_BANDS_LIST` for a band-size sweep:
+`NSTEPS_LIST="1 3 10"` and accepts `EMPTY_BANDS_LIST` for a band-size sweep. It
+also writes `combined_transfer_rows.md` and `combined_present_rows.md` so the
+remaining data motion and resident reuse sites can be compared across the sweep:
 
 ```
 cd tests/profile/si64
@@ -658,6 +660,10 @@ and captures available NVIDIA libraries plus CUDA-aware MPI hints:
 cd tests/profile/si64
 NSTEPS=1 ./run_gpu_exploration.sh
 ```
+
+The exploration run writes the same combined benchmark, comparison, transfer-row,
+and present-row reports as the standard benchmark, plus `gpu_capabilities.txt`
+when the capability helper is available.
 
 To compare NVHPC memory modes, build the optional profile binaries and add the
 cases explicitly:

--- a/tests/profile/si64/run_followup.sh
+++ b/tests/profile/si64/run_followup.sh
@@ -14,6 +14,8 @@ EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-${EMPTY_BANDS}}
 GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_stack gpu_resident_nosync gpu gpu_off"}
 CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
 ONE_RANK_CPU_CASES=${ONE_RANK_CPU_CASES:-"cpu nvhpc_cpu"}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 mkdir -p "${FOLLOWUP_ROOT}"
 echo "${FOLLOWUP_ROOT}" > "${HERE}/runs/latest_followup"
@@ -21,6 +23,8 @@ echo "${FOLLOWUP_ROOT}" > "${HERE}/runs/latest_followup"
 COMBINED="${FOLLOWUP_ROOT}/combined_benchmark.tsv"
 SUMMARY_LOG="${FOLLOWUP_ROOT}/followup.log"
 : > "${SUMMARY_LOG}"
+
+declare -a SUITE_ROOTS=()
 
 log() {
   printf '%s %s\n' "$(iso_now)" "$*" | tee -a "${SUMMARY_LOG}"
@@ -64,6 +68,7 @@ run_suite() {
     echo "${status}" > "${suite_root}.status"
   fi
   append_suite "${suite}" "${suite_root}/benchmark.tsv"
+  SUITE_ROOTS+=("${suite_root}")
 }
 
 for empty_bands in ${EMPTY_BANDS_LIST}; do
@@ -84,4 +89,36 @@ if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${FOLLOWUP_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${FOLLOWUP_ROOT}/combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${FOLLOWUP_ROOT}/combined_transfer_rows.tsv" || true
+    log "transfer_rows=${FOLLOWUP_ROOT}/combined_transfer_rows.md"
+  else
+    log "transfer_rows=none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${FOLLOWUP_ROOT}/combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${FOLLOWUP_ROOT}/combined_present_rows.tsv" || true
+    log "present_rows=${FOLLOWUP_ROOT}/combined_present_rows.md"
+  else
+    log "present_rows=none"
+  fi
 fi

--- a/tests/profile/si64/run_gpu_exploration.sh
+++ b/tests/profile/si64/run_gpu_exploration.sh
@@ -10,6 +10,8 @@ TIMEOUT=${TIMEOUT:-7200}
 EMPTY_BANDS=${EMPTY_BANDS:-128}
 GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_stack gpu_resident_stack_cufft gpu_resident_nosync gpu gpu_force_all gpu_3dfft gpu_managed gpu_unified gpu_off"}
 CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 mkdir -p "${GPU_EXPLORATION_ROOT}"
 echo "${GPU_EXPLORATION_ROOT}" > "${HERE}/runs/latest_gpu_exploration"
@@ -17,6 +19,8 @@ echo "${GPU_EXPLORATION_ROOT}" > "${HERE}/runs/latest_gpu_exploration"
 COMBINED="${GPU_EXPLORATION_ROOT}/combined_benchmark.tsv"
 LOG="${GPU_EXPLORATION_ROOT}/gpu_exploration.log"
 : > "${LOG}"
+
+declare -a SUITE_ROOTS=()
 
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOG}"
@@ -53,6 +57,7 @@ run_suite() {
     echo "${status}" > "${root}.status"
   fi
   append_suite "${suite}" "${root}/benchmark.tsv"
+  SUITE_ROOTS+=("${root}")
 }
 
 if [[ -x "${HERE}/../../../src/Tools/Scripts/paw_gpu_capabilities.sh" ]]; then
@@ -71,4 +76,36 @@ if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${GPU_EXPLORATION_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${GPU_EXPLORATION_ROOT}/combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${GPU_EXPLORATION_ROOT}/combined_transfer_rows.tsv" || true
+    log "transfer_rows=${GPU_EXPLORATION_ROOT}/combined_transfer_rows.md"
+  else
+    log "transfer_rows=none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${GPU_EXPLORATION_ROOT}/combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${GPU_EXPLORATION_ROOT}/combined_present_rows.tsv" || true
+    log "present_rows=${GPU_EXPLORATION_ROOT}/combined_present_rows.md"
+  else
+    log "present_rows=none"
+  fi
 fi


### PR DESCRIPTION
## Summary
- make run_followup.sh emit combined_transfer_rows.md/.tsv and combined_present_rows.md/.tsv
- make run_gpu_exploration.sh emit the same transfer/present hotspot artifacts
- document the extra follow-up and exploration benchmark outputs

## Validation
- Local: bash -n tests/profile/si64/run_followup.sh tests/profile/si64/run_gpu_exploration.sh
- Local: tests/profile/si64/check_harness.sh
- Local: python3 -m py_compile tests/profile/si64/profile_copy_rows.py tests/profile/si64/check_benchmark_tools.py
- Local: git diff --check
