### PR TITLE
Refresh gap night GPU cases

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -667,6 +667,20 @@ compares `gpu_resident`, `gpu_resident_nosync`, `gpu_off`, one-rank CPU and
 eight-rank CPU/NVHPC references. It inherits the follow-up benchmark's combined
 comparison, transfer-row, and present-row reports.
 
+For the expensive unresolved large-band gap profile, run:
+
+```
+cd tests/profile/si64
+./run_gap_profile_night.sh
+```
+
+It defaults to `EMPTY_BANDS=2048`, `NSTEPS=3` and GPU-only cases covering the
+current HPSI/OPSI residency candidates, the stacked diagnostic, and the older
+host-side addproduct/projector ablations. Set `RUN_CPU_REFERENCES=yes` to add
+one-rank and eight-rank CPU references. This wrapper delegates to
+`run_nvhpc_standard.sh`, so it writes the same combined benchmark, comparison,
+transfer-row, and present-row reports.
+
 For a short broad GPU exploration suite that includes the opt-in 3-D cuFFT path
 and captures available NVIDIA libraries plus CUDA-aware MPI hints:
 

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -513,8 +513,12 @@ After enabling the GPU-pack path by default, the final 1024-band smoke reported
 
 For the expensive unresolved point, use the dedicated night-run wrapper. It
 defaults to the GPU cases only so the run is not dominated by the known slow
-8-rank CPU reference; add `RUN_CPU_REFERENCES=yes` when CPU reference numbers
-are explicitly needed.
+8-rank CPU reference. The default case list now includes the current HPSI,
+OPSI, and stacked residency candidates, plus the older addproduct/projector
+host-side ablations for continuity. Add `RUN_CPU_REFERENCES=yes` when CPU
+reference numbers are explicitly needed. The wrapper delegates to
+`run_nvhpc_standard.sh`, so it writes the same combined benchmark, comparison,
+transfer-row, and present-row reports.
 
 ```
 cd tests/profile/si64

--- a/tests/profile/si64/run_gap_profile_night.sh
+++ b/tests/profile/si64/run_gap_profile_night.sh
@@ -11,7 +11,7 @@ export TIMEOUT=${TIMEOUT:-43200}
 export GPU_RANKS=${GPU_RANKS:-1}
 export CPU_RANKS=${CPU_RANKS:-8}
 export RUN_GPU_ALL=${RUN_GPU_ALL:-no}
-export GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_addpro_host gpu_resident_pro_host gpu_off"}
+export GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack gpu_resident_addpro_host gpu_resident_pro_host gpu_off"}
 export AUTO_BUILD_TARGETS=${AUTO_BUILD_TARGETS:-no}
 export AUTO_BUILD_JOBS=${AUTO_BUILD_JOBS:-16}
 


### PR DESCRIPTION
Summary:
- add HPSI, OPSI and stacked residency candidates to the large gap night default cases
- keep the older addproduct/projector host-side ablations for continuity
- document that the wrapper inherits standard benchmark, comparison, transfer and present reports

Validation:
- bash -n tests/profile/si64/run_gap_profile_night.sh
- tests/profile/si64/check_harness.sh