### PR TITLE
Cover specialized GPU dry-run smokes

### DIFF
--- a/tests/profile/si64/check_harness.sh
+++ b/tests/profile/si64/check_harness.sh
@@ -179,6 +179,80 @@ else
   test "${cusolver_dry_run_status}" -eq 0
 fi
 
+set +e
+DRY_RUN=yes \
+  RUN_ROOT_BASE="${tmpdir}/offden-dry-run" \
+  OFFDEN_CASES="gpu_resident_hpsi_offden_cublas_devicepack" \
+  EMPTY_BANDS=128 \
+  RUN_SHARED_GPU=no \
+  tests/profile/si64/run_offden_focus.sh > "${tmpdir}/offden-dry-run.out" 2>&1
+offden_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_GPU_OFFDEN_DEVICE_PACK=1" \
+  "${tmpdir}/offden-dry-run-128-1r/metadata.txt"
+if grep -q "^missing$" "${tmpdir}/offden-dry-run-128-1r/metadata.txt"; then
+  test "${offden_dry_run_status}" -ne 0
+else
+  test "${offden_dry_run_status}" -eq 0
+fi
+
+set +e
+DRY_RUN=yes \
+  RUN_ROOT_BASE="${tmpdir}/psim-focus-dry-run" \
+  PSIM_CASES="gpu_resident_hpsi_opsi_psim_phase" \
+  EMPTY_BANDS=128 \
+  RUN_SHARED_GPU=no \
+  RUN_LARGE_GPU=no \
+  tests/profile/si64/run_psim_focus.sh > "${tmpdir}/psim-focus-dry-run.out" 2>&1
+psim_focus_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_GPU_PSIM_PHASE_RESIDENCY=1" \
+  "${tmpdir}/psim-focus-dry-run-128-1r/metadata.txt"
+if grep -q "^missing$" "${tmpdir}/psim-focus-dry-run-128-1r/metadata.txt"; then
+  test "${psim_focus_dry_run_status}" -ne 0
+else
+  test "${psim_focus_dry_run_status}" -eq 0
+fi
+
+set +e
+DRY_RUN=yes \
+  RUN_ROOT_BASE="${tmpdir}/psim-lifecycle-dry-run" \
+  PSIM_LIFECYCLE_CASES="gpu_resident_hpsi_opsi_psim_phase" \
+  NSTEPS_LIST=1 \
+  EMPTY_BANDS_LIST=128 \
+  RUN_SHARED_GPU=no \
+  RUN_LARGE_GPU=no \
+  tests/profile/si64/run_psim_lifecycle.sh > "${tmpdir}/psim-lifecycle-dry-run.out" 2>&1
+psim_lifecycle_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_GPU_PSIM_PHASE_RESIDENCY=1" \
+  "${tmpdir}/psim-lifecycle-dry-run-empty128-nstep1-1r/metadata.txt"
+if grep -q "^missing$" \
+    "${tmpdir}/psim-lifecycle-dry-run-empty128-nstep1-1r/metadata.txt"; then
+  test "${psim_lifecycle_dry_run_status}" -ne 0
+else
+  test "${psim_lifecycle_dry_run_status}" -eq 0
+fi
+
+set +e
+DRY_RUN=yes \
+  RUN_ROOT_BASE="${tmpdir}/vpsi-dry-run" \
+  VPSI_BOUNDARY_CASES="gpu_resident_stack_cufft_force" \
+  NSTEPS_LIST=1 \
+  EMPTY_BANDS_LIST=128 \
+  RUN_SHARED_GPU=no \
+  RUN_LARGE_GPU=no \
+  tests/profile/si64/run_vpsi_boundary.sh > "${tmpdir}/vpsi-dry-run.out" 2>&1
+vpsi_dry_run_status=$?
+set -e
+grep -q "planned_full_command=.*CPPAW_CUFFT_ACC_MIN_ELEMENTS=0" \
+  "${tmpdir}/vpsi-dry-run-empty128-nstep1-1r/metadata.txt"
+if grep -q "^missing$" "${tmpdir}/vpsi-dry-run-empty128-nstep1-1r/metadata.txt"; then
+  test "${vpsi_dry_run_status}" -ne 0
+else
+  test "${vpsi_dry_run_status}" -eq 0
+fi
+
 test -f tests/profile/si64/si64.cntl
 test -f tests/profile/si64/si64.strc
 test -f tests/profile/si64/si64_bands.cntl

--- a/tests/profile/si64/run_benchmark.sh
+++ b/tests/profile/si64/run_benchmark.sh
@@ -361,10 +361,10 @@ case_note() {
       echo "Focused residency stack keyword: HPSI, OPSI, PROJ, DENMAT energy, and off-site device-pack accumulation."
       ;;
     gpu_resident_stack_cufft)
-      echo "Focused residency stack plus threshold-gated native cuFFT for LIB\\$FFTC8 calls."
+      echo "Focused residency stack plus threshold-gated native cuFFT for LIB\$FFTC8 calls."
       ;;
     gpu_resident_stack_cufft_force)
-      echo "Focused residency stack plus force-all native cuFFT for LIB\\$FFTC8 calls."
+      echo "Focused residency stack plus force-all native cuFFT for LIB\$FFTC8 calls."
       ;;
     gpu_resident_hpsi_opsi_denmat_energy_offden_cublas_devicepack_proj_accum)
       echo "Full residency diagnostic combining HPSI, OPSI, DENMAT energy, persistent THIS%PROJ, and off-site device-pack accumulation."

--- a/tests/profile/si64/run_offden_focus.sh
+++ b/tests/profile/si64/run_offden_focus.sh
@@ -11,6 +11,7 @@ GPU_RANKS=${GPU_RANKS:-1}
 SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
 REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-720}
+DRY_RUN=${DRY_RUN:-no}
 RUN_SHARED_GPU=${RUN_SHARED_GPU:-yes}
 RUN_ROOT_BASE=${RUN_ROOT_BASE:-${RUN_ROOT:-"${HERE}/runs/offden-focus-$(date +%Y%m%d-%H%M%S)"}}
 OFFDEN_CASES=${OFFDEN_CASES:-"gpu_resident_hpsi_offden_cublas_devicepack gpu_resident_hpsi_offden_cublas_devicepack_accum gpu_resident_hpsi_offden_cublas_devicepack_proj gpu_resident_hpsi_offden_cublas_devicepack_proj_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_accum gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj gpu_resident_hpsi_denmat_energy_offden_cublas_devicepack_proj_accum"}
@@ -52,7 +53,8 @@ run_suite() {
   echo "Running off-site DENMAT focus suite: ${label}"
   TEST="${TEST}" NSTEPS="${NSTEPS}" EMPTY_BANDS="${empty_bands}" \
     RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${OFFDEN_CASES}" \
-    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" DRY_RUN="${DRY_RUN}" \
+    REQUIRE_CASES="yes" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"
   SUITE_ROOTS+=("${root}")

--- a/tests/profile/si64/run_psim_focus.sh
+++ b/tests/profile/si64/run_psim_focus.sh
@@ -11,6 +11,7 @@ GPU_RANKS=${GPU_RANKS:-1}
 SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
 REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-720}
+DRY_RUN=${DRY_RUN:-no}
 RUN_SHARED_GPU=${RUN_SHARED_GPU:-yes}
 RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
@@ -62,7 +63,8 @@ run_suite() {
   echo "Running PSIM propagation focus suite: ${label}"
   TEST="${TEST}" NSTEPS="${NSTEPS}" EMPTY_BANDS="${empty_bands}" \
     RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${PSIM_CASES}" \
-    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" DRY_RUN="${DRY_RUN}" \
+    REQUIRE_CASES="yes" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"
   SUITE_ROOTS+=("${root}")

--- a/tests/profile/si64/run_psim_lifecycle.sh
+++ b/tests/profile/si64/run_psim_lifecycle.sh
@@ -11,6 +11,7 @@ SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
 SHARED_EMPTY_BANDS=${SHARED_EMPTY_BANDS:-512}
 REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-900}
+DRY_RUN=${DRY_RUN:-no}
 RUN_SHARED_GPU=${RUN_SHARED_GPU:-no}
 RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
@@ -55,7 +56,8 @@ run_suite() {
   echo "Running PSIM lifecycle suite: ${label}"
   TEST="${TEST}" NSTEPS="${nsteps}" EMPTY_BANDS="${empty_bands}" \
     RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${PSIM_LIFECYCLE_CASES}" \
-    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" DRY_RUN="${DRY_RUN}" \
+    REQUIRE_CASES="yes" \
     ENERGY_CHECK="${ENERGY_CHECK:-no}" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"

--- a/tests/profile/si64/run_vpsi_boundary.sh
+++ b/tests/profile/si64/run_vpsi_boundary.sh
@@ -11,6 +11,7 @@ SHARED_GPU_RANKS=${SHARED_GPU_RANKS:-4}
 SHARED_EMPTY_BANDS=${SHARED_EMPTY_BANDS:-512}
 REPEATS=${REPEATS:-1}
 TIMEOUT=${TIMEOUT:-900}
+DRY_RUN=${DRY_RUN:-no}
 RUN_SHARED_GPU=${RUN_SHARED_GPU:-no}
 RUN_LARGE_GPU=${RUN_LARGE_GPU:-no}
 LARGE_EMPTY_BANDS=${LARGE_EMPTY_BANDS:-2048}
@@ -72,7 +73,8 @@ run_suite() {
   echo "Running VPSI boundary suite: ${label}"
   TEST="${TEST}" NSTEPS="${nsteps}" EMPTY_BANDS="${empty_bands}" \
     RANKS="${ranks}" REPEATS="${REPEATS}" CASES="${VPSI_BOUNDARY_CASES}" \
-    TIMEOUT="${timeout}" RUN_ROOT="${root}" REQUIRE_CASES="yes" \
+    TIMEOUT="${timeout}" RUN_ROOT="${root}" DRY_RUN="${DRY_RUN}" \
+    REQUIRE_CASES="yes" \
     ENERGY_CHECK="${ENERGY_CHECK:-no}" \
     "${HERE}/run_benchmark.sh"
   append_suite "${label}" "${root}/benchmark.tsv"


### PR DESCRIPTION
## Summary
- pass `DRY_RUN` explicitly through the off-site DENMAT, PSIM, PSIM lifecycle, and VPSI focus wrappers
- add SI64 harness dry-run smokes for off-site DENMAT device packing, PSIM phase residency, and forced cuFFT residency-stack cases
- fix the `LIB$FFTC8` case-description quoting so cuFFT dry-runs do not trip `set -u`

## Tests
- `tests/profile/si64/check_harness.sh`
- `git diff --check`