### PR TITLE
Add PSIM lifecycle transfer row reports

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -608,12 +608,14 @@ time-step boundaries before broader cross-step wavefunction residency is enabled
 Because the one-step Si64 reference energy is not valid for multi-step dynamics,
 the fixed energy check is disabled by default for this harness; compare the
 reported energies between cases instead. It writes the normal combined benchmark
-TSV/Markdown plus per-case `ACC_COPY` row summaries from `profile_copy_rows.py`;
-the comparison Markdown reports each GPU-only focus case relative to the
-selected group baseline. The helper also accepts `--op-prefix`, `--op-regex`,
-and `--include-zero` for broader profile-row reports such as
-present/update/timing rows; its size column is `gbyte`, so mixed copy, update,
-and present reports do not imply every selected row is a copy.
+TSV/Markdown plus per-case and combined `ACC_COPY` row summaries from
+`profile_copy_rows.py`; the comparison Markdown reports each GPU-only focus
+case relative to the selected group baseline. It also writes
+`combined_transfer_rows.md`/`.tsv` for `ACC_COPY` plus `ACC_UPDATE` rows and
+`combined_present_rows.md`/`.tsv` for the most frequent resident-buffer checks,
+so lifecycle runs show both the remaining data motion and whether PSIM/OPSI
+buffers are reused across the step boundary. Set `COPY_TOP`,
+`PROFILE_ROW_TOP`, or `PRESENT_ROW_TOP` to widen those reports.
 Override `NSTEPS_LIST`, `EMPTY_BANDS_LIST`, `RUN_SHARED_GPU=yes`,
 `RUN_LARGE_GPU=yes`, or `PSIM_LIFECYCLE_CASES` for wider sweeps.
 

--- a/tests/profile/si64/run_psim_lifecycle.sh
+++ b/tests/profile/si64/run_psim_lifecycle.sh
@@ -15,11 +15,18 @@ RUN_SHARED_GPU=${RUN_SHARED_GPU:-no}
 RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
 COPY_TOP=${COPY_TOP:-8}
+PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-${COPY_TOP}}
+PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-${COPY_TOP}}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/psim-lifecycle-$(date +%Y%m%d-%H%M%S)"}}
 PSIM_LIFECYCLE_CASES=${PSIM_LIFECYCLE_CASES:-"gpu_resident gpu_psim_propagate gpu_resident_psim_phase gpu_resident_hpsi gpu_hpsi_psim_propagate gpu_resident_hpsi_psim_phase"}
 
 COMBINED="${RUN_ROOT_BASE}-combined.tsv"
 COPY_COMBINED="${RUN_ROOT_BASE}-copy-rows.md"
+COPY_COMBINED_TSV="${RUN_ROOT_BASE}-copy-rows.tsv"
+TRANSFER_COMBINED="${RUN_ROOT_BASE}-combined_transfer_rows.md"
+TRANSFER_COMBINED_TSV="${RUN_ROOT_BASE}-combined_transfer_rows.tsv"
+PRESENT_COMBINED="${RUN_ROOT_BASE}-combined_present_rows.md"
+PRESENT_COMBINED_TSV="${RUN_ROOT_BASE}-combined_present_rows.tsv"
 : > "${COMBINED}"
 
 declare -a SUITE_ROOTS=()
@@ -94,7 +101,38 @@ if [[ -s "${COMBINED}" ]]; then
 fi
 
 if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
-  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
-    --markdown "${SUITE_ROOTS[@]}" > "${COPY_COMBINED}" || true
-  echo "Combined copy-row data: ${COPY_COMBINED}"
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
+      --markdown "${SUITE_ROOTS[@]}" > "${COPY_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${COPY_TOP}" \
+      "${SUITE_ROOTS[@]}" > "${COPY_COMBINED_TSV}" || true
+    echo "Combined copy-row data: ${COPY_COMBINED}"
+  else
+    echo "Combined copy-row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" --markdown \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" > "${TRANSFER_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PROFILE_ROW_TOP}" \
+      --op-prefix ACC_COPY --op-prefix ACC_UPDATE \
+      "${SUITE_ROOTS[@]}" > "${TRANSFER_COMBINED_TSV}" || true
+    echo "Combined transfer row data: ${TRANSFER_COMBINED}"
+  else
+    echo "Combined transfer row data: none"
+  fi
+
+  if python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --markdown --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" > "${PRESENT_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case \
+      --top "${PRESENT_ROW_TOP}" --include-zero --sort-by calls \
+      --op-prefix ACC_PRESENT \
+      "${SUITE_ROOTS[@]}" > "${PRESENT_COMBINED_TSV}" || true
+    echo "Combined present row data: ${PRESENT_COMBINED}"
+  else
+    echo "Combined present row data: none"
+  fi
 fi


### PR DESCRIPTION
Summary:
- keep the existing PSIM lifecycle copy-row reports and add TSV companions
- add combined ACC_COPY/ACC_UPDATE transfer-row reports
- add combined ACC_PRESENT reuse reports and document the new artifacts

Validation:
- tests/profile/si64/check_harness.sh