### PR TITLE
Add VPSI combined row TSV reports

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -631,7 +631,7 @@ host-side FFT/RTOG output, then refreshes or creates the device-present `HPSI`
 buffer for the following `WAVES_ADDPRO` consumer. The harness compares
 `gpu_resident_hpsi`, `gpu_resident_hpsi_opsi`, `gpu_resident_stack`, and
 stack-plus-cuFFT variants with `NSTEPS=2` by default and writes combined
-benchmark tables plus selected profile tables for
+benchmark tables plus selected Markdown/TSV profile tables for
 `ACC_COPY`/`ACC_UPDATE`/`ACC_PRESENT` rows, separate seconds-sorted
 `PAW_VPSI_*` timing rows, and separate seconds-sorted `PW_GTOR_*`/`PW_RTOG_*`
 phase rows. Its comparison Markdown reports the stack and cuFFT variants

--- a/tests/profile/si64/run_vpsi_boundary.sh
+++ b/tests/profile/si64/run_vpsi_boundary.sh
@@ -22,8 +22,11 @@ VPSI_BOUNDARY_CASES=${VPSI_BOUNDARY_CASES:-"gpu_resident_hpsi gpu_resident_hpsi_
 
 COMBINED="${RUN_ROOT_BASE}-combined.tsv"
 ROWS_COMBINED="${RUN_ROOT_BASE}-profile-rows.md"
+ROWS_COMBINED_TSV="${RUN_ROOT_BASE}-profile-rows.tsv"
 VPSI_ROWS_COMBINED="${RUN_ROOT_BASE}-vpsi-rows.md"
+VPSI_ROWS_COMBINED_TSV="${RUN_ROOT_BASE}-vpsi-rows.tsv"
 FFT_ROWS_COMBINED="${RUN_ROOT_BASE}-fft-phase-rows.md"
+FFT_ROWS_COMBINED_TSV="${RUN_ROOT_BASE}-fft-phase-rows.tsv"
 : > "${COMBINED}"
 
 declare -a SUITE_ROOTS=()
@@ -131,16 +134,34 @@ if [[ -s "${COMBINED}" ]]; then
 fi
 
 if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
-  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
-    --markdown "${PROFILE_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
-    > "${ROWS_COMBINED}" || true
-  echo "Combined profile-row data: ${ROWS_COMBINED}"
-  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
-    --markdown "${VPSI_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
-    > "${VPSI_ROWS_COMBINED}" || true
-  echo "Combined VPSI-row data: ${VPSI_ROWS_COMBINED}"
-  python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
-    --markdown "${FFT_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
-    > "${FFT_ROWS_COMBINED}" || true
-  echo "Combined FFT phase-row data: ${FFT_ROWS_COMBINED}"
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
+      --markdown "${PROFILE_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${ROWS_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${ROW_TOP}" \
+      "${PROFILE_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${ROWS_COMBINED_TSV}" || true
+    echo "Combined profile-row data: ${ROWS_COMBINED}"
+  else
+    echo "Combined profile-row data: none"
+  fi
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
+      --markdown "${VPSI_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${VPSI_ROWS_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${VPSI_ROW_TOP}" \
+      "${VPSI_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${VPSI_ROWS_COMBINED_TSV}" || true
+    echo "Combined VPSI-row data: ${VPSI_ROWS_COMBINED}"
+  else
+    echo "Combined VPSI-row data: none"
+  fi
+  if python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
+      --markdown "${FFT_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${FFT_ROWS_COMBINED}"; then
+    python3 "${HERE}/profile_copy_rows.py" --per-case --top "${FFT_ROW_TOP}" \
+      "${FFT_ROW_ARGS[@]}" "${SUITE_ROOTS[@]}" \
+      > "${FFT_ROWS_COMBINED_TSV}" || true
+    echo "Combined FFT phase-row data: ${FFT_ROWS_COMBINED}"
+  else
+    echo "Combined FFT phase-row data: none"
+  fi
 fi


### PR DESCRIPTION
Summary:
- add TSV companions for combined VPSI boundary profile-row reports
- keep Markdown output for PR comments
- document the combined Markdown/TSV profile tables

Validation:
- tests/profile/si64/check_harness.sh