### PR TITLE
Add benchmark dry-run metadata mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ not apply to the present implementation.)
    ```
    To force all native paths for diagnostics, add `CPPAW_CUFFT_ACC=1` and
    `CPPAW_CUSOLVER_ACC_MIN_N=1`.
+   To inspect a benchmark matrix without starting CP-PAW runs, use the dry-run
+   mode. It writes `metadata.txt` with the executable, MPI launcher, runtime
+   environment, and accelerator case variables for each selected case:
+   ```
+   cd tests/profile/si64
+   DRY_RUN=yes CASES="gpu_resident_stack gpu_no_cufft" ./run_benchmark.sh
+   ```
    For explicit cuSOLVER/OpenACC dense eigensolver profiling:
    ```
    cd tests/profile/si64

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -40,6 +40,18 @@ python3 -m py_compile \
 
 python3 tests/profile/si64/check_benchmark_tools.py
 
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+DRY_RUN=yes \
+  RUN_ROOT="${tmpdir}/dry-run" \
+  CASES="gpu_resident_stack gpu_no_cufft" \
+  tests/profile/si64/run_benchmark.sh > "${tmpdir}/dry-run.out"
+grep -q "Benchmark dry-run metadata:" "${tmpdir}/dry-run.out"
+grep -q "case=gpu_resident_stack" "${tmpdir}/dry-run/metadata.txt"
+grep -q "case_env=CPPAW_GPU_RESIDENCY_STACK=1" "${tmpdir}/dry-run/metadata.txt"
+grep -q "case=gpu_no_cufft" "${tmpdir}/dry-run/metadata.txt"
+grep -q "case_env=CPPAW_CUFFT_ACC=0" "${tmpdir}/dry-run/metadata.txt"
+
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc
 test -f tests/profile/si64/si64_bands.cntl

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -14,6 +14,7 @@ RANKS=${RANKS:-1}
 REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-1800}
 REQUIRE_CASES=${REQUIRE_CASES:-no}
+DRY_RUN=${DRY_RUN:-no}
 RUN_ROOT=${RUN_ROOT:-"${HERE}/runs/${TEST}-nstep${NSTEPS}-${RANKS}ranks-$(date +%Y%m%d-%H%M%S)"}
 MPI_ARGS=${MPI_ARGS:---mca coll ^hcoll}
 CASES=${CASES:-"cpu nvhpc_cpu gpu_resident gpu_off"}
@@ -34,8 +35,13 @@ if [[ -z "${TIME_CMD}" ]]; then
   fi
 fi
 if [[ -z "${TIME_CMD}" ]]; then
-  echo "External time command not found; set TIME_CMD or install GNU time." >&2
-  exit 1
+  case "${DRY_RUN}" in
+    yes|true|1) ;;
+    *)
+      echo "External time command not found; set TIME_CMD or install GNU time." >&2
+      exit 1
+      ;;
+  esac
 fi
 
 case "${EXPECTED_ENERGY}" in
@@ -694,8 +700,11 @@ capture_metadata() {
       [[ -n "${note}" ]] && echo "note=${note}"
       extra_env=$(inherited_accel_env)
       [[ -n "${extra_env}" ]] && echo "inherited_accel_env=${extra_env}"
+      runtime_env=$(case_runtime_env "${case_name}" "${exe}")
+      [[ -n "${runtime_env}" ]] && echo "runtime_env=${runtime_env}"
+      case_env_line=$(case_env "${case_name}")
+      [[ -n "${case_env_line}" ]] && echo "case_env=${case_env_line}"
       if [[ -x "${exe}" ]]; then
-        runtime_env=$(case_runtime_env "${case_name}" "${exe}")
         if [[ -n "${runtime_env}" ]]; then
           # shellcheck disable=SC2086
           env ${runtime_env} ldd "${exe}" 2>/dev/null | grep -E "blas|lapack|fftw|cufft|cusolver|cublas|nvpl|openblas|libmpi" || true
@@ -710,9 +719,15 @@ capture_metadata() {
   } > "${RUN_ROOT}/metadata.txt" 2>&1
 }
 
-mkdir -p "${RUN_ROOT}"
+mkdir -p "${RUN_ROOT}" "${HERE}/runs"
 echo "${RUN_ROOT}" > "${HERE}/runs/latest"
 capture_metadata
+case "${DRY_RUN}" in
+  yes|true|1)
+    echo "Benchmark dry-run metadata: ${RUN_ROOT}"
+    exit 0
+    ;;
+esac
 
 for case_name in ${CASES}; do
   exe=$(if [[ "${RANKS}" -gt 1 ]]; then parallel_exe "${case_name}"; else serial_exe "${case_name}"; fi)


### PR DESCRIPTION
## Summary
- add `DRY_RUN=yes` to `tests/profile/si64/run_benchmark.sh` so benchmark matrices can be inspected without starting CP-PAW jobs
- record each case's runtime environment and accelerator `case_env` in `metadata.txt`
- cover the dry-run metadata path in `check_harness.sh` and document the mode in the README

## Tests
- `DRY_RUN=yes RUN_ROOT=$(mktemp -d)/dry CASES="gpu_resident_stack gpu_no_cufft" tests/profile/si64/run_benchmark.sh`
- `tests/profile/si64/check_harness.sh`
- `git diff --check`