### PR TITLE
Emit solver rows from cuSOLVER focus benchmark

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -812,7 +812,11 @@ cd tests/profile/si64
 It defaults to `EMPTY_BANDS_LIST="128 256 512"` and compares
 `cusolver`, `cusolver_generalized`, `cusolver_generalized_conservative`,
 `cusolver_off`, one-rank CPU/NVHPC and eight-rank CPU/NVHPC references. It
-writes both `combined_benchmark.md` and `combined_compare.md`.
+writes `combined_benchmark.md`, `combined_compare.md`,
+`combined_solver_rows.md`, `combined_transfer_rows.md`, and
+`combined_present_rows.md`. The solver-row report is sorted by seconds over
+`LAPACK*` and `CUSOLVER*` rows, so the focus run shows directly which
+eigensolver path was active and how much solver time remains.
 
 For reproducible comparisons, use the benchmark harness:
 

--- a/tests/profile/si64/run_cusolver_focus.sh
+++ b/tests/profile/si64/run_cusolver_focus.sh
@@ -12,6 +12,9 @@ GPU_RANKS=${GPU_RANKS:-1}
 CPU_RANKS=${CPU_RANKS:-8}
 CUSOLVER_CASES=${CUSOLVER_CASES:-"cusolver cusolver_generalized cusolver_generalized_conservative cusolver_off"}
 CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+SOLVER_ROW_TOP=${SOLVER_ROW_TOP:-16}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 mkdir -p "${CUSOLVER_FOCUS_ROOT}"
 echo "${CUSOLVER_FOCUS_ROOT}" > "${HERE}/runs/latest_cusolver_focus"
@@ -19,6 +22,8 @@ echo "${CUSOLVER_FOCUS_ROOT}" > "${HERE}/runs/latest_cusolver_focus"
 COMBINED="${CUSOLVER_FOCUS_ROOT}/combined_benchmark.tsv"
 LOG="${CUSOLVER_FOCUS_ROOT}/cusolver_focus.log"
 : > "${LOG}"
+
+declare -a SUITE_ROOTS=()
 
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOG}"
@@ -56,6 +61,7 @@ run_suite() {
     echo "${status}" > "${root}.status"
   fi
   append_suite "${suite}" "${root}/benchmark.tsv"
+  SUITE_ROOTS+=("${root}")
 }
 
 for empty_bands in ${EMPTY_BANDS_LIST}; do
@@ -74,4 +80,51 @@ if [[ -f "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${CUSOLVER_FOCUS_ROOT}/combined_compare.md" || true
   log "combined=${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${SOLVER_ROW_TOP}" --markdown --include-zero --sort-by seconds \
+      --op-prefix LAPACK --op-prefix CUSOLVER \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_solver_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${SOLVER_ROW_TOP}" --include-zero --sort-by seconds \
+      --op-prefix LAPACK --op-prefix CUSOLVER \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_solver_rows.tsv" || true
+    log "solver_rows=${CUSOLVER_FOCUS_ROOT}/combined_solver_rows.md"
+  else
+    log "solver_rows=none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_transfer_rows.tsv" || true
+    log "transfer_rows=${CUSOLVER_FOCUS_ROOT}/combined_transfer_rows.md"
+  else
+    log "transfer_rows=none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${CUSOLVER_FOCUS_ROOT}/combined_present_rows.tsv" || true
+    log "present_rows=${CUSOLVER_FOCUS_ROOT}/combined_present_rows.md"
+  else
+    log "present_rows=none"
+  fi
 fi


### PR DESCRIPTION
## Summary
- make run_cusolver_focus.sh emit combined_solver_rows.md/.tsv for LAPACK/CUSOLVER rows sorted by seconds
- add transfer and present row reports to the cuSOLVER focus benchmark
- document the extra cuSOLVER focus artifacts

## Validation
- Local: bash -n tests/profile/si64/run_cusolver_focus.sh
- Local: tests/profile/si64/check_harness.sh
- Local: python3 -m py_compile tests/profile/si64/profile_copy_rows.py tests/profile/si64/check_benchmark_tools.py
- Local: git diff --check
