### PR TITLE
Show planned commands in benchmark dry runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ not apply to the present implementation.)
    `CPPAW_CUSOLVER_ACC_MIN_N=1`.
    To inspect a benchmark matrix without starting CP-PAW runs, use the dry-run
    mode. It writes `metadata.txt` with the executable, MPI launcher, runtime
-   environment, and accelerator case variables for each selected case:
+   environment, accelerator case variables, and planned command line for each
+   selected case:
    ```
    cd tests/profile/si64
    DRY_RUN=yes CASES="gpu_resident_stack gpu_no_cufft" ./run_benchmark.sh

--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -49,8 +49,10 @@ DRY_RUN=yes \
 grep -q "Benchmark dry-run metadata:" "${tmpdir}/dry-run.out"
 grep -q "case=gpu_resident_stack" "${tmpdir}/dry-run/metadata.txt"
 grep -q "case_env=CPPAW_GPU_RESIDENCY_STACK=1" "${tmpdir}/dry-run/metadata.txt"
+grep -q "planned_full_command=.*CPPAW_GPU_RESIDENCY_STACK=1" "${tmpdir}/dry-run/metadata.txt"
 grep -q "case=gpu_no_cufft" "${tmpdir}/dry-run/metadata.txt"
 grep -q "case_env=CPPAW_CUFFT_ACC=0" "${tmpdir}/dry-run/metadata.txt"
+grep -q "planned_full_command=.*CPPAW_CUFFT_ACC=0" "${tmpdir}/dry-run/metadata.txt"
 
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -704,6 +704,17 @@ capture_metadata() {
       [[ -n "${runtime_env}" ]] && echo "runtime_env=${runtime_env}"
       case_env_line=$(case_env "${case_name}")
       [[ -n "${case_env_line}" ]] && echo "case_env=${case_env_line}"
+      env_line=$(combined_env "${extra_env}" "${runtime_env}" "${case_env_line}")
+      [[ -n "${env_line}" ]] && echo "planned_env=${env_line}"
+      cmd=$(run_command "${case_name}" "${exe}")
+      echo "planned_command=${cmd}"
+      time_part="${TIME_CMD:+${TIME_CMD} -p }"
+      timeout_part="${TIMEOUT_PREFIX:+${TIMEOUT_PREFIX} }"
+      if [[ -n "${env_line}" ]]; then
+        echo "planned_full_command=${time_part}env CPPAW_ACCEL_PROFILE_FILE=${case_name}_profile ${env_line} ${timeout_part}${cmd}"
+      else
+        echo "planned_full_command=${time_part}env CPPAW_ACCEL_PROFILE_FILE=${case_name}_profile ${timeout_part}${cmd}"
+      fi
       if [[ -x "${exe}" ]]; then
         if [[ -n "${runtime_env}" ]]; then
           # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary
- add `planned_command` and `planned_full_command` entries to benchmark dry-run metadata
- include the combined accelerator/runtime environment in the dry-run command preview
- extend the harness smoke test and README text to cover the command preview

## Tests
- `DRY_RUN=yes RUN_ROOT=$(mktemp -d)/dry CASES="gpu_resident_stack gpu_no_cufft" tests/profile/si64/run_benchmark.sh`
- `tests/profile/si64/check_harness.sh`
- `git diff --check`