### PR TITLE
Enable standard benchmark dry-run preflight

### DIFF
--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -70,6 +70,25 @@ else
   test "${dry_run_required_status}" -eq 0
 fi
 
+set +e
+DRY_RUN=yes \
+  NVHPC_STANDARD_ROOT="${tmpdir}/standard-dry-run" \
+  GPU_CASES="gpu_resident_stack" \
+  CPU_CASES="" \
+  tests/profile/si64/run_nvhpc_standard.sh > "${tmpdir}/standard-dry-run.out" 2>&1
+standard_dry_run_status=$?
+set -e
+grep -q "DRY-RUN skip pre-build binary check" \
+  "${tmpdir}/standard-dry-run/nvhpc_standard.log"
+grep -q "planned_full_command=.*CPPAW_GPU_RESIDENCY_STACK=1" \
+  "${tmpdir}/standard-dry-run/gpu_1rank/metadata.txt"
+if grep -q "^missing$" "${tmpdir}/standard-dry-run/gpu_1rank/metadata.txt"; then
+  test "${standard_dry_run_status}" -ne 0
+  grep -q "FAILED suites=" "${tmpdir}/standard-dry-run/nvhpc_standard.log"
+else
+  test "${standard_dry_run_status}" -eq 0
+fi
+
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc
 test -f tests/profile/si64/si64_bands.cntl

--- a/tests/profile/si64/run_nvhpc_standard.sh
+++ b/tests/profile/si64/run_nvhpc_standard.sh
@@ -12,6 +12,7 @@ TIMEOUT=${TIMEOUT:-7200}
 GPU_RANKS=${GPU_RANKS:-1}
 CPU_RANKS=${CPU_RANKS:-8}
 RUN_GPU_ALL=${RUN_GPU_ALL:-no}
+DRY_RUN=${DRY_RUN:-no}
 GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack gpu_resident_orthox_off gpu_resident_addpro_host gpu_resident_pro_host gpu_resident_invbatch_off gpu_resident_no_cusolver"}
 CPU_CASES=${CPU_CASES-"cpu nvhpc_cpu"}
 AUTO_BUILD_TARGETS=${AUTO_BUILD_TARGETS:-no}
@@ -230,6 +231,7 @@ LOG="${NVHPC_STANDARD_ROOT}/nvhpc_standard.log"
 : > "${LOG}"
 
 declare -a SUITE_ROOTS=()
+FAILED_SUITES=0
 
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOG}"
@@ -270,6 +272,7 @@ run_suite() {
     local status=$?
     log "FAIL  suite=${suite} status=${status}"
     echo "${status}" > "${root}.status"
+    FAILED_SUITES=$((FAILED_SUITES+1))
   fi
   append_suite "${suite}" "${root}/benchmark.tsv"
   SUITE_ROOTS+=("${root}")
@@ -278,7 +281,14 @@ run_suite() {
 collect_targets "${GPU_RANKS}" "${GPU_CASES}"
 collect_targets "1" "${CPU_CASES}"
 collect_targets "${CPU_RANKS}" "${CPU_CASES}"
-ensure_binaries
+case "${DRY_RUN}" in
+  yes|true|1)
+    log "DRY-RUN skip pre-build binary check; suite metadata records missing executables"
+    ;;
+  *)
+    ensure_binaries
+    ;;
+esac
 
 run_suite "gpu_${GPU_RANKS}rank" "${GPU_RANKS}" "${GPU_CASES}"
 run_suite "cpu_1rank" 1 "${CPU_CASES}"
@@ -323,4 +333,11 @@ if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
   else
     log "present_rows=none"
   fi
+fi
+
+if (( FAILED_SUITES > 0 )); then
+  log "FAILED suites=${FAILED_SUITES}"
+  case "${DRY_RUN}" in
+    yes|true|1) exit 1 ;;
+  esac
 fi


### PR DESCRIPTION
## Summary
- let `run_nvhpc_standard.sh` honor `DRY_RUN=yes` by skipping the early binary precheck
- route dry-run suites through `run_benchmark.sh` so per-suite `metadata.txt` records planned commands and missing executables
- return nonzero for dry-run suites with missing required cases while keeping metadata inspectable

## Tests
- `DRY_RUN=yes NVHPC_STANDARD_ROOT=$(mktemp -d)/std GPU_CASES="gpu_resident_stack" CPU_CASES="" tests/profile/si64/run_nvhpc_standard.sh`
- `tests/profile/si64/check_harness.sh`
- `git diff --check`