### PR TITLE
Add dry-run preflight to focus benchmarks

### DIFF
--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -131,6 +131,54 @@ else
   test "${exploration_dry_run_status}" -eq 0
 fi
 
+set +e
+DRY_RUN=yes \
+  FOLLOWUP_ROOT="${tmpdir}/followup-dry-run" \
+  NSTEPS_LIST=1 \
+  EMPTY_BANDS_LIST=128 \
+  GPU_CASES="gpu_resident_stack" \
+  ONE_RANK_CPU_CASES="" \
+  CPU_CASES="" \
+  tests/profile/si64/run_followup.sh > "${tmpdir}/followup-dry-run.out" 2>&1
+followup_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_GPU_RESIDENCY_STACK=1" \
+  "${tmpdir}/followup-dry-run/empty128_nstep1_1rank_gpu/metadata.txt"
+grep -q "SKIP  suite=empty128_nstep1_1rank_cpu empty case list" \
+  "${tmpdir}/followup-dry-run/followup.log"
+test ! -e "${tmpdir}/followup-dry-run/empty128_nstep1_1rank_cpu/metadata.txt"
+test ! -e "${tmpdir}/followup-dry-run/empty128_nstep1_8rank_cpu_ref/metadata.txt"
+if grep -q "^missing$" \
+    "${tmpdir}/followup-dry-run/empty128_nstep1_1rank_gpu/metadata.txt"; then
+  test "${followup_dry_run_status}" -ne 0
+  grep -q "FAILED suites=" "${tmpdir}/followup-dry-run/followup.log"
+else
+  test "${followup_dry_run_status}" -eq 0
+fi
+
+set +e
+DRY_RUN=yes \
+  CUSOLVER_FOCUS_ROOT="${tmpdir}/cusolver-dry-run" \
+  EMPTY_BANDS_LIST=128 \
+  CUSOLVER_CASES="cusolver_generalized" \
+  CPU_CASES="" \
+  tests/profile/si64/run_cusolver_focus.sh > "${tmpdir}/cusolver-dry-run.out" 2>&1
+cusolver_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_CUSOLVER_ACC_GENERALIZED_MIN_N=1" \
+  "${tmpdir}/cusolver-dry-run/empty128_1rank_cusolver/metadata.txt"
+grep -q "SKIP  suite=empty128_1rank_cpu empty case list" \
+  "${tmpdir}/cusolver-dry-run/cusolver_focus.log"
+test ! -e "${tmpdir}/cusolver-dry-run/empty128_1rank_cpu/metadata.txt"
+test ! -e "${tmpdir}/cusolver-dry-run/empty128_8rank_cpu_ref/metadata.txt"
+if grep -q "^missing$" \
+    "${tmpdir}/cusolver-dry-run/empty128_1rank_cusolver/metadata.txt"; then
+  test "${cusolver_dry_run_status}" -ne 0
+  grep -q "FAILED suites=" "${tmpdir}/cusolver-dry-run/cusolver_focus.log"
+else
+  test "${cusolver_dry_run_status}" -eq 0
+fi
+
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc
 test -f tests/profile/si64/si64_bands.cntl

--- a/tests/profile/si64/run_cusolver_focus.sh
+++ b/tests/profile/si64/run_cusolver_focus.sh
@@ -10,8 +10,9 @@ TIMEOUT=${TIMEOUT:-7200}
 EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-"128 256 512"}
 GPU_RANKS=${GPU_RANKS:-1}
 CPU_RANKS=${CPU_RANKS:-8}
+DRY_RUN=${DRY_RUN:-no}
 CUSOLVER_CASES=${CUSOLVER_CASES:-"cusolver cusolver_generalized cusolver_generalized_conservative cusolver_off"}
-CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+CPU_CASES=${CPU_CASES-"cpu nvhpc_cpu"}
 SOLVER_ROW_TOP=${SOLVER_ROW_TOP:-16}
 PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
 PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
@@ -24,9 +25,17 @@ LOG="${CUSOLVER_FOCUS_ROOT}/cusolver_focus.log"
 : > "${LOG}"
 
 declare -a SUITE_ROOTS=()
+FAILED_SUITES=0
 
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOG}"
+}
+
+require_cases_for_suite() {
+  case "${DRY_RUN}" in
+    yes|true|1) echo yes ;;
+    *) echo no ;;
+  esac
 }
 
 append_suite() {
@@ -48,17 +57,27 @@ run_suite() {
   local cases=$4
   local root="${CUSOLVER_FOCUS_ROOT}/${suite}"
   local suite_log="${CUSOLVER_FOCUS_ROOT}/${suite}.log"
+  local require_cases
 
+  if [[ -z ${cases// } ]]; then
+    log "SKIP  suite=${suite} empty case list"
+    echo "skipped" > "${root}.status"
+    return 0
+  fi
+
+  require_cases=$(require_cases_for_suite)
   log "START suite=${suite} empty_bands=${empty_bands} ranks=${ranks} cases=${cases}"
   if env TEST="${TEST}" EMPTY_BANDS="${empty_bands}" NSTEPS="${NSTEPS}" \
       RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${cases}" TIMEOUT="${TIMEOUT}" \
-      RUN_ROOT="${root}" "${HERE}/run_benchmark.sh" > "${suite_log}" 2>&1; then
+      DRY_RUN="${DRY_RUN}" REQUIRE_CASES="${require_cases}" RUN_ROOT="${root}" \
+      "${HERE}/run_benchmark.sh" > "${suite_log}" 2>&1; then
     log "DONE  suite=${suite}"
     echo 0 > "${root}.status"
   else
     local status=$?
     log "FAIL  suite=${suite} status=${status}"
     echo "${status}" > "${root}.status"
+    FAILED_SUITES=$((FAILED_SUITES+1))
   fi
   append_suite "${suite}" "${root}/benchmark.tsv"
   SUITE_ROOTS+=("${root}")
@@ -127,4 +146,11 @@ if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
   else
     log "present_rows=none"
   fi
+fi
+
+if (( FAILED_SUITES > 0 )); then
+  log "FAILED suites=${FAILED_SUITES}"
+  case "${DRY_RUN}" in
+    yes|true|1) exit 1 ;;
+  esac
 fi

--- a/tests/profile/si64/run_followup.sh
+++ b/tests/profile/si64/run_followup.sh
@@ -11,9 +11,10 @@ REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-7200}
 EMPTY_BANDS=${EMPTY_BANDS:-128}
 EMPTY_BANDS_LIST=${EMPTY_BANDS_LIST:-${EMPTY_BANDS}}
+DRY_RUN=${DRY_RUN:-no}
 GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_stack gpu_resident_nosync gpu gpu_off"}
-CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
-ONE_RANK_CPU_CASES=${ONE_RANK_CPU_CASES:-"cpu nvhpc_cpu"}
+CPU_CASES=${CPU_CASES-"cpu nvhpc_cpu"}
+ONE_RANK_CPU_CASES=${ONE_RANK_CPU_CASES-"cpu nvhpc_cpu"}
 PROFILE_ROW_TOP=${PROFILE_ROW_TOP:-16}
 PRESENT_ROW_TOP=${PRESENT_ROW_TOP:-16}
 
@@ -25,6 +26,7 @@ SUMMARY_LOG="${FOLLOWUP_ROOT}/followup.log"
 : > "${SUMMARY_LOG}"
 
 declare -a SUITE_ROOTS=()
+FAILED_SUITES=0
 
 log() {
   printf '%s %s\n' "$(iso_now)" "$*" | tee -a "${SUMMARY_LOG}"
@@ -32,6 +34,13 @@ log() {
 
 iso_now() {
   date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+require_cases_for_suite() {
+  case "${DRY_RUN}" in
+    yes|true|1) echo yes ;;
+    *) echo no ;;
+  esac
 }
 
 append_suite() {
@@ -54,11 +63,20 @@ run_suite() {
   shift 4
   local suite_root="${FOLLOWUP_ROOT}/${suite}"
   local suite_log="${FOLLOWUP_ROOT}/${suite}.log"
+  local require_cases
 
+  if [[ -z ${cases// } ]]; then
+    log "SKIP  suite=${suite} empty case list"
+    echo "skipped" > "${suite_root}.status"
+    return 0
+  fi
+
+  require_cases=$(require_cases_for_suite)
   log "START suite=${suite} nsteps=${nsteps} ranks=${ranks} cases=${cases} env=[$*]"
   if env TEST="${TEST}" EMPTY_BANDS="${EMPTY_BANDS}" NSTEPS="${nsteps}" \
       RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${cases}" TIMEOUT="${TIMEOUT}" \
-      RUN_ROOT="${suite_root}" "$@" "${HERE}/run_benchmark.sh" \
+      DRY_RUN="${DRY_RUN}" REQUIRE_CASES="${require_cases}" RUN_ROOT="${suite_root}" \
+      "$@" "${HERE}/run_benchmark.sh" \
       > "${suite_log}" 2>&1; then
     log "DONE  suite=${suite}"
     echo 0 > "${suite_root}.status"
@@ -66,6 +84,7 @@ run_suite() {
     local status=$?
     log "FAIL  suite=${suite} status=${status}"
     echo "${status}" > "${suite_root}.status"
+    FAILED_SUITES=$((FAILED_SUITES+1))
   fi
   append_suite "${suite}" "${suite_root}/benchmark.tsv"
   SUITE_ROOTS+=("${suite_root}")
@@ -121,4 +140,11 @@ if [[ "${#SUITE_ROOTS[@]}" -gt 0 ]]; then
   else
     log "present_rows=none"
   fi
+fi
+
+if (( FAILED_SUITES > 0 )); then
+  log "FAILED suites=${FAILED_SUITES}"
+  case "${DRY_RUN}" in
+    yes|true|1) exit 1 ;;
+  esac
 fi

--- a/tests/profile/si64/run_large_bands.sh
+++ b/tests/profile/si64/run_large_bands.sh
@@ -11,8 +11,8 @@ export REPEATS=${REPEATS:-1}
 export GPU_RANKS=${GPU_RANKS:-1}
 export CPU_RANKS=${CPU_RANKS:-8}
 export GPU_CASES=${GPU_CASES:-"gpu_resident gpu_resident_hpsi gpu_resident_hpsi_opsi gpu_resident_stack gpu_resident_addpro_host gpu_resident_pro_host gpu_resident_nosync gpu gpu_off"}
-export ONE_RANK_CPU_CASES=${ONE_RANK_CPU_CASES:-"cpu nvhpc_cpu"}
-export CPU_CASES=${CPU_CASES:-"cpu nvhpc_cpu"}
+export ONE_RANK_CPU_CASES=${ONE_RANK_CPU_CASES-"cpu nvhpc_cpu"}
+export CPU_CASES=${CPU_CASES-"cpu nvhpc_cpu"}
 
 case "${RUN_GPU_ALL:-no}" in
   yes|true|1) export GPU_CASES="${GPU_CASES} gpu_all gpu_all_off" ;;


### PR DESCRIPTION
## Summary
- add dry-run preflight handling to follow-up and cuSOLVER focus benchmark wrappers
- honor explicitly empty CPU case selections in follow-up, cuSOLVER focus, and large-band wrapper paths
- extend the SI64 harness with focused dry-run coverage for those wrappers

## Tests
- `tests/profile/si64/check_harness.sh`
- `git diff --check`