### PR TITLE
Honor required cases in benchmark dry runs

### DIFF
--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -54,6 +54,22 @@ grep -q "case=gpu_no_cufft" "${tmpdir}/dry-run/metadata.txt"
 grep -q "case_env=CPPAW_CUFFT_ACC=0" "${tmpdir}/dry-run/metadata.txt"
 grep -q "planned_full_command=.*CPPAW_CUFFT_ACC=0" "${tmpdir}/dry-run/metadata.txt"
 
+set +e
+DRY_RUN=yes \
+  REQUIRE_CASES=yes \
+  RUN_ROOT="${tmpdir}/dry-run-required" \
+  CASES="gpu_resident_stack" \
+  tests/profile/si64/run_benchmark.sh > "${tmpdir}/dry-run-required.out" 2>&1
+dry_run_required_status=$?
+set -e
+if grep -q "^missing$" "${tmpdir}/dry-run-required/metadata.txt"; then
+  test "${dry_run_required_status}" -ne 0
+  grep -q "Required benchmark cases missing executable:" \
+    "${tmpdir}/dry-run-required.out"
+else
+  test "${dry_run_required_status}" -eq 0
+fi
+
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc
 test -f tests/profile/si64/si64_bands.cntl

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -674,6 +674,7 @@ prepare_case() {
 }
 
 capture_metadata() {
+  local missing_cases=0
   {
     echo "date=$(iso_now)"
     echo "hostname=$(hostname)"
@@ -724,10 +725,19 @@ capture_metadata() {
         fi
       else
         echo "missing"
+        missing_cases=$((missing_cases+1))
       fi
       echo
     done
   } > "${RUN_ROOT}/metadata.txt" 2>&1
+  if [[ "${missing_cases}" -gt 0 \
+      && ( "${REQUIRE_CASES}" == "yes" \
+           || "${REQUIRE_CASES}" == "true" \
+           || "${REQUIRE_CASES}" == "1" ) ]]; then
+    echo "Required benchmark cases missing executable: ${missing_cases}" >&2
+    echo "See ${RUN_ROOT}/metadata.txt for case details." >&2
+    return 1
+  fi
 }
 
 mkdir -p "${RUN_ROOT}" "${HERE}/runs"


### PR DESCRIPTION
## Summary
- make `DRY_RUN=yes REQUIRE_CASES=yes` fail when selected benchmark cases have missing executables
- keep writing `metadata.txt` so the missing case and planned command remain inspectable
- cover both dry-run metadata and required-case behavior in `check_harness.sh`

## Tests
- `DRY_RUN=yes REQUIRE_CASES=yes RUN_ROOT=$(mktemp -d)/dry CASES="gpu_resident_stack" tests/profile/si64/run_benchmark.sh`
- `tests/profile/si64/check_harness.sh`
- `git diff --check`