### PR TITLE
Add focus profile row reports

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -564,7 +564,12 @@ DENMAT-energy cases. By default it runs `EMPTY_BANDS=2048` on one GPU rank and
 `OFFDEN_CASES`, `GPU_RANKS`, `SHARED_GPU_RANKS`, `EMPTY_BANDS`, or
 `RUN_SHARED_GPU=no` for narrower checks. It writes combined benchmark and
 comparison Markdown so the device-pack variants can be compared against the
-first successful focus-case baseline.
+first successful focus-case baseline. It also writes
+`combined_offden_rows.md`/`.tsv` for seconds-sorted `PAW_OFFDEN_*` and
+`CUBLAS_ZGEMM_OFFDEN_*` rows, plus `combined_transfer_rows.md`/`.tsv` and
+`combined_present_rows.md`/`.tsv` for the largest remaining OpenACC transfers
+and resident-buffer reuse checks. Set `OFFDEN_ROW_TOP`, `PROFILE_ROW_TOP`, or
+`PRESENT_ROW_TOP` to widen those reports.
 
 For the focused PSIM propagation comparison, run:
 
@@ -582,7 +587,12 @@ run directories, including a comparison table against the focus baseline. Set
 `RUN_LARGE_GPU=yes` to add a one-rank
 `LARGE_EMPTY_BANDS=2048` sweep, or override `PSIM_CASES`, `GPU_RANKS`,
 `SHARED_GPU_RANKS`, `EMPTY_BANDS`, and `RUN_SHARED_GPU=no` for narrower
-checks.
+checks. It also writes `combined_psim_rows.md`/`.tsv` for seconds-sorted
+PSIM/OPSI/propagation/orthogonalization rows, plus
+`combined_transfer_rows.md`/`.tsv` and `combined_present_rows.md`/`.tsv` for
+the remaining data motion and resident reuse around the PSIM propagation
+boundary. Set `PSIM_ROW_TOP`, `PROFILE_ROW_TOP`, or `PRESENT_ROW_TOP` to widen
+those reports.
 
 For the PSIM lifecycle comparison across at least two time steps, run:
 

--- a/tests/profile/si64/run_offden_focus.sh
+++ b/tests/profile/si64/run_offden_focus.sh
@@ -14,9 +14,20 @@ TIMEOUT=${TIMEOUT:-720}
 RUN_SHARED_GPU=${RUN_SHARED_GPU:-yes}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/offden-focus-$(date +%Y%m%d-%H%M%S)"}}
 OFFDEN_CASES=${OFFDEN_CASES:-"gpu_resident_hpsi_offden_cublas_devicepack gpu_resident_hpsi_offden_cublas_devicepack_accum gpu_resident_hpsi_offden_cublas_devicepack_proj gpu_resident_hpsi_offden_cublas_devicepack_proj_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum"}
+OFFDEN_ROW_TOP=${OFFDEN_ROW_TOP:-16}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 COMBINED="${RUN_ROOT_BASE}-combined.tsv"
 : > "${COMBINED}"
+
+declare -a SUITE_ROOTS=()
+OFFDEN_ROW_ARGS=(
+  --op-prefix PAW_OFFDEN_
+  --op-prefix CUBLAS_ZGEMM_OFFDEN_
+  --include-zero
+  --sort-by seconds
+)
 
 append_suite() {
   local suite=$1
@@ -44,6 +55,7 @@ run_suite() {
     TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"
+  SUITE_ROOTS+=("${root}")
 }
 
 run_suite "${EMPTY_BANDS}-${GPU_RANKS}r" "${GPU_RANKS}" "${EMPTY_BANDS}" "${TIMEOUT}"
@@ -61,4 +73,49 @@ if [[ -s "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${RUN_ROOT_BASE}-compare.md" || true
   echo "Combined benchmark data: ${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${OFFDEN_ROW_TOP}" --markdown "${OFFDEN_ROW_ARGS[@]}" \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_offden_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${OFFDEN_ROW_TOP}" "${OFFDEN_ROW_ARGS[@]}" \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_offden_rows.tsv" || true
+    echo "Combined off-site DENMAT row data: ${RUN_ROOT_BASE}-combined_offden_rows.md"
+  else
+    echo "Combined off-site DENMAT row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_transfer_rows.tsv" || true
+    echo "Combined transfer row data: ${RUN_ROOT_BASE}-combined_transfer_rows.md"
+  else
+    echo "Combined transfer row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_present_rows.tsv" || true
+    echo "Combined present row data: ${RUN_ROOT_BASE}-combined_present_rows.md"
+  else
+    echo "Combined present row data: none"
+  fi
 fi

--- a/tests/profile/si64/run_psim_focus.sh
+++ b/tests/profile/si64/run_psim_focus.sh
@@ -16,9 +16,28 @@ RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/psim-focus-$(date +%Y%m%d-%H%M%S)"}}
 PSIM_CASES=${PSIM_CASES:-"gpu_resident gpu_psim_propagate gpu_resident_psim_phase gpu_resident_hpsi gpu_hpsi_psim_propagate gpu_resident_hpsi_psim_phase"}
+PSIM_ROW_TOP=${PSIM_ROW_TOP:-16}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
 COMBINED="${RUN_ROOT_BASE}-combined.tsv"
 : > "${COMBINED}"
+
+declare -a SUITE_ROOTS=()
+PSIM_ROW_ARGS=(
+  --op-prefix PAW_ORTHO_
+  --op-prefix PAW_ADDOPSI_
+  --op-prefix ACC_COPY_PROP_
+  --op-prefix ACC_PRESENT_PROP_
+  --op-prefix ACC_COPY_ORTHO_
+  --op-prefix ACC_PRESENT_ORTHO_
+  --op-prefix ACC_COPY_ADDOPSI_
+  --op-prefix ACC_PRESENT_ADDOPSI_
+  --op-prefix ACC_COPY_OPSI_
+  --op-prefix ACC_PRESENT_OPSI_
+  --include-zero
+  --sort-by seconds
+)
 
 append_suite() {
   local suite=$1
@@ -46,6 +65,7 @@ run_suite() {
     TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"
+  SUITE_ROOTS+=("${root}")
 }
 
 run_suite "${EMPTY_BANDS}-${GPU_RANKS}r" "${GPU_RANKS}" "${EMPTY_BANDS}" "${TIMEOUT}"
@@ -70,4 +90,49 @@ if [[ -s "${COMBINED}" ]]; then
   python3 "${HERE}/benchmark_compare.py" "${COMBINED}" \
     > "${RUN_ROOT_BASE}-compare.md" || true
   echo "Combined benchmark data: ${COMBINED}"
+fi
+
+if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PSIM_ROW_TOP}" --markdown "${PSIM_ROW_ARGS[@]}" \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_psim_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PSIM_ROW_TOP}" "${PSIM_ROW_ARGS[@]}" \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_psim_rows.tsv" || true
+    echo "Combined PSIM row data: ${RUN_ROOT_BASE}-combined_psim_rows.md"
+  else
+    echo "Combined PSIM row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_transfer_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_transfer_rows.tsv" || true
+    echo "Combined transfer row data: ${RUN_ROOT_BASE}-combined_transfer_rows.md"
+  else
+    echo "Combined transfer row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_present_rows.md"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" \
+      > "${RUN_ROOT_BASE}-combined_present_rows.tsv" || true
+    echo "Combined present row data: ${RUN_ROOT_BASE}-combined_present_rows.md"
+  else
+    echo "Combined present row data: none"
+  fi
 fi


### PR DESCRIPTION
Summary:
- add off-site DENMAT profile-row reports to the offden focus harness
- add PSIM/orthogonalization profile-row reports to the PSIM focus harness
- document the new transfer, present and focus-row artifacts

Validation:
- tests/profile/si64/check_harness.sh