### PR TITLE
Add GPU library matrix harness

### DIFF
--- a/tests/profile/README.md
+++ b/tests/profile/README.md
@@ -547,6 +547,20 @@ default.
 Set `AUTO_BUILD_TARGETS=yes` (with `AUTO_BUILD_JOBS`) to automatically build all
 required profile binaries before benchmarking.
 
+Use the full diagnostic sweep only when comparing library combinations:
+
+```
+cd tests/profile/si64
+./run_gpu_library_matrix.sh
+```
+
+It defaults to the same `TEST=si64_bands`, `EMPTY_BANDS=1024`, `NSTEPS=1`
+shape, but expands `GPU_CASES` to include all-library, single-library,
+library-disabled, NVLAMATH/NVBLAS, and memory-mode diagnostics. It delegates to
+`run_nvhpc_standard.sh`, so it writes the same benchmark, comparison,
+transfer-row, and present-row reports. Set `AUTO_BUILD_TARGETS=yes` when the
+optional profile binaries should be built before the sweep.
+
 The Spark C86C Si64 decision table is kept in
 `tests/profile/si64/nvhpc_spark_benchmark_summary.md`.
 

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -18,6 +18,7 @@ bash -n tests/profile/si64/run_gap_profile_night.sh
 bash -n tests/profile/si64/run_large_bands.sh
 bash -n tests/profile/si64/run_large_bands_long.sh
 bash -n tests/profile/si64/run_gpu_exploration.sh
+bash -n tests/profile/si64/run_gpu_library_matrix.sh
 bash -n tests/profile/si64/run_nvhpc_standard.sh
 bash -n tests/profile/si64/run_nsys.sh
 bash -n tests/profile/si64/run_offden_focus.sh

--- a/tests/profile/si64/nvhpc_spark_benchmark_summary.md
+++ b/tests/profile/si64/nvhpc_spark_benchmark_summary.md
@@ -2669,7 +2669,9 @@ Use the full diagnostic sweep only when comparing library combinations:
 
 ```
 cd tests/profile/si64
-TEST=si64_bands EMPTY_BANDS=1024 NSTEPS=1 RUN_GPU_ALL=yes \
-  GPU_CASES="gpu_off gpu_all gpu_all_off gpu_resident gpu_resident_orthox_off gpu_resident_no_cusolver cublas cusolver cufft cufftw nvlamath nvblas gpu_no_cufft gpu_no_cublas gpu_no_cusolver gpu_managed gpu_unified" \
-  ./run_nvhpc_standard.sh
+./run_gpu_library_matrix.sh
 ```
+
+The library-matrix wrapper delegates to `run_nvhpc_standard.sh` with the same
+1024-band, one-step shape and expands the GPU case list to the all-library,
+single-library, library-disabled, NVLAMATH/NVBLAS, and memory-mode diagnostics.

--- a/tests/profile/si64/run_gpu_library_matrix.sh
+++ b/tests/profile/si64/run_gpu_library_matrix.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+export TEST=${TEST:-si64_bands}
+export EMPTY_BANDS=${EMPTY_BANDS:-1024}
+export NSTEPS=${NSTEPS:-1}
+export REPEATS=${REPEATS:-1}
+export TIMEOUT=${TIMEOUT:-7200}
+export GPU_RANKS=${GPU_RANKS:-1}
+export CPU_RANKS=${CPU_RANKS:-8}
+export RUN_GPU_ALL=${RUN_GPU_ALL:-no}
+export GPU_CASES=${GPU_CASES:-"gpu_off gpu_all gpu_all_off gpu_resident gpu_resident_orthox_off gpu_resident_no_cusolver cublas cusolver cufft cufftw nvlamath nvblas gpu_no_cufft gpu_no_cublas gpu_no_cusolver gpu_managed gpu_unified"}
+export CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+export AUTO_BUILD_TARGETS=${AUTO_BUILD_TARGETS:-no}
+export AUTO_BUILD_JOBS=${AUTO_BUILD_JOBS:-16}
+export NVHPC_STANDARD_ROOT=${NVHPC_STANDARD_ROOT:-${GPU_LIBRARY_MATRIX_ROOT:-"${HERE}/runs/${TEST}-gpu-library-matrix-$(date +%Y%m%d-%H%M%S)"}}
+
+mkdir -p "${HERE}/runs"
+echo "${NVHPC_STANDARD_ROOT}" > "${HERE}/runs/latest_gpu_library_matrix"
+
+"${HERE}/run_nvhpc_standard.sh"


### PR DESCRIPTION
Summary:
- add run_gpu_library_matrix.sh for the full library/ablation diagnostic sweep
- delegate to run_nvhpc_standard.sh so benchmark, comparison, transfer and present reports stay consistent
- document the wrapper in the README and Spark benchmark summary

Validation:
- tests/profile/si64/check_harness.sh
- git diff --check