### PR TITLE
Emit profile row reports from overnight benchmark

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -638,8 +638,9 @@ cd tests/profile/si64
 
 It defaults to `EMPTY_BANDS_LIST="128 256 512 1024"`, `NSTEPS_LIST=1` and
 compares one-rank GPU residency, one-rank CPU, and eight-rank CPU/NVHPC
-references. Set `RUN_GPU_ALL=yes` to include the all-library diagnostic cases
-`gpu_all` and `gpu_all_off`.
+references. It inherits the follow-up benchmark's combined comparison,
+transfer-row, and present-row reports. Set `RUN_GPU_ALL=yes` to include the
+all-library diagnostic cases `gpu_all` and `gpu_all_off`.
 
 For the longer validation preset used before promoting a residency diagnostic
 to a default, run:
@@ -651,7 +652,8 @@ cd tests/profile/si64
 
 It defaults to `EMPTY_BANDS_LIST="512 1024"` and `NSTEPS_LIST="3 10"` and
 compares `gpu_resident`, `gpu_resident_nosync`, `gpu_off`, one-rank CPU and
-eight-rank CPU/NVHPC references.
+eight-rank CPU/NVHPC references. It inherits the follow-up benchmark's combined
+comparison, transfer-row, and present-row reports.
 
 For a short broad GPU exploration suite that includes the opt-in 3-D cuFFT path
 and captures available NVIDIA libraries plus CUDA-aware MPI hints:
@@ -856,7 +858,10 @@ cd tests/profile/si64
 ```
 
 The top-level run directory is written to `runs/latest_overnight`; the combined
-benchmark table is `combined_benchmark.tsv`.
+benchmark table is `combined_benchmark.tsv`. The overnight run also writes
+`combined_benchmark.md`, `combined_compare.md`, `combined_transfer_rows.md` and
+`combined_present_rows.md` so the long run ends with the same speedup,
+data-motion, and resident-reuse summaries as the shorter benchmark harnesses.
 
 Set `RUN_NVLAMATH=yes` to add a short NVLAMATH comparison suite,
 `RUN_CUFFTW=yes` to add a short cuFFTW comparison suite, `RUN_CUFFT=yes` to add

--- a/tests/profile/si64/run_overnight.sh
+++ b/tests/profile/si64/run_overnight.sh
@@ -42,6 +42,8 @@ BAND_CASES=${BAND_CASES:-"gpu_resident gpu_resident_stack gpu_resident_nosync gp
 BAND_ONE_RANK_CPU_CASES=${BAND_ONE_RANK_CPU_CASES:-"cpu nvhpc_cpu"}
 BAND_CPU_CASES=${BAND_CPU_CASES:-"cpu nvhpc_cpu"}
 THRESHOLDS=${THRESHOLDS:-"1e7"}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
@@ -84,6 +86,8 @@ echo "${OVERNIGHT_ROOT}" > "${HERE}/runs/latest_overnight"
 COMBINED="${OVERNIGHT_ROOT}/combined_benchmark.tsv"
 SUMMARY_LOG="${OVERNIGHT_ROOT}/overnight.log"
 : > "${SUMMARY_LOG}"
+
+declare -a SUITE_ROOTS=()
 
 log() {
   printf '%s %s\n' "$(iso_now)" "$*" | tee -a "${SUMMARY_LOG}"
@@ -179,6 +183,7 @@ run_suite() {
     echo "${status}" > "${suite_root}.status"
   fi
   append_suite "${suite}" "${suite_root}/benchmark.tsv"
+  SUITE_ROOTS+=("${suite_root}")
 }
 
 run_nsys_trace() {
@@ -284,4 +289,36 @@ if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${OVERNIGHT_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${OVERNIGHT_ROOT}/combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${OVERNIGHT_ROOT}/combined_transfer_rows.tsv" || true
+    log "transfer_rows=${OVERNIGHT_ROOT}/combined_transfer_rows.md"
+  else
+    log "transfer_rows=none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${OVERNIGHT_ROOT}/combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${OVERNIGHT_ROOT}/combined_present_rows.tsv" || true
+    log "present_rows=${OVERNIGHT_ROOT}/combined_present_rows.md"
+  else
+    log "present_rows=none"
+  fi
 fi


### PR DESCRIPTION
## Summary
- make run_overnight.sh emit combined_transfer_rows.md/.tsv for top ACC_COPY/ACC_UPDATE rows
- add combined_present_rows.md/.tsv for frequent ACC_PRESENT reuse observations across overnight suites
- document inherited large-band reports and overnight benchmark profile-row artifacts

## Validation
- Local: bash -n tests/profile/si64/run_overnight.sh
- Local: tests/profile/si64/check_harness.sh
- Local: python3 -m py_compile tests/profile/si64/profile_copy_rows.py tests/profile/si64/check_benchmark_tools.py
- Local: git diff --check
